### PR TITLE
feat(capture): add zoom and pan to capture previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ On-screen translator for macOS, fully on-device. Captures any region of the scre
 ## Features
 
 - **Lives in the menu bar:** There is no Dock icon. Open the popover from the menu bar item, or press `⌘,` for Settings.
-- **Region capture:** Drag to select any part of the screen, or press **Space** to highlight and click a whole window like the macOS screenshot tool. The result appears in a floating preview with each line **blurred** behind its translation. Save the image, copy it, or copy the original or translated text.
+- **Region capture:** Drag to select any part of the screen, or press **Space** to highlight and click a whole window like the macOS screenshot tool. The result appears in a floating preview with translations drawn in place. Pinch to zoom, pan with two-finger scrolling or mouse dragging, and click the zoom percentage to fit the complete image. Save the image, copy it, or copy the original or translated text.
 - **Live overlay:** Pick a target the same way and an overlay snaps onto it, translating as the content changes. Clicks and scrolling pass through to the app underneath. The built-in **LIVE** handle pauses or resumes translation, and **×** closes it. Show the translation **in place** over the source, or in a separate **window** while the overlay stays a thin region frame.
 - **Predefine an area, translate on demand:** The overlay remembers its region, so **Show / hide overlay** flips translation on and off over the same spot without another selection. This works well for a game panel or fixed HUD. Hiding it stops all capture and translation until you bring it back.
 - **Reads the layout:** Recognition follows document structure. Vertical Japanese or Chinese and multi-column text are read in reading order, and vertical text stays vertical over the original.
@@ -45,7 +45,7 @@ On first launch, grant **Screen Recording** permission in System Settings → Pr
 ## Usage
 
 1. Pick the **Source** and **Target** languages in Settings (`⌘,`).
-2. **Capture a region:** Trigger **Capture Region** from the popover or your hotkey, then drag over the text. You can also press **Space** to highlight and click a whole window. The preview supports `⌘S` to save, `⌘C` to copy the image, `⌘O` to copy the original, `⌘T` to copy the translation, and `Esc` to close.
+2. **Capture a region:** Trigger **Capture Region** from the popover or your hotkey, then drag over the text. You can also press **Space** to highlight and click a whole window. Drag the preview’s title area to move the window. Use `⌘+` / `⌘−` to zoom and click the percentage or press `⌘0` to fit; 100% maps each image pixel to one display pixel. The preview supports `⌘S` to save, `⌘C` to copy the image, `⌘O` to copy the original, `⌘T` to copy the translation, and `Esc` to close. Save and copy always include the complete image at the original capture resolution, regardless of zoom or pan.
 3. **Use the live overlay:** Trigger **Live overlay…** from the menu bar or your hotkey, then drag a region or press **Space** to click a window. Use the **LIVE** handle to pause or resume, `⌘C` to copy the joined translation, and **×** to close.
 4. **Reuse a fixed area:** Once the overlay is placed, **Show / hide overlay** toggles it over the same region without another drag. Hiding it stops all capture and translation.
 

--- a/Sources/Capture/CaptureResultImage.swift
+++ b/Sources/Capture/CaptureResultImage.swift
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Accessibility
+import AppKit
+import SwiftUI
+
+/// Magnify a single composited image. Hosting the source image, restoration
+/// surfaces, and text as separate AppKit layers lets their rasterization diverge
+/// during minification, exposing source glyphs behind the translated text.
+struct CaptureResultImage: View, Equatable {
+
+  // MARK: Internal
+
+  let imageData: Data?
+  let imageSize: CGSize
+  let lines: [OverlayLine]
+
+  var body: some View {
+    Group {
+      if let renderedImage {
+        Image(decorative: renderedImage, scale: 1)
+          .resizable()
+          .overlay {
+            // Preserve source-text help and accessibility without adding any
+            // visible source or translation layers to the magnified image.
+            ForEach(lines) { line in
+              Color.clear
+                .frame(width: line.source.box.width * imageSize.width, height: line.source.box.height * imageSize.height)
+                .contentShape(Rectangle())
+                .help(Text(verbatim: line.source.text))
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(verbatim: line.displayedText))
+                .position(x: line.source.box.midX * imageSize.width, y: line.source.box.midY * imageSize.height)
+            }
+          }
+      } else if renderFailed {
+        Label("Could not render the capture image.", systemImage: "exclamationmark.triangle")
+      } else {
+        ProgressView()
+      }
+    }
+    .frame(width: imageSize.width, height: imageSize.height)
+    .task(id: input) {
+      guard !Task.isCancelled else { return }
+      let image = Self.render(
+        imageData: imageData,
+        imageSize: imageSize,
+        lines: lines,
+        prefersHorizontalTextLayout: prefersHorizontalTextLayout
+      )
+      renderedImage = image
+      renderFailed = image == nil
+    }
+    .onReceive(NotificationCenter.default
+      .publisher(for: AccessibilitySettings.prefersHorizontalTextLayoutDidChangeNotification))
+    { _ in
+      prefersHorizontalTextLayout = AccessibilitySettings.prefersHorizontalTextLayout
+    }
+  }
+
+  static func ==(lhs: Self, rhs: Self) -> Bool {
+    lhs.imageData == rhs.imageData && lhs.imageSize == rhs.imageSize && lhs.lines == rhs.lines
+  }
+
+  /// Shared compositor for preview and export; always runs at source resolution.
+  @MainActor
+  static func render(
+    imageData: Data?,
+    imageSize: CGSize,
+    lines: [OverlayLine],
+    prefersHorizontalTextLayout: Bool? = nil
+  ) -> CGImage? {
+    guard
+      let imageData, let source = NSImage(data: imageData),
+      imageSize.width.isFinite, imageSize.height.isFinite,
+      imageSize.width > 0, imageSize.height > 0
+    else { return nil }
+    let renderer = ImageRenderer(content:
+      ZStack {
+        Image(nsImage: source).resizable()
+        TranslationOverlayLayer(lines: lines, prefersHorizontalTextLayout: prefersHorizontalTextLayout)
+      }
+      .frame(width: imageSize.width, height: imageSize.height)
+      .environment(\.displayScale, 1)
+    )
+    renderer.scale = 1
+    return renderer.cgImage
+  }
+
+  @MainActor
+  static func png(imageData: Data?, imageSize: CGSize, lines: [OverlayLine]) -> Data? {
+    render(imageData: imageData, imageSize: imageSize, lines: lines)?.pngData
+  }
+
+  // MARK: Private
+
+  private struct Input: Equatable {
+    let imageData: Data?
+    let imageSize: CGSize
+    let lines: [OverlayLine]
+    let prefersHorizontalTextLayout: Bool
+  }
+
+  @State private var renderedImage: CGImage?
+  @State private var renderFailed = false
+  @State private var prefersHorizontalTextLayout = AccessibilitySettings.prefersHorizontalTextLayout
+
+  private var input: Input {
+    Input(imageData: imageData, imageSize: imageSize, lines: lines, prefersHorizontalTextLayout: prefersHorizontalTextLayout)
+  }
+}

--- a/Sources/Capture/RegionCaptureFeature.swift
+++ b/Sources/Capture/RegionCaptureFeature.swift
@@ -32,8 +32,8 @@ struct RegionCaptureFeature {
     /// on-device model isn't installed. Drives the "open Settings" hint.
     var translationUnavailable = false
     /// Set once the user copies the text; the window observes this to close.
-    /// (Image save/copy is handled by the window controller, which captures
-    /// the live glass result on screen and then closes the window itself.)
+    /// Image save/copy renders the complete capture in the result view; the
+    /// window controller handles delivery and closes the originating window.
     var finished = false
 
     @Shared(.settings) var settings
@@ -350,7 +350,7 @@ private final class RegionResultWindowController {
     panel.backgroundColor = .clear
     panel.hasShadow = true
     panel.level = .floating
-    panel.isMovableByWindowBackground = true
+    panel.isMovableByWindowBackground = false
     panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
     // NSHostingController (not NSHostingView) joins the responder chain, so
@@ -358,9 +358,9 @@ private final class RegionResultWindowController {
     let hosting = NSHostingController(
       rootView: RegionResultView(
         store: store,
-        onImageFrame: { [weak self] rect in self?.imageContentFrame = rect },
-        onSaveImage: { [weak self] in self?.saveImage() },
-        onCopyImage: { [weak self] in self?.copyImage() },
+        owningWindow: { [weak panel] in panel },
+        onSaveImage: { [weak self, weak panel] data in self?.saveImage(data, panel: panel) },
+        onCopyImage: { [weak self, weak panel] data in self?.copyImage(data, panel: panel) },
         onClose: { [weak panel] in panel?.close() }
       )
     )
@@ -372,11 +372,9 @@ private final class RegionResultWindowController {
 
     self.panel = panel
     // Resize the window to the screenshot's aspect ratio once the capture
-    // lands, so the image fits without scrolling; also remember the source
-    // pixel size so save/copy can momentarily resize to 1:1 for capture.
+    // lands, so the image initially fits the available screen.
     observeToken = observe { [weak self, weak panel] in
       guard let self, let panel, store.imageSize != .zero else { return }
-      capturedPixelSize = store.imageSize
       fitWindow(panel, toPixelSize: store.imageSize)
     }
     NotificationCenter.default.addObserver(
@@ -399,76 +397,12 @@ private final class RegionResultWindowController {
   @Dependency(\.date.now) private var now
   @Dependency(\.pasteboard) private var pasteboard
   @Dependency(\.savePanel) private var savePanel
-  @Dependency(\.screenCapture) private var screenCapture
 
   private var panel: NSWindow?
   private var observeToken: ObserveToken?
-  /// Latest on-screen rect of the image area, in the window's top-left SwiftUI
-  /// coordinates. Used to screen-capture the glass result for save/copy.
-  private var imageContentFrame = CGRect.zero
-  /// Source-screenshot pixel size; lets capture resize the panel to 1:1 with
-  /// the original pixels so the saved PNG isn't limited by on-screen scaling.
-  private var capturedPixelSize = CGSize.zero
 
-  /// Captures the live glass result on screen (the image area only), so the
-  /// saved/copied PNG is pixel-for-pixel what the user sees — and at the
-  /// original screenshot resolution. Briefly resizes the window so the image
-  /// area maps 1:1 to source pixels, then restores.
-  private func captureContentPNG() async -> Data? {
-    guard let panel, let contentView = panel.contentView, imageContentFrame.width > 1 else { return nil }
-    let originalFrame = panel.frame
-    let didResize = resizeForNativeCapture(panel: panel, contentView: contentView)
-    if didResize {
-      // Give SwiftUI a tick to relayout so imageContentFrame reflects the new
-      // window size before we read it for the capture rect.
-      try? await Task.sleep(for: .milliseconds(80))
-    }
-
-    // SwiftUI .global is top-left within the window content; AppKit is
-    // bottom-left. Flip, then convert window → screen coordinates.
-    let f = imageContentFrame
-    let windowRect = CGRect(x: f.minX, y: contentView.bounds.height - f.maxY, width: f.width, height: f.height)
-    let screenRect = panel.convertToScreen(windowRect)
-    let image = try? await screenCapture.captureImage(
-      screenRect,
-      displayID(coveringMostOf: screenRect),
-      nil
-    )
-    let data = image?.pngData
-
-    if didResize {
-      panel.setFrame(originalFrame, display: true)
-    }
-    return data
-  }
-
-  /// Resizes the panel so the image area matches the source's native points
-  /// (= original pixels at this display's backing scale). Skips when already
-  /// near 1:1 or when the native size wouldn't fit on screen.
-  private func resizeForNativeCapture(panel: NSWindow, contentView: NSView) -> Bool {
-    guard
-      capturedPixelSize.width > 0,
-      imageContentFrame.width > 1,
-      let screen = panel.screen ?? NSScreen.main
-    else { return false }
-    let scale = screen.backingScaleFactor
-    let nativeImageWidth = capturedPixelSize.width / scale
-    let ratio = nativeImageWidth / imageContentFrame.width
-    guard abs(ratio - 1.0) > 0.02 else { return false }
-
-    let current = contentView.frame.size
-    let target = CGSize(width: current.width * ratio, height: current.height * ratio)
-    let visible = screen.visibleFrame.size
-    guard target.width <= visible.width, target.height <= visible.height else { return false }
-
-    panel.setContentSize(target)
-    panel.center()
-    return true
-  }
-
-  private func saveImage() {
+  private func saveImage(_ data: Data, panel: NSWindow?) {
     Task { @MainActor in
-      guard let data = await captureContentPNG() else { return }
       let formatter = DateFormatter()
       formatter.dateFormat = "yyyy-MM-dd-HHmmss"
       let name = "SwiftyCrow-\(formatter.string(from: now)).png"
@@ -478,9 +412,8 @@ private final class RegionResultWindowController {
     }
   }
 
-  private func copyImage() {
+  private func copyImage(_ data: Data, panel: NSWindow?) {
     Task { @MainActor in
-      guard let data = await captureContentPNG() else { return }
       await pasteboard.copyImage(data)
       panel?.close()
     }
@@ -490,18 +423,18 @@ private final class RegionResultWindowController {
     let screen = panel.screen ?? NSScreen.main
     let scale = screen?.backingScaleFactor ?? 2
     let visible = screen?.visibleFrame.size ?? CGSize(width: 1440, height: 900)
-    let toolbarHeight: CGFloat = 52
+    let chromeHeight: CGFloat = 86
     let padding: CGFloat = 24
 
     var width = pixelSize.width / scale + padding
     var height = pixelSize.height / scale + padding
     let maxWidth = visible.width * 0.85
-    let maxHeight = visible.height * 0.85 - toolbarHeight
+    let maxHeight = visible.height * 0.85 - chromeHeight
     let ratio = min(min(maxWidth / width, maxHeight / height), 1)
     width *= ratio
     height *= ratio
 
-    panel.setContentSize(CGSize(width: max(360, width), height: height + toolbarHeight))
+    panel.setContentSize(CGSize(width: max(360, width), height: height + chromeHeight))
     panel.center()
   }
 }

--- a/Sources/Capture/RegionResultView.swift
+++ b/Sources/Capture/RegionResultView.swift
@@ -5,16 +5,16 @@ import AppKit
 import ComposableArchitecture
 import SwiftUI
 
+// MARK: - RegionResultView
+
 struct RegionResultView: View {
 
   // MARK: Internal
 
   let store: StoreOf<RegionCaptureFeature>
-  /// Reports the on-screen rect of the image area (window top-left coords) so
-  /// the controller can screen-capture exactly that region for save/copy.
-  let onImageFrame: (CGRect) -> Void
-  let onSaveImage: () -> Void
-  let onCopyImage: () -> Void
+  let owningWindow: () -> NSWindow?
+  let onSaveImage: (Data) -> Void
+  let onCopyImage: (Data) -> Void
   let onClose: () -> Void
 
   var body: some View {
@@ -31,8 +31,22 @@ struct RegionResultView: View {
           .padding(.horizontal, 14)
           .padding(.vertical, 8)
       }
+      if let exportError {
+        Text(exportError)
+          .font(.caption)
+          .foregroundStyle(.red)
+          .padding(.horizontal, 14)
+      }
       CaptureStatusNote(lines: store.overlayLines)
       content
+      Divider().opacity(0.4)
+      HStack {
+        Spacer(minLength: 0)
+        CaptureZoomControls(model: zoomModel)
+          .disabled(store.imageData == nil)
+      }
+      .padding(.horizontal, 14)
+      .padding(.vertical, 6)
     }
     .frame(minWidth: 360, minHeight: 280)
     .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
@@ -49,33 +63,9 @@ struct RegionResultView: View {
 
   @State private var hoveredHelp: String?
   @State private var keyMonitor: Any?
-
-  /// The original screenshot with source-replacement surfaces and translated
-  /// glyphs composited by the same overlay layer used in live mode.
-  @ViewBuilder
-  private var translatedImage: some View {
-    let backdrop = store.imageData.flatMap(NSImage.init(data:))
-    if let backdrop {
-      ZStack {
-        Image(nsImage: backdrop)
-          .resizable()
-        TranslationOverlayLayer(lines: store.overlayLines)
-      }
-      .aspectRatio(aspectRatio, contentMode: .fit)
-      .background(
-        GeometryReader { proxy in
-          Color.clear
-            .onAppear { onImageFrame(proxy.frame(in: .global)) }
-            .onChange(of: proxy.frame(in: .global)) { _, frame in onImageFrame(frame) }
-        }
-      )
-    }
-  }
-
-  private var aspectRatio: CGFloat {
-    guard store.imageSize.height > 0 else { return 1 }
-    return store.imageSize.width / store.imageSize.height
-  }
+  @State private var exportError: String?
+  @State private var zoomModel = CaptureZoomModel()
+  @Environment(\.displayScale) private var displayScale
 
   private var toolbar: some View {
     HStack(spacing: 10) {
@@ -93,8 +83,12 @@ struct RegionResultView: View {
       .contentShape(Rectangle())
       .gesture(WindowDragGesture())
       .allowsWindowActivationEvents()
-      toolbarButton("square.and.arrow.down", help: helpText("Save image", shortcuts.regionSave), action: onSaveImage)
-      toolbarButton("doc.on.doc", help: helpText("Copy image", shortcuts.regionCopyImage), action: onCopyImage)
+      toolbarButton(
+        "square.and.arrow.down",
+        help: helpText("Save image", shortcuts.regionSave),
+        action: { exportImage(onSaveImage) }
+      )
+      toolbarButton("doc.on.doc", help: helpText("Copy image", shortcuts.regionCopyImage), action: { exportImage(onCopyImage) })
       toolbarButton("text.quote", help: helpText("Copy original text", shortcuts.regionCopyOriginal)) {
         store.send(.copyOriginalRequested)
       }
@@ -111,9 +105,12 @@ struct RegionResultView: View {
   @ViewBuilder
   private var content: some View {
     if store.imageData != nil {
-      translatedImage
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(12)
+      ZoomableCaptureCanvas(imageSize: store.imageSize, backingScale: displayScale, model: zoomModel) {
+        CaptureResultImage(imageData: store.imageData, imageSize: store.imageSize, lines: store.overlayLines)
+          .equatable()
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .padding(12)
     } else if let error = store.lastError {
       Label(error, systemImage: "exclamationmark.triangle.fill")
         .foregroundStyle(.red)
@@ -145,6 +142,21 @@ struct RegionResultView: View {
     store.settings.shortcuts
   }
 
+  private func exportImage(_ action: (Data) -> Void) {
+    guard
+      let data = CaptureResultImage.png(
+        imageData: store.imageData,
+        imageSize: store.imageSize,
+        lines: store.overlayLines
+      )
+    else {
+      exportError = "Could not render the capture image. Please try again."
+      return
+    }
+    exportError = nil
+    action(data)
+  }
+
   private func toolbarButton(_ systemName: String, help: String, action: @escaping () -> Void) -> some View {
     Button(action: action) {
       Image(systemName: systemName)
@@ -152,6 +164,7 @@ struct RegionResultView: View {
         .frame(width: 26, height: 26)
     }
     .buttonStyle(.plain)
+    .accessibilityLabel(Text(help))
     .help(help)
     .onHover { hovering in
       if hovering {
@@ -172,6 +185,8 @@ struct RegionResultView: View {
   private func installMonitor() {
     guard keyMonitor == nil else { return }
     keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+      let windowNumber = event.windowNumber
+      let characters = event.charactersIgnoringModifiers
       let keyCode = Int(event.keyCode)
       var carbonModifiers = 0
       let flags = event.modifierFlags
@@ -180,14 +195,15 @@ struct RegionResultView: View {
       if flags.contains(.option) { carbonModifiers |= 2048 }
       if flags.contains(.control) { carbonModifiers |= 4096 }
       let consumed = MainActor.assumeIsolated {
+        guard owningWindow()?.windowNumber == windowNumber, owningWindow()?.isKeyWindow == true else { return false }
         if keyCode == 53 { // Escape
           onClose()
           return true
         }
-        if matches(keyCode, carbonModifiers, shortcuts.regionSave) { onSaveImage()
+        if matches(keyCode, carbonModifiers, shortcuts.regionSave) { exportImage(onSaveImage)
           return true
         }
-        if matches(keyCode, carbonModifiers, shortcuts.regionCopyImage) { onCopyImage()
+        if matches(keyCode, carbonModifiers, shortcuts.regionCopyImage) { exportImage(onCopyImage)
           return true
         }
         if matches(keyCode, carbonModifiers, shortcuts.regionCopyOriginal) { store.send(.copyOriginalRequested)
@@ -195,6 +211,16 @@ struct RegionResultView: View {
         }
         if matches(keyCode, carbonModifiers, shortcuts.regionCopyTranslation) {
           store.send(.copyTranslationRequested)
+          return true
+        }
+        if store.imageData != nil, carbonModifiers == 256 || carbonModifiers == 768 {
+          switch characters {
+          case "+",
+               "=": zoomModel.zoomIn()
+          case "-": zoomModel.zoomOut()
+          case "0": zoomModel.resetToFit()
+          default: return false
+          }
           return true
         }
         return false
@@ -213,5 +239,39 @@ struct RegionResultView: View {
   private func matches(_ keyCode: Int, _ carbonModifiers: Int, _ hotKey: HotKey?) -> Bool {
     guard let hotKey, keyCode == hotKey.carbonKeyCode else { return false }
     return carbonModifiers == hotKey.carbonModifiers
+  }
+}
+
+// MARK: - CaptureZoomControls
+
+/// Keep frequent magnification updates local to the controls. The source image
+/// and translated document do not need to be rebuilt while pinching or panning.
+private struct CaptureZoomControls: View {
+  let model: CaptureZoomModel
+
+  var body: some View {
+    HStack(spacing: 10) {
+      Button(action: model.zoomOut) {
+        Image(systemName: "minus.magnifyingglass").frame(width: 26, height: 26)
+      }
+      .disabled(!model.canZoomOut)
+      .accessibilityLabel("Zoom out")
+      .help("Zoom out (⌘−)")
+      Button(action: model.resetToFit) {
+        Text("\(model.percentage)%")
+          .font(.caption.monospacedDigit())
+          .frame(minWidth: 40, minHeight: 26)
+          .contentShape(Rectangle())
+      }
+      .accessibilityLabel("Zoom \(model.percentage) percent. Fit image")
+      .help("Fit image (⌘0)")
+      Button(action: model.zoomIn) {
+        Image(systemName: "plus.magnifyingglass").frame(width: 26, height: 26)
+      }
+      .disabled(!model.canZoomIn)
+      .accessibilityLabel("Zoom in")
+      .help("Zoom in (⌘+)")
+    }
+    .buttonStyle(.plain)
   }
 }

--- a/Sources/Capture/ZoomableCaptureCanvas.swift
+++ b/Sources/Capture/ZoomableCaptureCanvas.swift
@@ -1,139 +1,105 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import AppKit
 import SwiftUI
 
 // MARK: - CaptureZoomGeometry
 
-/// Pure geometry shared by the AppKit canvas and its unit tests.
+/// Capture geometry is always measured in source pixels. A 100% zoom maps one
+/// source pixel to one display pixel, including on Retina displays.
 enum CaptureZoomGeometry {
-  static let magnificationRange: ClosedRange<CGFloat> = 1...6
-  static let maximumOversampledArea: CGFloat = 16_000_000
+  static let maximumScale: CGFloat = 8
 
-  /// Keep enough backing detail for a useful first zoom step on 1x displays.
-  /// Retina displays already provide this density without a larger document.
-  static func detailScale(forBackingScale backingScale: CGFloat) -> CGFloat {
-    guard backingScale.isFinite, backingScale > 0 else { return 1 }
-    return max(1, 2 / backingScale)
-  }
-
-  static func detailedDocumentSize(_ source: CGSize, backingScale: CGFloat) -> CGSize {
+  static func fitScale(image: CGSize, viewport: CGSize, backingScale: CGFloat) -> CGFloat? {
     guard
-      source.width.isFinite,
-      source.height.isFinite,
-      source.width > 0,
-      source.height > 0
-    else { return .zero }
-
-    let requestedScale = detailScale(forBackingScale: backingScale)
-    let areaLimitedScale = (maximumOversampledArea / (source.width * source.height)).squareRoot()
-    let scale = max(1, min(requestedScale, areaLimitedScale))
-    return CGSize(width: source.width * scale, height: source.height * scale)
+      image.width.isFinite, image.height.isFinite,
+      viewport.width.isFinite, viewport.height.isFinite,
+      image.width > 0, image.height > 0, viewport.width > 0, viewport.height > 0,
+      backingScale.isFinite, backingScale > 0
+    else { return nil }
+    return min(1, min(viewport.width / image.width, viewport.height / image.height) * backingScale)
   }
 
-  static func fitMagnification(_ source: CGSize, in destination: CGSize) -> CGFloat {
-    guard
-      source.width.isFinite,
-      source.height.isFinite,
-      destination.width.isFinite,
-      destination.height.isFinite,
-      source.width > 0,
-      source.height > 0,
-      destination.width > 0,
-      destination.height > 0
-    else { return 0 }
-
-    return min(destination.width / source.width, destination.height / source.height)
+  static func normalizedCenter(of rect: CGRect, in size: CGSize) -> CGPoint {
+    guard size.width > 0, size.height > 0 else { return CGPoint(x: 0.5, y: 0.5) }
+    return CGPoint(x: rect.midX / size.width, y: rect.midY / size.height)
   }
 
-  static func aspectFit(_ source: CGSize, in destination: CGSize) -> CGSize {
-    let ratio = fitMagnification(source, in: destination)
-    guard ratio > 0 else { return .zero }
-    return CGSize(width: source.width * ratio, height: source.height * ratio)
-  }
-
-  static func clampedMagnification(_ value: CGFloat) -> CGFloat {
-    guard value.isFinite else { return magnificationRange.lowerBound }
-    return min(magnificationRange.upperBound, max(magnificationRange.lowerBound, value))
-  }
-
-  static func normalizedCenter(of visibleRect: CGRect, in documentSize: CGSize) -> CGPoint {
-    guard documentSize.width > 0, documentSize.height > 0 else {
-      return CGPoint(x: 0.5, y: 0.5)
+  static func scrollOrigin(center: CGPoint, visibleSize: CGSize, documentSize: CGSize) -> CGPoint {
+    func coordinate(_ center: CGFloat, visible: CGFloat, document: CGFloat) -> CGFloat {
+      if document <= visible { return (document - visible) / 2 }
+      return max(0, min(document - visible, center * document - visible / 2))
     }
     return CGPoint(
-      x: min(1, max(0, visibleRect.midX / documentSize.width)),
-      y: min(1, max(0, visibleRect.midY / documentSize.height))
+      x: coordinate(center.x, visible: visibleSize.width, document: documentSize.width),
+      y: coordinate(center.y, visible: visibleSize.height, document: documentSize.height)
     )
   }
 
-  static func scrollOrigin(
-    preserving normalizedCenter: CGPoint,
-    visibleSize: CGSize,
-    documentSize: CGSize
-  ) -> CGPoint {
-    let maximum = CGPoint(
-      x: max(0, documentSize.width - visibleSize.width),
-      y: max(0, documentSize.height - visibleSize.height)
-    )
-    return CGPoint(
-      x: min(maximum.x, max(0, normalizedCenter.x * documentSize.width - visibleSize.width / 2)),
-      y: min(maximum.y, max(0, normalizedCenter.y * documentSize.height - visibleSize.height / 2))
-    )
-  }
 }
 
 // MARK: - CaptureZoomModel
 
-/// View-local controls for a capture result's native AppKit scroll view. Zoom
-/// and pan are presentation state, so they intentionally do not live in TCA or
-/// the persisted app settings.
+/// Presentation state belongs to this result window, independently of capture,
+/// translation, and persisted settings.
 @MainActor
 @Observable
 final class CaptureZoomModel {
 
   // MARK: Internal
 
-  private(set) var relativeScale: CGFloat = 1
+  private(set) var scale: CGFloat = 1
+  private(set) var minimumScale: CGFloat = 0.1
+  private(set) var isFitting = true
 
   var percentage: Int {
-    Int((relativeScale * 100).rounded())
+    Int((scale * 100).rounded())
+  }
+
+  var canZoomIn: Bool {
+    scale < CaptureZoomGeometry.maximumScale - 0.001
+  }
+
+  var canZoomOut: Bool {
+    scale > minimumScale + 0.001
+  }
+
+  func zoomIn() {
+    command?(.scale(scale * 1.25))
+  }
+
+  func zoomOut() {
+    command?(.scale(scale / 1.25))
   }
 
   func resetToFit() {
     command?(.fit)
   }
 
-  func zoomIn() {
-    command?(.zoomIn)
-  }
-
-  func zoomOut() {
-    command?(.zoomOut)
-  }
-
   // MARK: Fileprivate
 
   fileprivate enum Command {
+    case scale(CGFloat)
     case fit
-    case zoomIn
-    case zoomOut
   }
 
   fileprivate var command: ((Command) -> Void)?
 
-  fileprivate func update(relativeScale: CGFloat) {
-    self.relativeScale = relativeScale
+  fileprivate func update(scale: CGFloat, minimumScale: CGFloat, isFitting: Bool) {
+    self.scale = scale
+    self.minimumScale = minimumScale
+    self.isFitting = isFitting
   }
 }
 
 // MARK: - ZoomableCaptureCanvas
 
-/// Hosts the complete capture result in `NSScrollView` so two-finger panning,
-/// pinch magnification, momentum, and the user's natural-scrolling preference
-/// are all handled by AppKit.
+/// AppKit owns pinch, two-axis scrolling, momentum, natural-scroll direction,
+/// and scrollbars. SwiftUI owns the unchanged, source-sized image document.
 struct ZoomableCaptureCanvas<Content: View>: NSViewRepresentable {
-
   @MainActor
-  final class Coordinator: NSObject {
+  final class Coordinator {
 
     // MARK: Lifecycle
 
@@ -144,134 +110,101 @@ struct ZoomableCaptureCanvas<Content: View>: NSViewRepresentable {
     // MARK: Internal
 
     var imageSize = CGSize.zero
+    var backingScale: CGFloat = 1
     var hostingView: NSHostingView<Content>?
 
     func connect(to scrollView: CaptureScrollView) {
       model.command = { [weak self, weak scrollView] command in
         guard let self, let scrollView else { return }
-        apply(command, to: scrollView)
+        switch command {
+        case .fit:
+          isFitting = true
+          layoutDocument(in: scrollView, force: true)
+
+        case .scale(let scale):
+          isFitting = false
+          setScale(scale, center: center(in: scrollView), in: scrollView)
+        }
       }
     }
 
-    func layoutDocument(in scrollView: CaptureScrollView) {
-      guard
-        imageSize.width > 0,
-        imageSize.height > 0,
-        let hostingView
-      else { return }
-
+    func layoutDocument(in scrollView: CaptureScrollView, force: Bool = false) {
+      guard let hostingView else { return }
       let viewport = scrollView.contentSize
-      guard viewport.width > 1, viewport.height > 1 else { return }
-      let nextFitMagnification = CaptureZoomGeometry.fitMagnification(imageSize, in: viewport)
-      guard nextFitMagnification > 0 else { return }
+      let displayScale = scrollView.window?.backingScaleFactor ?? backingScale
+      guard let fit = CaptureZoomGeometry.fitScale(image: imageSize, viewport: viewport, backingScale: displayScale)
+      else { return }
+      let imageChanged = hostingView.frame.size != imageSize
+      guard force || imageChanged || viewport != lastViewport || displayScale != lastBackingScale else { return }
 
-      let previousDocumentSize = hostingView.frame.size
-      let previousFitMagnification = fitMagnification
-      let currentRelativeScale = previousFitMagnification > 0
-        ? scrollView.magnification / previousFitMagnification
-        : model.relativeScale
-      let preservedCenter = scrollView.takePendingNormalizedCenter()
-      let documentChanged = previousDocumentSize != imageSize
-      let fitChanged = abs(previousFitMagnification - nextFitMagnification) > 0.0001
-      guard documentChanged || fitChanged else {
-        return
-      }
-
-      let visible = scrollView.documentVisibleRect
-      let normalizedCenter = preservedCenter
-        ?? CaptureZoomGeometry.normalizedCenter(of: visible, in: previousDocumentSize)
-      let relativeScale = CaptureZoomGeometry.clampedMagnification(currentRelativeScale)
-      let wasFit = abs(relativeScale - CaptureZoomGeometry.magnificationRange.lowerBound) < 0.001
-
-      fitMagnification = nextFitMagnification
-      scrollView.fitMagnification = nextFitMagnification
-      updateMagnificationRange(for: nextFitMagnification, in: scrollView)
+      let preservedCenter = scrollView.takePendingCenter() ?? center(in: scrollView)
+      let nativeScale = scrollView.magnification * lastBackingScale
+      if imageChanged { isFitting = true }
+      lastViewport = viewport
+      lastBackingScale = displayScale
+      minimumScale = min(0.1, fit)
       hostingView.frame = CGRect(origin: .zero, size: imageSize)
       hostingView.layoutSubtreeIfNeeded()
-
-      let targetRelativeScale = wasFit ? CaptureZoomGeometry.magnificationRange.lowerBound : relativeScale
-      let targetCenter = wasFit ? CGPoint(x: 0.5, y: 0.5) : normalizedCenter
-      setMagnification(
-        nextFitMagnification * targetRelativeScale,
-        preserving: targetCenter,
+      updateMagnificationRange(in: scrollView)
+      setScale(
+        isFitting ? fit : nativeScale,
+        center: isFitting ? CGPoint(x: 0.5, y: 0.5) : preservedCenter,
         in: scrollView
       )
-      model.update(relativeScale: targetRelativeScale)
     }
 
-    func magnificationChanged(_ magnification: CGFloat) {
-      guard fitMagnification > 0 else { return }
-      model.update(relativeScale: CaptureZoomGeometry.clampedMagnification(magnification / fitMagnification))
+    func magnificationChanged(in scrollView: CaptureScrollView) {
+      isFitting = false
+      model.update(
+        scale: scrollView.magnification * lastBackingScale,
+        minimumScale: minimumScale,
+        isFitting: false
+      )
     }
 
     // MARK: Private
 
     private let model: CaptureZoomModel
-    private var fitMagnification: CGFloat = 1
+    private var lastViewport = CGSize.zero
+    private var lastBackingScale: CGFloat = 1
+    private var minimumScale: CGFloat = 0.1
+    private var isFitting = true
 
-    /// AppKit raises an Objective-C exception if either bound crosses the
-    /// other, even momentarily. Small captures can have a Fit scale above the
-    /// previous 6x maximum, while a later large capture can move both bounds
-    /// below the previous minimum, so update the outward bound first.
-    private func updateMagnificationRange(for fitMagnification: CGFloat, in scrollView: NSScrollView) {
-      let minimum = fitMagnification * CaptureZoomGeometry.magnificationRange.lowerBound
-      let maximum = fitMagnification * CaptureZoomGeometry.magnificationRange.upperBound
+    private func center(in scrollView: NSScrollView) -> CGPoint {
+      CaptureZoomGeometry.normalizedCenter(of: scrollView.documentVisibleRect, in: hostingView?.frame.size ?? .zero)
+    }
 
-      if minimum > scrollView.maxMagnification {
-        scrollView.maxMagnification = maximum
-        scrollView.minMagnification = minimum
-      } else if maximum < scrollView.minMagnification {
-        scrollView.minMagnification = minimum
-        scrollView.maxMagnification = maximum
+    private func setScale(_ scale: CGFloat, center: CGPoint, in scrollView: CaptureScrollView) {
+      let clamped = min(CaptureZoomGeometry.maximumScale, max(minimumScale, scale))
+      scrollView.setMagnification(clamped / lastBackingScale, centeredAt: CGPoint(
+        x: center.x * imageSize.width,
+        y: center.y * imageSize.height
+      ))
+      let origin = CaptureZoomGeometry.scrollOrigin(
+        center: center,
+        visibleSize: scrollView.documentVisibleRect.size,
+        documentSize: imageSize
+      )
+      scrollView.scrollContent(to: origin)
+      model.update(scale: clamped, minimumScale: minimumScale, isFitting: isFitting)
+    }
+
+    /// AppKit raises if the bounds cross even momentarily during display changes.
+    private func updateMagnificationRange(in scrollView: NSScrollView) {
+      let lower = minimumScale / lastBackingScale
+      let upper = CaptureZoomGeometry.maximumScale / lastBackingScale
+      if lower > scrollView.maxMagnification {
+        scrollView.maxMagnification = upper
+        scrollView.minMagnification = lower
       } else {
-        scrollView.minMagnification = minimum
-        scrollView.maxMagnification = maximum
+        scrollView.minMagnification = lower
+        scrollView.maxMagnification = upper
       }
     }
-
-    private func apply(_ command: CaptureZoomModel.Command, to scrollView: CaptureScrollView) {
-      guard fitMagnification > 0 else { return }
-      let currentRelativeScale = scrollView.magnification / fitMagnification
-      let nextRelativeScale: CGFloat =
-        switch command {
-        case .fit:
-          CaptureZoomGeometry.magnificationRange.lowerBound
-        case .zoomIn:
-          CaptureZoomGeometry.clampedMagnification(currentRelativeScale * 1.25)
-        case .zoomOut:
-          CaptureZoomGeometry.clampedMagnification(currentRelativeScale / 1.25)
-        }
-      let normalizedCenter = CaptureZoomGeometry.normalizedCenter(
-        of: scrollView.documentVisibleRect,
-        in: scrollView.documentView?.frame.size ?? .zero
-      )
-      setMagnification(fitMagnification * nextRelativeScale, preserving: normalizedCenter, in: scrollView)
-      model.update(relativeScale: nextRelativeScale)
-    }
-
-    private func setMagnification(
-      _ magnification: CGFloat,
-      preserving normalizedCenter: CGPoint,
-      in scrollView: CaptureScrollView
-    ) {
-      let currentCenter = CGPoint(
-        x: scrollView.documentVisibleRect.midX,
-        y: scrollView.documentVisibleRect.midY
-      )
-      scrollView.setMagnification(magnification, centeredAt: currentCenter)
-      guard let documentView = scrollView.documentView else { return }
-      let origin = CaptureZoomGeometry.scrollOrigin(
-        preserving: normalizedCenter,
-        visibleSize: scrollView.documentVisibleRect.size,
-        documentSize: documentView.frame.size
-      )
-      scrollView.contentView.scroll(to: origin)
-      scrollView.reflectScrolledClipView(scrollView.contentView)
-    }
-
   }
 
   let imageSize: CGSize
+  let backingScale: CGFloat
   let model: CaptureZoomModel
   @ViewBuilder let content: Content
 
@@ -282,43 +215,42 @@ struct ZoomableCaptureCanvas<Content: View>: NSViewRepresentable {
   func makeNSView(context: Context) -> CaptureScrollView {
     let scrollView = CaptureScrollView()
     scrollView.allowsMagnification = true
-    scrollView.minMagnification = 0.01
-    scrollView.maxMagnification = CaptureZoomGeometry.magnificationRange.upperBound
-    scrollView.autohidesScrollers = true
+    scrollView.minMagnification = 0.001
+    scrollView.maxMagnification = CaptureZoomGeometry.maximumScale
     scrollView.borderType = .noBorder
     scrollView.drawsBackground = false
     scrollView.hasHorizontalScroller = true
     scrollView.hasVerticalScroller = true
-    scrollView.horizontalScrollElasticity = .automatic
-    scrollView.verticalScrollElasticity = .automatic
+    scrollView.autohidesScrollers = true
     scrollView.scrollerStyle = .overlay
     scrollView.usesPredominantAxisScrolling = false
-
-    let clipView = CenteringClipView()
-    clipView.drawsBackground = false
-    scrollView.contentView = clipView
-
-    let hostingView = NSHostingView(rootView: content)
-    hostingView.frame = CGRect(origin: .zero, size: CGSize(width: 1, height: 1))
-    scrollView.documentView = hostingView
-    scrollView.onMagnificationChanged = { [weak coordinator = context.coordinator] magnification in
-      coordinator?.magnificationChanged(magnification)
-    }
+    let clip = CenteringCaptureClipView()
+    clip.drawsBackground = false
+    scrollView.contentView = clip
+    scrollView.installPanGesture()
+    let hosting = NSHostingView(rootView: content)
+    hosting.sizingOptions = []
+    hosting.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
+    scrollView.documentView = hosting
+    context.coordinator.hostingView = hosting
+    context.coordinator.connect(to: scrollView)
     scrollView.onLayout = { [weak coordinator = context.coordinator, weak scrollView] in
       guard let scrollView else { return }
       coordinator?.layoutDocument(in: scrollView)
     }
-    context.coordinator.hostingView = hostingView
-    context.coordinator.connect(to: scrollView)
+    scrollView.onMagnificationChanged = { [weak coordinator = context.coordinator, weak scrollView] in
+      guard let scrollView else { return }
+      coordinator?.magnificationChanged(in: scrollView)
+    }
     return scrollView
   }
 
   func updateNSView(_ scrollView: CaptureScrollView, context: Context) {
     context.coordinator.imageSize = imageSize
+    context.coordinator.backingScale = backingScale
     context.coordinator.hostingView?.rootView = content
-    context.coordinator.layoutDocument(in: scrollView)
+    scrollView.needsLayout = true
   }
-
 }
 
 // MARK: - CaptureScrollView
@@ -328,24 +260,23 @@ final class CaptureScrollView: NSScrollView {
   // MARK: Internal
 
   var onLayout: (() -> Void)?
-  var onMagnificationChanged: ((CGFloat) -> Void)?
-  var fitMagnification: CGFloat = 1
+  var onMagnificationChanged: (() -> Void)?
+
+  func installPanGesture() {
+    let pan = NSPanGestureRecognizer(target: self, action: #selector(panImage(_:)))
+    pan.buttonMask = 1
+    contentView.addGestureRecognizer(pan)
+  }
 
   override func setFrameSize(_ newSize: NSSize) {
-    if
-      pendingNormalizedCenter == nil,
-      magnification > fitMagnification * (CaptureZoomGeometry.magnificationRange.lowerBound + 0.001),
-      frame.size != newSize,
-      let documentView,
-      documentView.frame.width > 0,
-      documentView.frame.height > 0
-    {
-      pendingNormalizedCenter = CaptureZoomGeometry.normalizedCenter(
-        of: documentVisibleRect,
-        in: documentView.frame.size
-      )
-    }
+    if frame.size != newSize { preserveCenter() }
     super.setFrameSize(newSize)
+  }
+
+  override func viewDidChangeBackingProperties() {
+    preserveCenter()
+    super.viewDidChangeBackingProperties()
+    needsLayout = true
   }
 
   override func layout() {
@@ -355,36 +286,70 @@ final class CaptureScrollView: NSScrollView {
 
   override func magnify(with event: NSEvent) {
     super.magnify(with: event)
-    onMagnificationChanged?(magnification)
+    onMagnificationChanged?()
   }
 
-  // MARK: Fileprivate
+  /// NSClipView.scroll(to:) itself does not constrain programmatic panning.
+  func scrollContent(to origin: CGPoint) {
+    var proposed = contentView.bounds
+    proposed.origin = origin
+    contentView.scroll(to: contentView.constrainBoundsRect(proposed).origin)
+    reflectScrolledClipView(contentView)
+  }
 
-  fileprivate func takePendingNormalizedCenter() -> CGPoint? {
-    defer { pendingNormalizedCenter = nil }
-    return pendingNormalizedCenter
+  func takePendingCenter() -> CGPoint? {
+    defer { pendingCenter = nil }
+    return pendingCenter
   }
 
   // MARK: Private
 
-  private var pendingNormalizedCenter: CGPoint?
+  private var pendingCenter: CGPoint?
+  private var panOrigin: CGPoint?
+
+  private func preserveCenter() {
+    guard pendingCenter == nil, let documentView else { return }
+    pendingCenter = CaptureZoomGeometry.normalizedCenter(of: documentVisibleRect, in: documentView.frame.size)
+  }
+
+  @objc
+  private func panImage(_ gesture: NSPanGestureRecognizer) {
+    switch gesture.state {
+    case .began:
+      panOrigin = contentView.bounds.origin
+      NSCursor.closedHand.push()
+
+    case .changed:
+      guard let panOrigin else { return }
+      let translation = gesture.translation(in: contentView)
+      scrollContent(to: CGPoint(x: panOrigin.x - translation.x, y: panOrigin.y - translation.y))
+
+    case .ended,
+         .cancelled,
+         .failed:
+      if panOrigin != nil { NSCursor.pop() }
+      panOrigin = nil
+
+    default:
+      break
+    }
+  }
 }
 
-// MARK: - CenteringClipView
+// MARK: - CenteringCaptureClipView
 
-/// Centers a fitted document while retaining NSClipView's native scrolling and
-/// gesture behavior as soon as magnification makes the document larger.
-private final class CenteringClipView: NSClipView {
+/// Center documents smaller than the viewport while allowing native scrolling
+/// and edge constraints once the image is larger.
+final class CenteringCaptureClipView: NSClipView {
   override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
-    var constrained = super.constrainBoundsRect(proposedBounds)
-    guard let documentView else { return constrained }
-
-    if documentView.frame.width < bounds.width {
-      constrained.origin.x = (documentView.frame.width - bounds.width) / 2
+    var result = super.constrainBoundsRect(proposedBounds)
+    guard let documentView else { return result }
+    if documentView.frame.width < result.width {
+      result.origin.x = (documentView.frame.width - result.width) / 2
     }
-    if documentView.frame.height < bounds.height {
-      constrained.origin.y = (documentView.frame.height - bounds.height) / 2
+    if documentView.frame.height < result.height {
+      result.origin.y = (documentView.frame.height - result.height) / 2
     }
-    return constrained
+    return result
   }
 }

--- a/Sources/Capture/ZoomableCaptureCanvas.swift
+++ b/Sources/Capture/ZoomableCaptureCanvas.swift
@@ -1,0 +1,390 @@
+import AppKit
+import SwiftUI
+
+// MARK: - CaptureZoomGeometry
+
+/// Pure geometry shared by the AppKit canvas and its unit tests.
+enum CaptureZoomGeometry {
+  static let magnificationRange: ClosedRange<CGFloat> = 1...6
+  static let maximumOversampledArea: CGFloat = 16_000_000
+
+  /// Keep enough backing detail for a useful first zoom step on 1x displays.
+  /// Retina displays already provide this density without a larger document.
+  static func detailScale(forBackingScale backingScale: CGFloat) -> CGFloat {
+    guard backingScale.isFinite, backingScale > 0 else { return 1 }
+    return max(1, 2 / backingScale)
+  }
+
+  static func detailedDocumentSize(_ source: CGSize, backingScale: CGFloat) -> CGSize {
+    guard
+      source.width.isFinite,
+      source.height.isFinite,
+      source.width > 0,
+      source.height > 0
+    else { return .zero }
+
+    let requestedScale = detailScale(forBackingScale: backingScale)
+    let areaLimitedScale = (maximumOversampledArea / (source.width * source.height)).squareRoot()
+    let scale = max(1, min(requestedScale, areaLimitedScale))
+    return CGSize(width: source.width * scale, height: source.height * scale)
+  }
+
+  static func fitMagnification(_ source: CGSize, in destination: CGSize) -> CGFloat {
+    guard
+      source.width.isFinite,
+      source.height.isFinite,
+      destination.width.isFinite,
+      destination.height.isFinite,
+      source.width > 0,
+      source.height > 0,
+      destination.width > 0,
+      destination.height > 0
+    else { return 0 }
+
+    return min(destination.width / source.width, destination.height / source.height)
+  }
+
+  static func aspectFit(_ source: CGSize, in destination: CGSize) -> CGSize {
+    let ratio = fitMagnification(source, in: destination)
+    guard ratio > 0 else { return .zero }
+    return CGSize(width: source.width * ratio, height: source.height * ratio)
+  }
+
+  static func clampedMagnification(_ value: CGFloat) -> CGFloat {
+    guard value.isFinite else { return magnificationRange.lowerBound }
+    return min(magnificationRange.upperBound, max(magnificationRange.lowerBound, value))
+  }
+
+  static func normalizedCenter(of visibleRect: CGRect, in documentSize: CGSize) -> CGPoint {
+    guard documentSize.width > 0, documentSize.height > 0 else {
+      return CGPoint(x: 0.5, y: 0.5)
+    }
+    return CGPoint(
+      x: min(1, max(0, visibleRect.midX / documentSize.width)),
+      y: min(1, max(0, visibleRect.midY / documentSize.height))
+    )
+  }
+
+  static func scrollOrigin(
+    preserving normalizedCenter: CGPoint,
+    visibleSize: CGSize,
+    documentSize: CGSize
+  ) -> CGPoint {
+    let maximum = CGPoint(
+      x: max(0, documentSize.width - visibleSize.width),
+      y: max(0, documentSize.height - visibleSize.height)
+    )
+    return CGPoint(
+      x: min(maximum.x, max(0, normalizedCenter.x * documentSize.width - visibleSize.width / 2)),
+      y: min(maximum.y, max(0, normalizedCenter.y * documentSize.height - visibleSize.height / 2))
+    )
+  }
+}
+
+// MARK: - CaptureZoomModel
+
+/// View-local controls for a capture result's native AppKit scroll view. Zoom
+/// and pan are presentation state, so they intentionally do not live in TCA or
+/// the persisted app settings.
+@MainActor
+@Observable
+final class CaptureZoomModel {
+
+  // MARK: Internal
+
+  private(set) var relativeScale: CGFloat = 1
+
+  var percentage: Int {
+    Int((relativeScale * 100).rounded())
+  }
+
+  func resetToFit() {
+    command?(.fit)
+  }
+
+  func zoomIn() {
+    command?(.zoomIn)
+  }
+
+  func zoomOut() {
+    command?(.zoomOut)
+  }
+
+  // MARK: Fileprivate
+
+  fileprivate enum Command {
+    case fit
+    case zoomIn
+    case zoomOut
+  }
+
+  fileprivate var command: ((Command) -> Void)?
+
+  fileprivate func update(relativeScale: CGFloat) {
+    self.relativeScale = relativeScale
+  }
+}
+
+// MARK: - ZoomableCaptureCanvas
+
+/// Hosts the complete capture result in `NSScrollView` so two-finger panning,
+/// pinch magnification, momentum, and the user's natural-scrolling preference
+/// are all handled by AppKit.
+struct ZoomableCaptureCanvas<Content: View>: NSViewRepresentable {
+
+  @MainActor
+  final class Coordinator: NSObject {
+
+    // MARK: Lifecycle
+
+    init(model: CaptureZoomModel) {
+      self.model = model
+    }
+
+    // MARK: Internal
+
+    var imageSize = CGSize.zero
+    var hostingView: NSHostingView<Content>?
+
+    func connect(to scrollView: CaptureScrollView) {
+      model.command = { [weak self, weak scrollView] command in
+        guard let self, let scrollView else { return }
+        apply(command, to: scrollView)
+      }
+    }
+
+    func layoutDocument(in scrollView: CaptureScrollView) {
+      guard
+        imageSize.width > 0,
+        imageSize.height > 0,
+        let hostingView
+      else { return }
+
+      let viewport = scrollView.contentSize
+      guard viewport.width > 1, viewport.height > 1 else { return }
+      let nextFitMagnification = CaptureZoomGeometry.fitMagnification(imageSize, in: viewport)
+      guard nextFitMagnification > 0 else { return }
+
+      let previousDocumentSize = hostingView.frame.size
+      let previousFitMagnification = fitMagnification
+      let currentRelativeScale = previousFitMagnification > 0
+        ? scrollView.magnification / previousFitMagnification
+        : model.relativeScale
+      let preservedCenter = scrollView.takePendingNormalizedCenter()
+      let documentChanged = previousDocumentSize != imageSize
+      let fitChanged = abs(previousFitMagnification - nextFitMagnification) > 0.0001
+      guard documentChanged || fitChanged else {
+        return
+      }
+
+      let visible = scrollView.documentVisibleRect
+      let normalizedCenter = preservedCenter
+        ?? CaptureZoomGeometry.normalizedCenter(of: visible, in: previousDocumentSize)
+      let relativeScale = CaptureZoomGeometry.clampedMagnification(currentRelativeScale)
+      let wasFit = abs(relativeScale - CaptureZoomGeometry.magnificationRange.lowerBound) < 0.001
+
+      fitMagnification = nextFitMagnification
+      scrollView.fitMagnification = nextFitMagnification
+      updateMagnificationRange(for: nextFitMagnification, in: scrollView)
+      hostingView.frame = CGRect(origin: .zero, size: imageSize)
+      hostingView.layoutSubtreeIfNeeded()
+
+      let targetRelativeScale = wasFit ? CaptureZoomGeometry.magnificationRange.lowerBound : relativeScale
+      let targetCenter = wasFit ? CGPoint(x: 0.5, y: 0.5) : normalizedCenter
+      setMagnification(
+        nextFitMagnification * targetRelativeScale,
+        preserving: targetCenter,
+        in: scrollView
+      )
+      model.update(relativeScale: targetRelativeScale)
+    }
+
+    func magnificationChanged(_ magnification: CGFloat) {
+      guard fitMagnification > 0 else { return }
+      model.update(relativeScale: CaptureZoomGeometry.clampedMagnification(magnification / fitMagnification))
+    }
+
+    // MARK: Private
+
+    private let model: CaptureZoomModel
+    private var fitMagnification: CGFloat = 1
+
+    /// AppKit raises an Objective-C exception if either bound crosses the
+    /// other, even momentarily. Small captures can have a Fit scale above the
+    /// previous 6x maximum, while a later large capture can move both bounds
+    /// below the previous minimum, so update the outward bound first.
+    private func updateMagnificationRange(for fitMagnification: CGFloat, in scrollView: NSScrollView) {
+      let minimum = fitMagnification * CaptureZoomGeometry.magnificationRange.lowerBound
+      let maximum = fitMagnification * CaptureZoomGeometry.magnificationRange.upperBound
+
+      if minimum > scrollView.maxMagnification {
+        scrollView.maxMagnification = maximum
+        scrollView.minMagnification = minimum
+      } else if maximum < scrollView.minMagnification {
+        scrollView.minMagnification = minimum
+        scrollView.maxMagnification = maximum
+      } else {
+        scrollView.minMagnification = minimum
+        scrollView.maxMagnification = maximum
+      }
+    }
+
+    private func apply(_ command: CaptureZoomModel.Command, to scrollView: CaptureScrollView) {
+      guard fitMagnification > 0 else { return }
+      let currentRelativeScale = scrollView.magnification / fitMagnification
+      let nextRelativeScale: CGFloat =
+        switch command {
+        case .fit:
+          CaptureZoomGeometry.magnificationRange.lowerBound
+        case .zoomIn:
+          CaptureZoomGeometry.clampedMagnification(currentRelativeScale * 1.25)
+        case .zoomOut:
+          CaptureZoomGeometry.clampedMagnification(currentRelativeScale / 1.25)
+        }
+      let normalizedCenter = CaptureZoomGeometry.normalizedCenter(
+        of: scrollView.documentVisibleRect,
+        in: scrollView.documentView?.frame.size ?? .zero
+      )
+      setMagnification(fitMagnification * nextRelativeScale, preserving: normalizedCenter, in: scrollView)
+      model.update(relativeScale: nextRelativeScale)
+    }
+
+    private func setMagnification(
+      _ magnification: CGFloat,
+      preserving normalizedCenter: CGPoint,
+      in scrollView: CaptureScrollView
+    ) {
+      let currentCenter = CGPoint(
+        x: scrollView.documentVisibleRect.midX,
+        y: scrollView.documentVisibleRect.midY
+      )
+      scrollView.setMagnification(magnification, centeredAt: currentCenter)
+      guard let documentView = scrollView.documentView else { return }
+      let origin = CaptureZoomGeometry.scrollOrigin(
+        preserving: normalizedCenter,
+        visibleSize: scrollView.documentVisibleRect.size,
+        documentSize: documentView.frame.size
+      )
+      scrollView.contentView.scroll(to: origin)
+      scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
+  }
+
+  let imageSize: CGSize
+  let model: CaptureZoomModel
+  @ViewBuilder let content: Content
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(model: model)
+  }
+
+  func makeNSView(context: Context) -> CaptureScrollView {
+    let scrollView = CaptureScrollView()
+    scrollView.allowsMagnification = true
+    scrollView.minMagnification = 0.01
+    scrollView.maxMagnification = CaptureZoomGeometry.magnificationRange.upperBound
+    scrollView.autohidesScrollers = true
+    scrollView.borderType = .noBorder
+    scrollView.drawsBackground = false
+    scrollView.hasHorizontalScroller = true
+    scrollView.hasVerticalScroller = true
+    scrollView.horizontalScrollElasticity = .automatic
+    scrollView.verticalScrollElasticity = .automatic
+    scrollView.scrollerStyle = .overlay
+    scrollView.usesPredominantAxisScrolling = false
+
+    let clipView = CenteringClipView()
+    clipView.drawsBackground = false
+    scrollView.contentView = clipView
+
+    let hostingView = NSHostingView(rootView: content)
+    hostingView.frame = CGRect(origin: .zero, size: CGSize(width: 1, height: 1))
+    scrollView.documentView = hostingView
+    scrollView.onMagnificationChanged = { [weak coordinator = context.coordinator] magnification in
+      coordinator?.magnificationChanged(magnification)
+    }
+    scrollView.onLayout = { [weak coordinator = context.coordinator, weak scrollView] in
+      guard let scrollView else { return }
+      coordinator?.layoutDocument(in: scrollView)
+    }
+    context.coordinator.hostingView = hostingView
+    context.coordinator.connect(to: scrollView)
+    return scrollView
+  }
+
+  func updateNSView(_ scrollView: CaptureScrollView, context: Context) {
+    context.coordinator.imageSize = imageSize
+    context.coordinator.hostingView?.rootView = content
+    context.coordinator.layoutDocument(in: scrollView)
+  }
+
+}
+
+// MARK: - CaptureScrollView
+
+final class CaptureScrollView: NSScrollView {
+
+  // MARK: Internal
+
+  var onLayout: (() -> Void)?
+  var onMagnificationChanged: ((CGFloat) -> Void)?
+  var fitMagnification: CGFloat = 1
+
+  override func setFrameSize(_ newSize: NSSize) {
+    if
+      pendingNormalizedCenter == nil,
+      magnification > fitMagnification * (CaptureZoomGeometry.magnificationRange.lowerBound + 0.001),
+      frame.size != newSize,
+      let documentView,
+      documentView.frame.width > 0,
+      documentView.frame.height > 0
+    {
+      pendingNormalizedCenter = CaptureZoomGeometry.normalizedCenter(
+        of: documentVisibleRect,
+        in: documentView.frame.size
+      )
+    }
+    super.setFrameSize(newSize)
+  }
+
+  override func layout() {
+    super.layout()
+    onLayout?()
+  }
+
+  override func magnify(with event: NSEvent) {
+    super.magnify(with: event)
+    onMagnificationChanged?(magnification)
+  }
+
+  // MARK: Fileprivate
+
+  fileprivate func takePendingNormalizedCenter() -> CGPoint? {
+    defer { pendingNormalizedCenter = nil }
+    return pendingNormalizedCenter
+  }
+
+  // MARK: Private
+
+  private var pendingNormalizedCenter: CGPoint?
+}
+
+// MARK: - CenteringClipView
+
+/// Centers a fitted document while retaining NSClipView's native scrolling and
+/// gesture behavior as soon as magnification makes the document larger.
+private final class CenteringClipView: NSClipView {
+  override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
+    var constrained = super.constrainBoundsRect(proposedBounds)
+    guard let documentView else { return constrained }
+
+    if documentView.frame.width < bounds.width {
+      constrained.origin.x = (documentView.frame.width - bounds.width) / 2
+    }
+    if documentView.frame.height < bounds.height {
+      constrained.origin.y = (documentView.frame.height - bounds.height) / 2
+    }
+    return constrained
+  }
+}

--- a/Sources/Overlay/OverlayView.swift
+++ b/Sources/Overlay/OverlayView.swift
@@ -32,6 +32,8 @@ struct OverlayView: View {
   let onToggleLive: () -> Void
   let onClose: () -> Void
 
+  @Binding var isShowingInformation: Bool
+
   var body: some View {
     bodyContent
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -48,8 +50,8 @@ struct OverlayView: View {
         // Drag handle: the only way to move the overlay. Use SwiftUI's native
         // window gesture so dragging remains reliable inside NSHostingView.
         MoveHandle()
-          .opacity(showMoveHandle ? 1 : 0)
-          .animation(.easeOut(duration: 0.15), value: showMoveHandle)
+          .opacity(showsControls ? 1 : 0)
+          .animation(.easeOut(duration: 0.15), value: showsControls)
           .padding(8)
           .frame(
             width: OverlayChromeMetrics.moveHandleSize.width,
@@ -66,10 +68,38 @@ struct OverlayView: View {
               .foregroundStyle(.orange)
               .help("Some text may be misread. Compare with the original.")
           }
-          if showMoveHandle {
+          if showsControls {
             let notices = Array(Set(lines.compactMap(\.modelNotice))).sorted()
-            if !notices.isEmpty {
-              Image(systemName: "info.circle").help(notices.joined(separator: "\n"))
+            if !notices.isEmpty || isShowingInformation {
+              Button {
+                if isShowingInformation {
+                  isShowingInformation = false
+                } else {
+                  informationMessages = notices
+                  isShowingInformation = true
+                }
+              } label: {
+                Image(systemName: "info.circle")
+                  .frame(width: 26, height: 26)
+                  .contentShape(Rectangle())
+              }
+              .buttonStyle(.plain)
+              .accessibilityLabel("Translation information")
+              .help("Show translation information")
+              .popover(isPresented: $isShowingInformation, arrowEdge: .bottom) {
+                VStack(alignment: .leading, spacing: 12) {
+                  Text("Translation information")
+                    .font(.headline)
+                  ForEach(informationMessages, id: \.self) { message in
+                    Text(verbatim: message)
+                      .font(.callout)
+                      .fixedSize(horizontal: false, vertical: true)
+                  }
+                }
+                .textSelection(.enabled)
+                .padding(16)
+                .frame(width: 320, alignment: .leading)
+              }
             }
           }
           // A small spinner while the overlay is busy (capturing / OCR or
@@ -82,7 +112,7 @@ struct OverlayView: View {
           // appear while the cursor is over the overlay. Removed from layout
           // (not just hidden) when away, so the spinner sits flush in the
           // top-right corner on its own instead of leaving a gap for them.
-          if showMoveHandle {
+          if showsControls {
             HStack(spacing: 6) {
               LiveHandle(isLive: isLive, action: onToggleLive)
               CloseHandle(action: onClose)
@@ -90,7 +120,7 @@ struct OverlayView: View {
             .transition(.move(edge: .trailing).combined(with: .opacity))
           }
         }
-        .animation(.easeOut(duration: 0.18), value: showMoveHandle)
+        .animation(.easeOut(duration: 0.18), value: showsControls)
         .padding(10)
       }
       .overlay(alignment: .bottom) {
@@ -111,9 +141,17 @@ struct OverlayView: View {
       .animation(.easeOut(duration: 0.15), value: frameOnly)
       .animation(.easeOut(duration: 0.15), value: translationUnavailable)
       .animation(.easeOut(duration: 0.15), value: isPreparingRecognition)
+      .onDisappear { isShowingInformation = false }
   }
 
   // MARK: Private
+
+  /// Keep the opened explanation stable while live OCR/translation updates.
+  @State private var informationMessages = [String]()
+
+  private var showsControls: Bool {
+    showMoveHandle || isShowingInformation
+  }
 
   @ViewBuilder
   private var bodyContent: some View {

--- a/Sources/Overlay/OverlayWindowController.swift
+++ b/Sources/Overlay/OverlayWindowController.swift
@@ -136,6 +136,7 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
   /// model carries stale state into the next use. Both windows are cheap to
   /// rebuild on the next show, which also re-snaps them to the stored frame.
   private func teardownWindows() {
+    model.isPresentingInformation = false
     pendingInteractionReset?.cancel()
     pendingInteractionReset = nil
     model.isInteracting = false
@@ -223,7 +224,12 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
       model: model,
       onToggleLive: { [weak self] in self?.eventHandler?(.toggleLive) },
       onClose: { [weak self] in self?.eventHandler?(.close) },
-      onCopy: { [weak self] in self?.copyTranslation() }
+      onCopy: { [weak self] in self?.copyTranslation() },
+      onInformationPresentedChange: { [weak self] presented in
+        guard let self, model.isPresentingInformation != presented else { return }
+        model.isPresentingInformation = presented
+        updatePassThroughForCursor()
+      }
     )
     let hosting = NSHostingView(rootView: rootView)
     hosting.frame = panel.contentLayoutRect
@@ -276,6 +282,7 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
   private func sourceContentInteracted(_ event: NSEvent) {
     guard
       model.isLive,
+      !model.isPresentingInformation,
       event.type == .scrollWheel || event.type == .leftMouseDragged,
       window?.frame.contains(NSEvent.mouseLocation) == true
     else { return }
@@ -299,6 +306,14 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
     // (interior pass-through means SwiftUI's .onHover never fires here).
     let inside = frame.contains(mouse)
     if model.cursorInside != inside { model.cursorInside = inside }
+
+    // A presented popover owns interaction until dismissal. Do not fade its
+    // anchor or send clicks/scrolling through to the captured app behind it.
+    if model.isPresentingInformation {
+      window.alphaValue = 1
+      window.ignoresMouseEvents = false
+      return
+    }
 
     // Top-left move handle: the ONLY region that drags the window. Its hit zone
     // is always live, even while the handle itself is faded out.
@@ -416,6 +431,7 @@ final class OverlayWindowModel {
   /// Whether the cursor is over the overlay — drives the move handle's
   /// hover-visibility (set from the controller's global cursor tracking).
   var cursorInside = false
+  var isPresentingInformation = false
   var isLive = false
   var isTranslating = false
   var liveMode = OverlayLiveMode.inPlace
@@ -441,6 +457,7 @@ private struct OverlayRootView: View {
   let onToggleLive: () -> Void
   let onClose: () -> Void
   let onCopy: () -> Void
+  let onInformationPresentedChange: (Bool) -> Void
 
   var body: some View {
     OverlayView(
@@ -453,7 +470,11 @@ private struct OverlayRootView: View {
       frameOnly: model.isWindowFrame,
       showMoveHandle: model.cursorInside,
       onToggleLive: onToggleLive,
-      onClose: onClose
+      onClose: onClose,
+      isShowingInformation: Binding(
+        get: { model.isPresentingInformation },
+        set: onInformationPresentedChange
+      )
     )
     .background {
       // Hidden affordances: ⌘, opens Settings, ⌘C copies the translated text.

--- a/Tests/Capture/CaptureResultImageTests.swift
+++ b/Tests/Capture/CaptureResultImageTests.swift
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import AppKit
+import Testing
+@testable import SwiftyCrow
+
+@Suite("Capture image export")
+@MainActor
+struct CaptureResultImageTests {
+  @Test
+  func exportsAllCornersAtSourceResolutionWithoutAWindow() throws {
+    let size = CGSize(width: 1800, height: 1200)
+    let context = try #require(CGContext(
+      data: nil,
+      width: 1800,
+      height: 1200,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    for (rect, color) in [
+      (CGRect(x: 0, y: 600, width: 900, height: 600), CGColor(red: 1, green: 0, blue: 0, alpha: 1)),
+      (CGRect(x: 900, y: 600, width: 900, height: 600), CGColor(red: 0, green: 1, blue: 0, alpha: 1)),
+      (CGRect(x: 0, y: 0, width: 900, height: 600), CGColor(red: 0, green: 0, blue: 1, alpha: 1)),
+      (CGRect(x: 900, y: 0, width: 900, height: 600), CGColor(red: 1, green: 1, blue: 0, alpha: 1)),
+    ] {
+      context.setFillColor(color)
+      context.fill(rect)
+    }
+    let source = try #require(context.makeImage()?.pngData)
+    let output = try #require(CaptureResultImage.png(imageData: source, imageSize: size, lines: []))
+    let original = try #require(NSBitmapImageRep(data: source))
+    let rendered = try #require(NSBitmapImageRep(data: output))
+    #expect(rendered.pixelsWide == 1800)
+    #expect(rendered.pixelsHigh == 1200)
+    for (x, y) in [(10, 10), (1790, 10), (10, 1190), (1790, 1190)] {
+      let expected = try #require(original.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB))
+      let actual = try #require(rendered.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB))
+      #expect(abs(actual.redComponent - expected.redComponent) < 0.03)
+      #expect(abs(actual.greenComponent - expected.greenComponent) < 0.03)
+      #expect(abs(actual.blueComponent - expected.blueComponent) < 0.03)
+    }
+  }
+
+  @Test(arguments: [false, true])
+  func exportIncludesTranslatedGlyphs(horizontal: Bool) throws {
+    let size = CGSize(width: 600, height: 400)
+    let context = try #require(CGContext(
+      data: nil,
+      width: 600,
+      height: 400,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(gray: 1, alpha: 1))
+    context.fill(CGRect(origin: .zero, size: size))
+    let data = try #require(context.makeImage()?.pngData)
+    var line = OverlayLine(id: UUID(), source: .init(
+      recognized: .init(boundingBoxNormalized: CGRect(x: 0.2, y: 0.2, width: 0.6, height: 0.6), text: "Source text"),
+      language: Locale.Language(identifier: "en")
+    ))
+    if !horizontal { line.source.layout = .vertical(characterScale: 0.05, progression: .rightToLeft) }
+    line.showTranslation(horizontal ? "Complete translated text" : "日本語の翻訳", language: Locale.Language(identifier: horizontal
+        ? "en"
+        : "ja"))
+    let output = try #require(CaptureResultImage.png(imageData: data, imageSize: size, lines: [line]))
+    let rendered = try #require(NSBitmapImageRep(data: output))
+    var darkPixels = 0
+    for y in stride(from: 85, to: 315, by: 2) {
+      for x in stride(from: 125, to: 475, by: 2) {
+        let color = try #require(rendered.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB))
+        if color.redComponent < 0.5 { darkPixels += 1 }
+      }
+    }
+    #expect(darkPixels > 20)
+    let corner = try #require(rendered.colorAt(x: 10, y: 10)?.usingColorSpace(.deviceRGB))
+    #expect(corner.redComponent > 0.98)
+  }
+
+  @Test(arguments: [0.1, 0.65, 1.0, 1.41])
+  func scalingTheCompositedPreviewCannotRevealSourcePixels(scale: Double) throws {
+    let size = CGSize(width: 400, height: 240)
+    let context = try #require(CGContext(
+      data: nil,
+      width: 400,
+      height: 240,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(gray: 1, alpha: 1))
+    context.fill(CGRect(origin: .zero, size: size))
+    // Magenta represents original glyph pixels that must be completely erased.
+    context.setFillColor(CGColor(red: 1, green: 0, blue: 1, alpha: 1))
+    context.fill(CGRect(x: 80, y: 96, width: 240, height: 48))
+    let source = try #require(context.makeImage()?.pngData)
+    var line = OverlayLine(id: UUID(), source: .init(
+      recognized: .init(boundingBoxNormalized: CGRect(x: 0.2, y: 0.4, width: 0.6, height: 0.2), text: "Original text"),
+      language: Locale.Language(identifier: "en")
+    ))
+    line.showTranslation("번역된 내용", language: Locale.Language(identifier: "ko"))
+    let composite = try #require(CaptureResultImage.render(imageData: source, imageSize: size, lines: [line]))
+    let width = Int((size.width * scale).rounded())
+    let height = Int((size.height * scale).rounded())
+    let scaled = try #require(CGContext(
+      data: nil,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    scaled.interpolationQuality = .high
+    scaled.draw(composite, in: CGRect(x: 0, y: 0, width: width, height: height))
+    let bitmap = NSBitmapImageRep(cgImage: try #require(scaled.makeImage()))
+    var sourcePixels = 0
+    for y in 0..<height {
+      for x in 0..<width {
+        let color = try #require(bitmap.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB))
+        if color.redComponent > 0.6, color.blueComponent > 0.6, color.greenComponent < 0.4 {
+          sourcePixels += 1
+        }
+      }
+    }
+    #expect(sourcePixels == 0)
+  }
+
+  @Test
+  func refusesMissingOrInvalidCapture() {
+    #expect(CaptureResultImage.png(imageData: nil, imageSize: .zero, lines: []) == nil)
+    #expect(CaptureResultImage.png(imageData: Data(), imageSize: CGSize(width: 10, height: 10), lines: []) == nil)
+  }
+}

--- a/Tests/Capture/CaptureZoomGeometryTests.swift
+++ b/Tests/Capture/CaptureZoomGeometryTests.swift
@@ -1,131 +1,45 @@
-import XCTest
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
 
+import CoreGraphics
+import Testing
 @testable import SwiftyCrow
 
-final class CaptureZoomGeometryTests: XCTestCase {
-
-  func testDetailScaleOnlyOversamplesOneXDisplays() {
-    XCTAssertEqual(CaptureZoomGeometry.detailScale(forBackingScale: 1), 2)
-    XCTAssertEqual(CaptureZoomGeometry.detailScale(forBackingScale: 2), 1)
-    XCTAssertEqual(CaptureZoomGeometry.detailScale(forBackingScale: 3), 1)
-    XCTAssertEqual(CaptureZoomGeometry.detailScale(forBackingScale: 0), 1)
-    XCTAssertEqual(
-      CaptureZoomGeometry.detailedDocumentSize(
-        CGSize(width: 640, height: 480),
-        backingScale: 1
-      ),
-      CGSize(width: 1280, height: 960)
-    )
+@Suite("Capture zoom geometry")
+struct CaptureZoomGeometryTests {
+  @Test
+  func fitUsesNativePixelsOnStandardAndRetinaDisplays() {
+    let image = CGSize(width: 1600, height: 800)
+    let viewport = CGSize(width: 600, height: 400)
+    #expect(CaptureZoomGeometry.fitScale(image: image, viewport: viewport, backingScale: 1) == 0.375)
+    #expect(CaptureZoomGeometry.fitScale(image: image, viewport: viewport, backingScale: 2) == 0.75)
   }
 
-  func testDetailedDocumentSizeCapsLargeCaptureOversampling() {
-    let source = CGSize(width: 3840, height: 2160)
-    let detailed = CaptureZoomGeometry.detailedDocumentSize(source, backingScale: 1)
-
-    XCTAssertGreaterThan(detailed.width, source.width)
-    XCTAssertLessThan(detailed.width, source.width * 2)
-    XCTAssertLessThanOrEqual(
-      detailed.width * detailed.height,
-      CaptureZoomGeometry.maximumOversampledArea + 1
-    )
-    let alreadyLarge = CGSize(width: 6000, height: 4000)
-    XCTAssertEqual(
-      CaptureZoomGeometry.detailedDocumentSize(alreadyLarge, backingScale: 1),
-      alreadyLarge
-    )
-    XCTAssertEqual(
-      CaptureZoomGeometry.detailedDocumentSize(.zero, backingScale: 1),
-      .zero
-    )
+  @Test
+  func fitDoesNotEnlargeSmallCaptures() {
+    #expect(CaptureZoomGeometry.fitScale(
+      image: CGSize(width: 40, height: 30),
+      viewport: CGSize(width: 600, height: 400),
+      backingScale: 2
+    ) == 1)
   }
 
-  func testAspectFitHandlesWideTallAndMatchingImages() {
-    XCTAssertEqual(
-      CaptureZoomGeometry.aspectFit(CGSize(width: 400, height: 200), in: CGSize(width: 300, height: 300)),
-      CGSize(width: 300, height: 150)
-    )
-    XCTAssertEqual(
-      CaptureZoomGeometry.aspectFit(CGSize(width: 200, height: 400), in: CGSize(width: 300, height: 300)),
-      CGSize(width: 150, height: 300)
-    )
-    XCTAssertEqual(
-      CaptureZoomGeometry.aspectFit(CGSize(width: 400, height: 200), in: CGSize(width: 200, height: 100)),
-      CGSize(width: 200, height: 100)
-    )
+  @Test
+  func rejectsUnavailableAndInvalidGeometry() {
+    let size = CGSize(width: 200, height: 100)
+    #expect(CaptureZoomGeometry.fitScale(image: .zero, viewport: size, backingScale: 1) == nil)
+    #expect(CaptureZoomGeometry.fitScale(image: size, viewport: .zero, backingScale: 1) == nil)
+    #expect(CaptureZoomGeometry.fitScale(image: size, viewport: size, backingScale: .infinity) == nil)
+    #expect(CaptureZoomGeometry.fitScale(image: size, viewport: size, backingScale: 0) == nil)
   }
 
-  func testAspectFitRejectsInvalidGeometry() {
-    XCTAssertEqual(
-      CaptureZoomGeometry.aspectFit(.zero, in: CGSize(width: 300, height: 300)),
-      .zero
-    )
-    XCTAssertEqual(
-      CaptureZoomGeometry.aspectFit(
-        CGSize(width: 100, height: 100),
-        in: CGSize(width: CGFloat.infinity, height: 300)
-      ),
-      .zero
-    )
-  }
-
-  func testFitMagnificationSupportsDownscalingAndUpscaling() {
-    XCTAssertEqual(
-      CaptureZoomGeometry.fitMagnification(
-        CGSize(width: 800, height: 400),
-        in: CGSize(width: 600, height: 400)
-      ),
-      0.75
-    )
-    XCTAssertEqual(
-      CaptureZoomGeometry.fitMagnification(
-        CGSize(width: 200, height: 100),
-        in: CGSize(width: 600, height: 400)
-      ),
-      3
-    )
-    XCTAssertEqual(CaptureZoomGeometry.fitMagnification(.zero, in: CGSize(width: 600, height: 400)), 0)
-  }
-
-  func testMagnificationClampsToSupportedRange() {
-    XCTAssertEqual(CaptureZoomGeometry.clampedMagnification(0.5), 1)
-    XCTAssertEqual(CaptureZoomGeometry.clampedMagnification(2.5), 2.5)
-    XCTAssertEqual(CaptureZoomGeometry.clampedMagnification(9), 6)
-    XCTAssertEqual(CaptureZoomGeometry.clampedMagnification(.infinity), 1)
-  }
-
-  func testNormalizedCenterSurvivesDocumentResize() {
-    let center = CaptureZoomGeometry.normalizedCenter(
-      of: CGRect(x: 300, y: 100, width: 200, height: 100),
-      in: CGSize(width: 800, height: 400)
-    )
+  @Test
+  func preservedCenterIsClampedToVisibleDocumentEdges() {
     let origin = CaptureZoomGeometry.scrollOrigin(
-      preserving: center,
-      visibleSize: CGSize(width: 300, height: 150),
-      documentSize: CGSize(width: 1_200, height: 600)
+      center: CGPoint(x: 0.9, y: 0.1),
+      visibleSize: CGSize(width: 400, height: 200),
+      documentSize: CGSize(width: 800, height: 400)
     )
-
-    XCTAssertEqual(center.x, 0.5)
-    XCTAssertEqual(center.y, 0.375)
-    XCTAssertEqual(origin.x, 450)
-    XCTAssertEqual(origin.y, 150)
-  }
-
-  func testScrollOriginStaysWithinDocumentBounds() {
-    XCTAssertEqual(
-      CaptureZoomGeometry.scrollOrigin(
-        preserving: CGPoint(x: -1, y: 2),
-        visibleSize: CGSize(width: 200, height: 100),
-        documentSize: CGSize(width: 500, height: 300)
-      ),
-      CGPoint(x: 0, y: 200)
-    )
-    XCTAssertEqual(
-      CaptureZoomGeometry.scrollOrigin(
-        preserving: CGPoint(x: 0.5, y: 0.5),
-        visibleSize: CGSize(width: 500, height: 500),
-        documentSize: CGSize(width: 200, height: 100)
-      ),
-      .zero
-    )
+    #expect(origin == CGPoint(x: 400, y: 0))
   }
 }

--- a/Tests/Capture/CaptureZoomGeometryTests.swift
+++ b/Tests/Capture/CaptureZoomGeometryTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+
+@testable import SwiftyCrow
+
+final class CaptureZoomGeometryTests: XCTestCase {
+
+  func testDetailScaleOnlyOversamplesOneXDisplays() {
+    XCTAssertEqual(CaptureZoomGeometry.detailScale(forBackingScale: 1), 2)
+    XCTAssertEqual(CaptureZoomGeometry.detailScale(forBackingScale: 2), 1)
+    XCTAssertEqual(CaptureZoomGeometry.detailScale(forBackingScale: 3), 1)
+    XCTAssertEqual(CaptureZoomGeometry.detailScale(forBackingScale: 0), 1)
+    XCTAssertEqual(
+      CaptureZoomGeometry.detailedDocumentSize(
+        CGSize(width: 640, height: 480),
+        backingScale: 1
+      ),
+      CGSize(width: 1280, height: 960)
+    )
+  }
+
+  func testDetailedDocumentSizeCapsLargeCaptureOversampling() {
+    let source = CGSize(width: 3840, height: 2160)
+    let detailed = CaptureZoomGeometry.detailedDocumentSize(source, backingScale: 1)
+
+    XCTAssertGreaterThan(detailed.width, source.width)
+    XCTAssertLessThan(detailed.width, source.width * 2)
+    XCTAssertLessThanOrEqual(
+      detailed.width * detailed.height,
+      CaptureZoomGeometry.maximumOversampledArea + 1
+    )
+    let alreadyLarge = CGSize(width: 6000, height: 4000)
+    XCTAssertEqual(
+      CaptureZoomGeometry.detailedDocumentSize(alreadyLarge, backingScale: 1),
+      alreadyLarge
+    )
+    XCTAssertEqual(
+      CaptureZoomGeometry.detailedDocumentSize(.zero, backingScale: 1),
+      .zero
+    )
+  }
+
+  func testAspectFitHandlesWideTallAndMatchingImages() {
+    XCTAssertEqual(
+      CaptureZoomGeometry.aspectFit(CGSize(width: 400, height: 200), in: CGSize(width: 300, height: 300)),
+      CGSize(width: 300, height: 150)
+    )
+    XCTAssertEqual(
+      CaptureZoomGeometry.aspectFit(CGSize(width: 200, height: 400), in: CGSize(width: 300, height: 300)),
+      CGSize(width: 150, height: 300)
+    )
+    XCTAssertEqual(
+      CaptureZoomGeometry.aspectFit(CGSize(width: 400, height: 200), in: CGSize(width: 200, height: 100)),
+      CGSize(width: 200, height: 100)
+    )
+  }
+
+  func testAspectFitRejectsInvalidGeometry() {
+    XCTAssertEqual(
+      CaptureZoomGeometry.aspectFit(.zero, in: CGSize(width: 300, height: 300)),
+      .zero
+    )
+    XCTAssertEqual(
+      CaptureZoomGeometry.aspectFit(
+        CGSize(width: 100, height: 100),
+        in: CGSize(width: CGFloat.infinity, height: 300)
+      ),
+      .zero
+    )
+  }
+
+  func testFitMagnificationSupportsDownscalingAndUpscaling() {
+    XCTAssertEqual(
+      CaptureZoomGeometry.fitMagnification(
+        CGSize(width: 800, height: 400),
+        in: CGSize(width: 600, height: 400)
+      ),
+      0.75
+    )
+    XCTAssertEqual(
+      CaptureZoomGeometry.fitMagnification(
+        CGSize(width: 200, height: 100),
+        in: CGSize(width: 600, height: 400)
+      ),
+      3
+    )
+    XCTAssertEqual(CaptureZoomGeometry.fitMagnification(.zero, in: CGSize(width: 600, height: 400)), 0)
+  }
+
+  func testMagnificationClampsToSupportedRange() {
+    XCTAssertEqual(CaptureZoomGeometry.clampedMagnification(0.5), 1)
+    XCTAssertEqual(CaptureZoomGeometry.clampedMagnification(2.5), 2.5)
+    XCTAssertEqual(CaptureZoomGeometry.clampedMagnification(9), 6)
+    XCTAssertEqual(CaptureZoomGeometry.clampedMagnification(.infinity), 1)
+  }
+
+  func testNormalizedCenterSurvivesDocumentResize() {
+    let center = CaptureZoomGeometry.normalizedCenter(
+      of: CGRect(x: 300, y: 100, width: 200, height: 100),
+      in: CGSize(width: 800, height: 400)
+    )
+    let origin = CaptureZoomGeometry.scrollOrigin(
+      preserving: center,
+      visibleSize: CGSize(width: 300, height: 150),
+      documentSize: CGSize(width: 1_200, height: 600)
+    )
+
+    XCTAssertEqual(center.x, 0.5)
+    XCTAssertEqual(center.y, 0.375)
+    XCTAssertEqual(origin.x, 450)
+    XCTAssertEqual(origin.y, 150)
+  }
+
+  func testScrollOriginStaysWithinDocumentBounds() {
+    XCTAssertEqual(
+      CaptureZoomGeometry.scrollOrigin(
+        preserving: CGPoint(x: -1, y: 2),
+        visibleSize: CGSize(width: 200, height: 100),
+        documentSize: CGSize(width: 500, height: 300)
+      ),
+      CGPoint(x: 0, y: 200)
+    )
+    XCTAssertEqual(
+      CaptureZoomGeometry.scrollOrigin(
+        preserving: CGPoint(x: 0.5, y: 0.5),
+        visibleSize: CGSize(width: 500, height: 500),
+        documentSize: CGSize(width: 200, height: 100)
+      ),
+      .zero
+    )
+  }
+}

--- a/Tests/Capture/ZoomableCaptureCanvasTests.swift
+++ b/Tests/Capture/ZoomableCaptureCanvasTests.swift
@@ -1,0 +1,162 @@
+import AppKit
+import SwiftUI
+import XCTest
+
+@testable import SwiftyCrow
+
+final class ZoomableCaptureCanvasTests: XCTestCase {
+
+  @MainActor
+  func testCoordinatorFitsDocumentAndRespondsToZoomCommands() {
+    let model = CaptureZoomModel()
+    let coordinator = ZoomableCaptureCanvas<Color>.Coordinator(model: model)
+    let scrollView = CaptureScrollView(frame: CGRect(x: 0, y: 0, width: 600, height: 400))
+    scrollView.allowsMagnification = true
+    scrollView.minMagnification = 0.01
+    scrollView.maxMagnification = CaptureZoomGeometry.magnificationRange.upperBound
+
+    let hostingView = NSHostingView(rootView: Color.clear)
+    hostingView.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
+    scrollView.documentView = hostingView
+    coordinator.hostingView = hostingView
+    coordinator.imageSize = CGSize(width: 800, height: 400)
+    coordinator.connect(to: scrollView)
+
+    coordinator.layoutDocument(in: scrollView)
+
+    XCTAssertEqual(hostingView.frame.width, 800, accuracy: 0.01)
+    XCTAssertEqual(hostingView.frame.height, 400, accuracy: 0.01)
+    XCTAssertEqual(scrollView.magnification, 0.75, accuracy: 0.001)
+
+    model.zoomIn()
+    XCTAssertEqual(scrollView.magnification, 0.9375, accuracy: 0.001)
+    XCTAssertEqual(model.percentage, 125)
+
+    model.zoomOut()
+    XCTAssertEqual(scrollView.magnification, 0.75, accuracy: 0.001)
+    XCTAssertEqual(model.percentage, 100)
+  }
+
+  @MainActor
+  func testCoordinatorClampsToolbarZoomAndRefitsAfterResize() {
+    let model = CaptureZoomModel()
+    let coordinator = ZoomableCaptureCanvas<Color>.Coordinator(model: model)
+    let scrollView = CaptureScrollView(frame: CGRect(x: 0, y: 0, width: 600, height: 400))
+    scrollView.allowsMagnification = true
+    scrollView.minMagnification = 0.01
+    scrollView.maxMagnification = CaptureZoomGeometry.magnificationRange.upperBound
+
+    let hostingView = NSHostingView(rootView: Color.clear)
+    hostingView.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
+    scrollView.documentView = hostingView
+    coordinator.hostingView = hostingView
+    coordinator.imageSize = CGSize(width: 800, height: 400)
+    coordinator.connect(to: scrollView)
+    coordinator.layoutDocument(in: scrollView)
+
+    for _ in 0..<20 {
+      model.zoomIn()
+    }
+    XCTAssertEqual(scrollView.magnification, 4.5, accuracy: 0.001)
+    XCTAssertEqual(model.percentage, 600)
+
+    model.resetToFit()
+    scrollView.frame = CGRect(x: 0, y: 0, width: 300, height: 500)
+    coordinator.layoutDocument(in: scrollView)
+
+    XCTAssertEqual(scrollView.magnification, 0.375, accuracy: 0.001)
+    XCTAssertEqual(model.percentage, 100)
+    XCTAssertEqual(hostingView.frame.width, 800, accuracy: 0.01)
+    XCTAssertEqual(hostingView.frame.height, 400, accuracy: 0.01)
+  }
+
+  @MainActor
+  func testCoordinatorPreservesZoomedViewportCenterAfterResize() {
+    let model = CaptureZoomModel()
+    let coordinator = ZoomableCaptureCanvas<Color>.Coordinator(model: model)
+    let scrollView = CaptureScrollView(frame: CGRect(x: 0, y: 0, width: 600, height: 400))
+    scrollView.allowsMagnification = true
+    scrollView.minMagnification = 0.01
+    scrollView.maxMagnification = CaptureZoomGeometry.magnificationRange.upperBound
+
+    let hostingView = NSHostingView(rootView: Color.clear)
+    hostingView.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
+    scrollView.documentView = hostingView
+    coordinator.hostingView = hostingView
+    coordinator.imageSize = CGSize(width: 800, height: 400)
+    coordinator.connect(to: scrollView)
+    coordinator.layoutDocument(in: scrollView)
+
+    scrollView.setMagnification(1.5, centeredAt: CGPoint(x: 400, y: 200))
+    scrollView.contentView.scroll(to: CGPoint(x: 240, y: 50))
+    scrollView.reflectScrolledClipView(scrollView.contentView)
+    let before = CaptureZoomGeometry.normalizedCenter(
+      of: scrollView.documentVisibleRect,
+      in: hostingView.frame.size
+    )
+
+    scrollView.setFrameSize(CGSize(width: 800, height: 500))
+    coordinator.layoutDocument(in: scrollView)
+    let after = CaptureZoomGeometry.normalizedCenter(
+      of: scrollView.documentVisibleRect,
+      in: hostingView.frame.size
+    )
+
+    XCTAssertEqual(after.x, before.x, accuracy: 0.01)
+    XCTAssertEqual(after.y, before.y, accuracy: 0.01)
+    XCTAssertEqual(scrollView.magnification, 2, accuracy: 0.001)
+    XCTAssertEqual(model.percentage, 200)
+  }
+
+  @MainActor
+  func testCoordinatorSafelyFitsCaptureAbovePreviousMaximum() {
+    let model = CaptureZoomModel()
+    let coordinator = ZoomableCaptureCanvas<Color>.Coordinator(model: model)
+    let scrollView = CaptureScrollView(frame: CGRect(x: 0, y: 0, width: 600, height: 400))
+    scrollView.allowsMagnification = true
+    scrollView.minMagnification = 0.01
+    scrollView.maxMagnification = CaptureZoomGeometry.magnificationRange.upperBound
+
+    let hostingView = NSHostingView(rootView: Color.clear)
+    hostingView.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
+    scrollView.documentView = hostingView
+    coordinator.hostingView = hostingView
+    coordinator.imageSize = CGSize(width: 40, height: 30)
+    coordinator.connect(to: scrollView)
+
+    coordinator.layoutDocument(in: scrollView)
+
+    let expectedFit = CaptureZoomGeometry.fitMagnification(
+      hostingView.frame.size,
+      in: scrollView.contentSize
+    )
+    XCTAssertGreaterThan(expectedFit, CaptureZoomGeometry.magnificationRange.upperBound)
+    XCTAssertEqual(scrollView.minMagnification, expectedFit, accuracy: 0.001)
+    XCTAssertEqual(
+      scrollView.maxMagnification,
+      expectedFit * CaptureZoomGeometry.magnificationRange.upperBound,
+      accuracy: 0.001
+    )
+    XCTAssertEqual(scrollView.magnification, expectedFit, accuracy: 0.001)
+    XCTAssertEqual(model.percentage, 100)
+
+    coordinator.imageSize = CGSize(width: 2400, height: 1600)
+    coordinator.layoutDocument(in: scrollView)
+
+    let expectedRefit = CaptureZoomGeometry.fitMagnification(
+      hostingView.frame.size,
+      in: scrollView.contentSize
+    )
+    XCTAssertLessThan(
+      expectedRefit * CaptureZoomGeometry.magnificationRange.upperBound,
+      expectedFit
+    )
+    XCTAssertEqual(scrollView.minMagnification, expectedRefit, accuracy: 0.001)
+    XCTAssertEqual(
+      scrollView.maxMagnification,
+      expectedRefit * CaptureZoomGeometry.magnificationRange.upperBound,
+      accuracy: 0.001
+    )
+    XCTAssertEqual(scrollView.magnification, expectedRefit, accuracy: 0.001)
+  }
+}

--- a/Tests/Capture/ZoomableCaptureCanvasTests.swift
+++ b/Tests/Capture/ZoomableCaptureCanvasTests.swift
@@ -1,162 +1,152 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import AppKit
 import SwiftUI
-import XCTest
-
+import Testing
 @testable import SwiftyCrow
 
-final class ZoomableCaptureCanvasTests: XCTestCase {
+@Suite("Native capture viewport")
+@MainActor
+struct ZoomableCaptureCanvasTests {
 
-  @MainActor
-  func testCoordinatorFitsDocumentAndRespondsToZoomCommands() {
-    let model = CaptureZoomModel()
-    let coordinator = ZoomableCaptureCanvas<Color>.Coordinator(model: model)
-    let scrollView = CaptureScrollView(frame: CGRect(x: 0, y: 0, width: 600, height: 400))
-    scrollView.allowsMagnification = true
-    scrollView.minMagnification = 0.01
-    scrollView.maxMagnification = CaptureZoomGeometry.magnificationRange.upperBound
+  // MARK: Internal
 
-    let hostingView = NSHostingView(rootView: Color.clear)
-    hostingView.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
-    scrollView.documentView = hostingView
-    coordinator.hostingView = hostingView
-    coordinator.imageSize = CGSize(width: 800, height: 400)
-    coordinator.connect(to: scrollView)
-
-    coordinator.layoutDocument(in: scrollView)
-
-    XCTAssertEqual(hostingView.frame.width, 800, accuracy: 0.01)
-    XCTAssertEqual(hostingView.frame.height, 400, accuracy: 0.01)
-    XCTAssertEqual(scrollView.magnification, 0.75, accuracy: 0.001)
-
-    model.zoomIn()
-    XCTAssertEqual(scrollView.magnification, 0.9375, accuracy: 0.001)
-    XCTAssertEqual(model.percentage, 125)
-
-    model.zoomOut()
-    XCTAssertEqual(scrollView.magnification, 0.75, accuracy: 0.001)
-    XCTAssertEqual(model.percentage, 100)
+  @Test
+  func fitTracksWindowSizeUntilUserZooms() {
+    let fixture = Fixture()
+    #expect(abs(fixture.model.scale - 0.375) < 0.001)
+    fixture.scroll.setFrameSize(CGSize(width: 300, height: 300))
+    fixture.layout()
+    #expect(abs(fixture.model.scale - 0.1875) < 0.001)
+    #expect(fixture.model.isFitting)
+    fixture.model.zoomIn()
+    #expect(abs(fixture.model.scale - 0.234375) < 0.001)
+    #expect(!fixture.model.isFitting)
   }
 
+  @Test
+  func resizingPreservesManualScaleAndViewportCenter() {
+    let fixture = Fixture()
+    fixture.pinch(to: 1.5)
+    fixture.scroll.contentView.scroll(to: CGPoint(x: 400, y: 220))
+    fixture.scroll.reflectScrolledClipView(fixture.scroll.contentView)
+    let before = fixture.center
+    fixture.scroll.setFrameSize(CGSize(width: 800, height: 500))
+    fixture.layout()
+    #expect(abs(fixture.model.scale - 1.5) < 0.001)
+    #expect(abs(fixture.center.x - before.x) < 0.001)
+    #expect(abs(fixture.center.y - before.y) < 0.001)
+  }
+
+  @Test
+  func movingAcrossDisplayScalesPreservesNativeZoom() {
+    let fixture = Fixture(backingScale: 2)
+    #expect(abs(fixture.model.scale - 0.75) < 0.001)
+    fixture.pinch(to: 0.75)
+    #expect(abs(fixture.model.scale - 1.5) < 0.001)
+    let before = fixture.center
+    fixture.coordinator.backingScale = 1
+    fixture.layout()
+    #expect(abs(fixture.scroll.magnification - 1.5) < 0.001)
+    #expect(abs(fixture.model.scale - 1.5) < 0.001)
+    #expect(abs(fixture.center.x - before.x) < 0.001)
+    #expect(abs(fixture.center.y - before.y) < 0.001)
+  }
+
+  @Test
+  func fitRecentersPannedImageAndTranslationUpdatesPreserveZoom() {
+    let fixture = Fixture()
+    fixture.pinch(to: 2)
+    fixture.scroll.contentView.scroll(to: CGPoint(x: 500, y: 250))
+    let before = fixture.center
+    fixture.coordinator.hostingView?.rootView = .red
+    fixture.layout()
+    #expect(fixture.model.scale == 2)
+    #expect(fixture.center == before)
+    fixture.model.resetToFit()
+    #expect(abs(fixture.model.scale - 0.375) < 0.001)
+    #expect(abs(fixture.center.x - 0.5) < 0.001)
+    #expect(abs(fixture.center.y - 0.5) < 0.001)
+  }
+
+  @Test
+  func mousePanCannotMoveTheImagePastItsEdges() {
+    let fixture = Fixture()
+    fixture.pinch(to: 2)
+    fixture.scroll.scrollContent(to: CGPoint(x: -1000, y: -1000))
+    #expect(abs(fixture.scroll.contentView.bounds.minX) < 0.001)
+    #expect(abs(fixture.scroll.contentView.bounds.minY) < 0.001)
+    fixture.scroll.scrollContent(to: CGPoint(x: 10000, y: 10000))
+    #expect(abs(fixture.scroll.contentView.bounds.maxX - 1600) < 0.001)
+    #expect(abs(fixture.scroll.contentView.bounds.maxY - 800) < 0.001)
+    fixture.model.resetToFit()
+    fixture.scroll.scrollContent(to: CGPoint(x: 10000, y: 10000))
+    #expect(abs(fixture.center.x - 0.5) < 0.001)
+    #expect(abs(fixture.center.y - 0.5) < 0.001)
+  }
+
+  @Test
+  func toolbarZoomStopsAtBoundsAndNewImagesRefit() {
+    let fixture = Fixture()
+    for _ in 0..<50 { fixture.model.zoomIn() }
+    #expect(fixture.model.scale == 8)
+    #expect(!fixture.model.canZoomIn)
+    for _ in 0..<50 { fixture.model.zoomOut() }
+    #expect(fixture.model.scale == 0.1)
+    #expect(!fixture.model.canZoomOut)
+    fixture.coordinator.imageSize = CGSize(width: 40, height: 30)
+    fixture.layout()
+    #expect(fixture.model.scale == 1)
+    fixture.coordinator.imageSize = CGSize(width: 2400, height: 1600)
+    fixture.layout()
+    #expect(abs(fixture.model.scale - 0.25) < 0.001)
+    #expect(fixture.model.isFitting)
+  }
+
+  // MARK: Private
+
   @MainActor
-  func testCoordinatorClampsToolbarZoomAndRefitsAfterResize() {
-    let model = CaptureZoomModel()
-    let coordinator = ZoomableCaptureCanvas<Color>.Coordinator(model: model)
-    let scrollView = CaptureScrollView(frame: CGRect(x: 0, y: 0, width: 600, height: 400))
-    scrollView.allowsMagnification = true
-    scrollView.minMagnification = 0.01
-    scrollView.maxMagnification = CaptureZoomGeometry.magnificationRange.upperBound
+  private struct Fixture {
 
-    let hostingView = NSHostingView(rootView: Color.clear)
-    hostingView.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
-    scrollView.documentView = hostingView
-    coordinator.hostingView = hostingView
-    coordinator.imageSize = CGSize(width: 800, height: 400)
-    coordinator.connect(to: scrollView)
-    coordinator.layoutDocument(in: scrollView)
+    // MARK: Lifecycle
 
-    for _ in 0..<20 {
-      model.zoomIn()
+    init(backingScale: CGFloat = 1) {
+      model = CaptureZoomModel()
+      coordinator = ZoomableCaptureCanvas<Color>.Coordinator(model: model)
+      scroll = CaptureScrollView(frame: CGRect(x: 0, y: 0, width: 600, height: 400))
+      scroll.allowsMagnification = true
+      scroll.minMagnification = 0.001
+      scroll.maxMagnification = 8
+      scroll.contentView = CenteringCaptureClipView()
+      let hosting = NSHostingView(rootView: Color.clear)
+      hosting.sizingOptions = []
+      hosting.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
+      scroll.documentView = hosting
+      coordinator.hostingView = hosting
+      coordinator.imageSize = CGSize(width: 1600, height: 800)
+      coordinator.backingScale = backingScale
+      coordinator.connect(to: scroll)
+      layout()
     }
-    XCTAssertEqual(scrollView.magnification, 4.5, accuracy: 0.001)
-    XCTAssertEqual(model.percentage, 600)
 
-    model.resetToFit()
-    scrollView.frame = CGRect(x: 0, y: 0, width: 300, height: 500)
-    coordinator.layoutDocument(in: scrollView)
+    // MARK: Internal
 
-    XCTAssertEqual(scrollView.magnification, 0.375, accuracy: 0.001)
-    XCTAssertEqual(model.percentage, 100)
-    XCTAssertEqual(hostingView.frame.width, 800, accuracy: 0.01)
-    XCTAssertEqual(hostingView.frame.height, 400, accuracy: 0.01)
-  }
+    let model: CaptureZoomModel
+    let coordinator: ZoomableCaptureCanvas<Color>.Coordinator
+    let scroll: CaptureScrollView
 
-  @MainActor
-  func testCoordinatorPreservesZoomedViewportCenterAfterResize() {
-    let model = CaptureZoomModel()
-    let coordinator = ZoomableCaptureCanvas<Color>.Coordinator(model: model)
-    let scrollView = CaptureScrollView(frame: CGRect(x: 0, y: 0, width: 600, height: 400))
-    scrollView.allowsMagnification = true
-    scrollView.minMagnification = 0.01
-    scrollView.maxMagnification = CaptureZoomGeometry.magnificationRange.upperBound
+    var center: CGPoint {
+      CaptureZoomGeometry.normalizedCenter(of: scroll.documentVisibleRect, in: coordinator.imageSize)
+    }
 
-    let hostingView = NSHostingView(rootView: Color.clear)
-    hostingView.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
-    scrollView.documentView = hostingView
-    coordinator.hostingView = hostingView
-    coordinator.imageSize = CGSize(width: 800, height: 400)
-    coordinator.connect(to: scrollView)
-    coordinator.layoutDocument(in: scrollView)
+    func layout() {
+      coordinator.layoutDocument(in: scroll)
+    }
 
-    scrollView.setMagnification(1.5, centeredAt: CGPoint(x: 400, y: 200))
-    scrollView.contentView.scroll(to: CGPoint(x: 240, y: 50))
-    scrollView.reflectScrolledClipView(scrollView.contentView)
-    let before = CaptureZoomGeometry.normalizedCenter(
-      of: scrollView.documentVisibleRect,
-      in: hostingView.frame.size
-    )
-
-    scrollView.setFrameSize(CGSize(width: 800, height: 500))
-    coordinator.layoutDocument(in: scrollView)
-    let after = CaptureZoomGeometry.normalizedCenter(
-      of: scrollView.documentVisibleRect,
-      in: hostingView.frame.size
-    )
-
-    XCTAssertEqual(after.x, before.x, accuracy: 0.01)
-    XCTAssertEqual(after.y, before.y, accuracy: 0.01)
-    XCTAssertEqual(scrollView.magnification, 2, accuracy: 0.001)
-    XCTAssertEqual(model.percentage, 200)
-  }
-
-  @MainActor
-  func testCoordinatorSafelyFitsCaptureAbovePreviousMaximum() {
-    let model = CaptureZoomModel()
-    let coordinator = ZoomableCaptureCanvas<Color>.Coordinator(model: model)
-    let scrollView = CaptureScrollView(frame: CGRect(x: 0, y: 0, width: 600, height: 400))
-    scrollView.allowsMagnification = true
-    scrollView.minMagnification = 0.01
-    scrollView.maxMagnification = CaptureZoomGeometry.magnificationRange.upperBound
-
-    let hostingView = NSHostingView(rootView: Color.clear)
-    hostingView.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
-    scrollView.documentView = hostingView
-    coordinator.hostingView = hostingView
-    coordinator.imageSize = CGSize(width: 40, height: 30)
-    coordinator.connect(to: scrollView)
-
-    coordinator.layoutDocument(in: scrollView)
-
-    let expectedFit = CaptureZoomGeometry.fitMagnification(
-      hostingView.frame.size,
-      in: scrollView.contentSize
-    )
-    XCTAssertGreaterThan(expectedFit, CaptureZoomGeometry.magnificationRange.upperBound)
-    XCTAssertEqual(scrollView.minMagnification, expectedFit, accuracy: 0.001)
-    XCTAssertEqual(
-      scrollView.maxMagnification,
-      expectedFit * CaptureZoomGeometry.magnificationRange.upperBound,
-      accuracy: 0.001
-    )
-    XCTAssertEqual(scrollView.magnification, expectedFit, accuracy: 0.001)
-    XCTAssertEqual(model.percentage, 100)
-
-    coordinator.imageSize = CGSize(width: 2400, height: 1600)
-    coordinator.layoutDocument(in: scrollView)
-
-    let expectedRefit = CaptureZoomGeometry.fitMagnification(
-      hostingView.frame.size,
-      in: scrollView.contentSize
-    )
-    XCTAssertLessThan(
-      expectedRefit * CaptureZoomGeometry.magnificationRange.upperBound,
-      expectedFit
-    )
-    XCTAssertEqual(scrollView.minMagnification, expectedRefit, accuracy: 0.001)
-    XCTAssertEqual(
-      scrollView.maxMagnification,
-      expectedRefit * CaptureZoomGeometry.magnificationRange.upperBound,
-      accuracy: 0.001
-    )
-    XCTAssertEqual(scrollView.magnification, expectedRefit, accuracy: 0.001)
+    func pinch(to magnification: CGFloat) {
+      scroll.setMagnification(magnification, centeredAt: CGPoint(x: 800, y: 400))
+      coordinator.magnificationChanged(in: scroll)
+    }
   }
 }


### PR DESCRIPTION
Capture previews now support pinch zoom, two-finger scrolling, and mouse dragging using AppKit's native scroll view. Zoom controls sit in the bottom-right status bar; clicking the percentage or pressing Command-0 fits the image. Manual zoom and the viewed position stay stable when resizing or moving between displays.

The preview and PNG export share a single composite at the original capture resolution, keeping source text covered at every zoom level. Save and Copy always include the whole image. Existing text layout and settings remain unchanged. The live overlay's information icon also opens its model notices in a popover.

Validation: 197 macOS tests pass and the Debug build succeeds. Coverage includes viewport geometry, display-scale changes, pan limits, full-resolution export, and source masking at 10%, 65%, 100%, and 141%. Manual interaction verification is pending.

<details>
<summary>Original PR description</summary>

#Added fitted capture translations and native zoom/pan in capture popup

> Warning: Modified with Codex

## Summary

  - Added two optional Capture settings for complete translation fitting and native zoom/pan in
  region-capture results.
  - Fit complete horizontal and vertical translations inside their detected OCR boxes.
  - Prefer word-boundary wrapping while handling explicit newlines and long unbreakable text
  without clipping or ellipses.
  - Present capture results in a native `NSScrollView` with trackpad pinch zoom, two-finger
  diagonal panning, momentum, and natural scrolling.
  - Added toolbar and keyboard zoom controls using `⌘+`, `⌘−`, and `⌘0`.
  - Preserve the viewport center when resizing the result window.
  - Improve small-font legibility on 1x displays using bounded additional backing detail while
  avoiding redundant oversampling on Retina displays.
  - Continue exporting the complete capture when saving or copying, rather than only the
  visible zoomed viewport.

  ## Compatibility

  - Both new settings default to disabled.
  - Existing configuration files decode safely when the new settings are absent.
  - The existing capture rendering path remains unchanged when the options are disabled.
  - Live overlay behavior is unchanged.

  ## Validation

  - Added 28 unit tests covering:
    - Settings backward compatibility and round trips
    - Horizontal and vertical text fitting
    - Multilingual text and explicit newlines
    - Long unbreakable text
    - Zoom geometry and magnification limits
    - Viewport preservation across resize
    - Small-capture magnification safety
    - Backing-detail memory limits
  - Confirmed trackpad pinch zoom, horizontal/vertical/diagonal two-finger panning, and
  momentum on macOS.
  - Confirmed complete translated text fitting and improved small-font legibility on a 1080p
  display.
  - Confirmed Save and Copy export the complete capture rather than the current viewport.

  ## Test command

  ```sh
  mise exec -- tuist xcodebuild test \
    -scheme SwiftyCrow \
    -workspace SwiftyCrow.xcworkspace \
    -destination 'platform=macOS' \
    -derivedDataPath DerivedData \
    CODE_SIGNING_ALLOWED=NO \
    CODE_SIGNING_REQUIRED=NO

  Result: 28 tests passed with 0 failures.
  ```

</details>
