### PR TITLE
fix(overlay): lay vertical CJK blocks out horizontally for non-CJK targets

### DIFF
--- a/Sources/Capture/CaptureFeature.swift
+++ b/Sources/Capture/CaptureFeature.swift
@@ -338,6 +338,7 @@ struct CaptureFeature {
         overlayLine.box = line.boundingBoxNormalized
         overlayLine.rowCount = line.rowCount
         overlayLine.isVerticalBlock = line.isVerticalBlock
+        overlayLine.verticalLayout = line.isVerticalBlock && target.usesVerticalScript
         overlayLine.verticalCharScale = line.verticalCharScale
         if let cached {
           overlayLine.translated = cached
@@ -351,6 +352,7 @@ struct CaptureFeature {
           translated: cached,
           rowCount: line.rowCount,
           isVerticalBlock: line.isVerticalBlock,
+          verticalLayout: line.isVerticalBlock && target.usesVerticalScript,
           verticalCharScale: line.verticalCharScale
         )
       }

--- a/Sources/Capture/RegionCaptureFeature.swift
+++ b/Sources/Capture/RegionCaptureFeature.swift
@@ -106,6 +106,7 @@ struct RegionCaptureFeature {
             translated: sameLanguage ? line.text : nil,
             rowCount: line.rowCount,
             isVerticalBlock: line.isVerticalBlock,
+            verticalLayout: line.isVerticalBlock && target.usesVerticalScript,
             verticalCharScale: line.verticalCharScale
           )
           newLines.append(overlayLine)

--- a/Sources/Models/Language.swift
+++ b/Sources/Models/Language.swift
@@ -29,6 +29,21 @@ struct Language: Codable, Equatable, Hashable, Identifiable, Sendable {
   }
 }
 
+extension Locale.Language {
+  /// Whether text in this language is conventionally set in vertical columns.
+  /// Vertical CJK column layout only reads correctly when the text itself is
+  /// CJK — a Latin translation stacked one character per row is unreadable.
+  var usesVerticalScript: Bool {
+    switch languageCode?.identifier {
+    case "ja",
+         "zh",
+         "ko",
+         "yue": true
+    default: false
+    }
+  }
+}
+
 extension Language {
   /// Reserved code for the auto-detect source sentinel.
   static let autoCode = "auto"

--- a/Sources/Models/OverlayLine.swift
+++ b/Sources/Models/OverlayLine.swift
@@ -15,9 +15,12 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
   /// Number of source rows `box` spans; >1 for sentences stitched from wrapped
   /// lines, so the renderer wraps the text instead of drawing one giant row.
   var rowCount = 1
-  /// True when `box` covers a block of stitched vertical CJK columns, so the
-  /// renderer lays the translation out vertically (top-to-bottom, right-to-left).
+  /// True when `box` covers a block of stitched vertical CJK columns.
   var isVerticalBlock = false
+  /// Whether the translation itself should be drawn in vertical columns
+  /// (top-to-bottom, right-to-left). Only true when the target language is
+  /// written vertically; otherwise the block is laid out horizontally.
+  var verticalLayout = false
   /// Source character size for a vertical block (a column's width, 0–1
   /// normalized), so the renderer can match the original font scale.
   var verticalCharScale: CGFloat = 0

--- a/Sources/Overlay/TranslationOverlayLayer.swift
+++ b/Sources/Overlay/TranslationOverlayLayer.swift
@@ -3,12 +3,17 @@
 
 import SwiftUI
 
+// MARK: - TranslationOverlayLayer
+
 /// Draws each translated line at its source bounding box, sized to that box's
 /// height. Shared by the live overlay (Liquid Glass chips) and the
 /// region-capture result. The result uses `glass: false` because ImageRenderer
 /// can't rasterize Liquid Glass, so a solid chip keeps the saved/copied image
 /// matching what's on screen.
 struct TranslationOverlayLayer: View {
+
+  // MARK: Internal
+
   let lines: [OverlayLine]
   var glass = true
 
@@ -18,7 +23,8 @@ struct TranslationOverlayLayer: View {
     }
   }
 
-  @ViewBuilder
+  // MARK: Private
+
   private func chips(in size: CGSize) -> some View {
     ForEach(lines) { line in
       let box = line.box
@@ -26,13 +32,19 @@ struct TranslationOverlayLayer: View {
       let height = max(1, box.height * size.height)
 
       Group {
-        if line.isVerticalBlock {
+        if line.isVerticalBlock, line.verticalLayout {
           // The chip hugs the vertical text (so the glass matches it) and is
           // pinned to the box's top-right, where vertical CJK starts reading.
           // A column's width is the source character size, so render near that
           // scale to keep the page's font hierarchy.
-          blockChip(for: line, width: width, height: height, sourceFont: line.verticalCharScale * size.width)
+          verticalBlockChip(for: line, width: width, height: height, sourceFont: line.verticalCharScale * size.width)
             .frame(width: width, height: height, alignment: .topTrailing)
+        } else if line.isVerticalBlock {
+          // Vertical CJK source but a horizontally-written target, so the
+          // translation is wrapped horizontally and centred on the source box
+          // instead of being stacked one character per row.
+          horizontalBlockChip(for: line, width: width, height: height)
+            .frame(width: width, height: height, alignment: .center)
         } else {
           let rows = max(1, line.rowCount)
           let fontSize = max(8, min(96, height / CGFloat(rows) * 0.85))
@@ -47,7 +59,6 @@ struct TranslationOverlayLayer: View {
     }
   }
 
-  @ViewBuilder
   private func lineChip(for line: OverlayLine, fontSize: CGFloat, rows: Int) -> some View {
     background(
       for: line,
@@ -64,12 +75,12 @@ struct TranslationOverlayLayer: View {
     )
   }
 
-  /// A stitched block of vertical CJK columns: lay the translation out the same
-  /// way the source reads — characters top-to-bottom, columns right-to-left —
-  /// so it sits over the original like an in-place replacement. Sized so the
-  /// text roughly fills the box.
+  /// A stitched block of vertical CJK columns rendered into a vertically-written
+  /// target: lay the translation out the same way the source reads — characters
+  /// top-to-bottom, columns right-to-left — so it sits over the original like an
+  /// in-place replacement. Sized so the text roughly fills the box.
   @ViewBuilder
-  private func blockChip(for line: OverlayLine, width: CGFloat, height: CGFloat, sourceFont: CGFloat) -> some View {
+  private func verticalBlockChip(for line: OverlayLine, width: CGFloat, height: CGFloat, sourceFont: CGFloat) -> some View {
     let text = line.translated ?? line.sourceText
     // Largest font that still fits the box, then prefer the source font scale so
     // the hierarchy is kept — capped to the fit so a long translation can't spill.
@@ -82,6 +93,32 @@ struct TranslationOverlayLayer: View {
       // glass background matches the translation instead of the full box.
       label: VerticalText(text: text, fontSize: fontSize, availableHeight: max(1, height - 12))
         .padding(6)
+    )
+  }
+
+  /// A stitched block of vertical CJK columns rendered into a horizontally-written
+  /// target. The column layout can't be reused: a Latin translation forced through
+  /// it lands one character per row, which is unreadable. Wrap it horizontally over
+  /// the source box instead.
+  @ViewBuilder
+  private func horizontalBlockChip(for line: OverlayLine, width: CGFloat, height: CGFloat) -> some View {
+    let text = line.translated ?? line.sourceText
+    // Vertical CJK boxes are tall and narrow. Horizontal text needs more width, so
+    // let the chip widen past the source box (staying centred on it) before the
+    // font has to shrink — capped by the box height so it can't swallow the page.
+    let chipWidth = max(width, min(width * 2.2, height))
+    // Largest font that still fills the chip, capped so a short line can't balloon.
+    let fit = (chipWidth * height / CGFloat(max(text.count, 1))).squareRoot() * 1.3
+    let fontSize = max(8, min(fit, 96))
+    background(
+      for: line,
+      cornerRadius: 12,
+      label: Text(text)
+        .font(.system(size: fontSize, weight: .semibold))
+        .multilineTextAlignment(.center)
+        .minimumScaleFactor(0.35)
+        .padding(6)
+        .frame(width: chipWidth, alignment: .center)
     )
   }
 
@@ -99,7 +136,7 @@ struct TranslationOverlayLayer: View {
   }
 }
 
-// MARK: - Vertical text
+// MARK: - VerticalText
 
 /// Lays out a string as vertical CJK writing: each character upright, stacked
 /// top-to-bottom, columns advancing right-to-left.
@@ -119,6 +156,8 @@ private struct VerticalText: View {
   }
 }
 
+// MARK: - VerticalColumns
+
 /// Places each subview (one character) top-to-bottom; when a column fills
 /// `availableHeight` it wraps to a new column on the left. Reports the size it
 /// actually uses so the surrounding chip hugs the text.
@@ -126,7 +165,7 @@ private struct VerticalColumns: Layout {
   var charExtent: CGFloat
   var availableHeight: CGFloat
 
-  func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+  func sizeThatFits(proposal _: ProposedViewSize, subviews: Subviews, cache _: inout ()) -> CGSize {
     guard !subviews.isEmpty else { return .zero }
     let columnWidth = subviews.map { $0.sizeThatFits(.unspecified).width }.max() ?? charExtent
     let perColumn = max(1, Int(availableHeight / charExtent))
@@ -135,7 +174,7 @@ private struct VerticalColumns: Layout {
     return CGSize(width: CGFloat(columns) * columnWidth, height: CGFloat(rows) * charExtent)
   }
 
-  func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+  func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
     guard !subviews.isEmpty else { return }
     let columnWidth = subviews.map { $0.sizeThatFits(.unspecified).width }.max() ?? charExtent
     let perColumn = max(1, Int(availableHeight / charExtent))


### PR DESCRIPTION
## The bug

Translating a Japanese manga speech bubble (vertical writing) to English renders the translation as a column of single letters instead of a sentence — effectively unreadable.

Source bubble: 「ごめんなさいね ゆきえさん 急に訪ねてしまって」 → the overlay drew a stack reading `I` / `dl` / `y` / `sv` / `ui` / `ds` … rather than "Sorry for dropping by so suddenly, Yukie-san."

## Cause

`OCRClient` correctly flags the paragraph as vertical and stitches the columns into one block with the full text — translation itself is fine. The problem is purely layout: `TranslationOverlayLayer` sends every `isVerticalBlock` line through `VerticalText` / `VerticalColumns`, which places **one character per cell, top-to-bottom, columns right-to-left**.

That's correct when the translation is itself CJK. But it's applied regardless of target language, so a Latin translation gets one character per row.

This is a follow-up to #8, which added the vertical layout — the layout is right, it's just being used for targets it can't serve.

## Fix

Decide the layout from the **target** language rather than only the source:

- `Locale.Language.usesVerticalScript` — true for `ja` / `zh` / `ko` / `yue`.
- `OverlayLine.verticalLayout` — set at the three construction sites as `isVerticalBlock && target.usesVerticalScript`. `isVerticalBlock` keeps its original meaning (the *source* was a stitched vertical block).
- `TranslationOverlayLayer` now branches three ways:
  - vertical source + vertical target → `verticalBlockChip` (unchanged behaviour, still pinned top-right where vertical CJK starts reading)
  - vertical source + horizontal target → new `horizontalBlockChip`: normal wrapped `Text`, centred on the source box, chip allowed to widen past the box (up to 2.2×, capped by box height) because horizontal text needs more width than a narrow CJK column
  - everything else → `lineChip` (unchanged)

So JA→ZH/KO keeps the in-place vertical replacement; JA→EN and friends become readable. No settings surface added — it follows the language pair automatically.

## Testing

Built and run locally against the case above; the bubble now renders as a wrapped horizontal sentence. Formatted with the repo's `.swiftformat`.

One note: I'm on Xcode 26.0, and `main` currently needs the macOS 26.4 SDK for `TranslationSession.Strategy` / `preferredStrategy` in `TranslationClient.swift`. To build I stubbed that call locally — that shim is **not** part of this PR, and this change is orthogonal to it. Worth double-checking my build claim on a 26.4 toolchain.

If you'd rather this were a user-facing toggle than automatic, happy to rework it.