### PR TITLE
fix(overlay): preserve source layout and update web CTA

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -7,10 +7,10 @@ let bundleIdPrefix = "dev.PangMo5"
 
 let developmentTeam = Environment.developmentTeam.getString(default: "")
 let sparklePublicEDKey = Environment.sparklePublicEdKey.getString(default: "")
-// Single source of truth for the marketing version. The release workflow
-// verifies the pushed tag matches this before building.
+/// Single source of truth for the marketing version. The release workflow
+/// verifies the pushed tag matches this before building.
 let appVersion = "2.9.1"
-// Build number is injected by CI (github.run_number); 1 for local builds.
+/// Build number is injected by CI (github.run_number); 1 for local builds.
 let buildNumber = Environment.buildNumber.getString(default: "1")
 
 let baseSettings: SettingsDictionary = [
@@ -102,6 +102,18 @@ let project = Project(
           .release(name: "Release"),
         ]
       )
+    ),
+    .target(
+      name: "SwiftyCrowTests",
+      destinations: .macOS,
+      product: .unitTests,
+      bundleId: "\(bundleIdPrefix).SwiftyCrowTests",
+      deploymentTargets: .macOS("26.0"),
+      infoPlist: .default,
+      sources: ["Tests/**"],
+      dependencies: [
+        .target(name: "SwiftyCrow")
+      ]
     ),
   ]
 )

--- a/Sources/Capture/CaptureFeature.swift
+++ b/Sources/Capture/CaptureFeature.swift
@@ -19,10 +19,10 @@ struct CaptureFeature {
     case translation
   }
 
-  /// One live capture: the screenshot (for the detached Window mode) plus the
+  /// One live capture: the backdrop (for the detached Window mode) plus the
   /// recognized lines and their sampled source appearance.
   struct LiveCapture: Sendable {
-    var imageData: Data?
+    var backdrop: OverlayBackdrop?
     var imageSize: CGSize
     var result: OCRResult
   }
@@ -53,9 +53,9 @@ struct CaptureFeature {
     /// Drives the "open Settings" hint in the menu bar.
     var translationUnavailable = false
     var overlayLines = [OverlayLine]()
-    /// Raw screenshot shown by the detached Window mode. In-place mode only
+    /// Captured pixels shown by the detached Window mode. In-place mode only
     /// needs the sampled appearance carried by each OCR line.
-    var sourceImageData: Data?
+    var backdrop: OverlayBackdrop?
     var imageSize = CGSize.zero
     /// Whether a live overlay is currently placed on screen. There's no overlay
     /// until the user selects a region/window; `dismissOverlay` clears it.
@@ -109,7 +109,7 @@ struct CaptureFeature {
         state.isTranslating = false
         state.translationRequestContext = nil
         state.overlayLines = []
-        state.sourceImageData = nil
+        state.backdrop = nil
         state.isPreparingRecognition = false
         state.lastError = nil
         state.translationUnavailable = false
@@ -213,7 +213,9 @@ struct CaptureFeature {
               // against a cold Vision daemon made the first capture slower and
               // could leave two expensive document requests competing.
               await ocr.warmUp()
+              let cadenceClock = ContinuousClock()
               while !Task.isCancelled {
+                let tickStarted = cadenceClock.now
                 let snapshot = settings.wrappedValue
                 let frame = overlayFrame.wrappedValue
                 // Every stage inside runCapture is deadline-bounded, so a tick
@@ -230,7 +232,15 @@ struct CaptureFeature {
                   Log.capture.error("Live tick failed: \(error.localizedDescription, privacy: .public)")
                 }
                 await send(.captureResponse(result))
-                try await clock.sleep(for: .seconds(snapshot.capture.interval))
+                let elapsed = tickStarted.duration(to: cadenceClock.now)
+                if
+                  let delay = LiveCaptureCadence.remainingDelay(
+                    interval: .seconds(snapshot.capture.interval),
+                    elapsed: elapsed
+                  )
+                {
+                  try await clock.sleep(for: delay)
+                }
               }
             }
             .cancellable(id: CancelID.live, cancelInFlight: true)
@@ -336,7 +346,7 @@ struct CaptureFeature {
       state.overlayLines = []
       state.isTranslating = false
       state.translationRequestContext = nil
-      state.sourceImageData = nil
+      state.backdrop = nil
       return .cancel(id: CancelID.translation)
     }
 
@@ -384,7 +394,7 @@ struct CaptureFeature {
         previous.source = stableSources[index]
         return previous
       }
-      state.sourceImageData = windowMode ? capture.imageData : nil
+      state.backdrop = windowMode ? capture.backdrop : nil
       return .none
     }
 
@@ -436,7 +446,7 @@ struct CaptureFeature {
     }
 
     state.overlayLines = newLines
-    state.sourceImageData = windowMode ? capture.imageData : nil
+    state.backdrop = windowMode ? capture.backdrop : nil
 
     state.isTranslating = !groups.isEmpty
     if groups.isEmpty {
@@ -550,12 +560,25 @@ struct CaptureFeature {
     let result = try await withDeadline(CaptureDeadline.ocr, stage: .ocr, clock: clock) { [ocr] in
       try await ocr.recognizeText(image, settings.languages.source)
     }
-    // Only carry the screenshot when Window mode displays a detached result.
-    let needsImage = settings.overlay.liveMode == .window
+    // Window mode retains the immutable capture directly. Encoding every tick
+    // to PNG and decoding it again in SwiftUI added work and allocation churn
+    // precisely while the live overlay was trying to refresh.
+    let needsBackdrop = settings.overlay.liveMode == .window
     return LiveCapture(
-      imageData: needsImage ? image.pngData : nil,
+      backdrop: needsBackdrop ? OverlayBackdrop(image: image) : nil,
       imageSize: CGSize(width: image.width, height: image.height),
       result: result
     )
+  }
+}
+
+// MARK: - LiveCaptureCadence
+
+enum LiveCaptureCadence {
+  /// Keeps the configured interval start-to-start. Processing time already
+  /// consumes part of the interval and must not be added to it again.
+  static func remainingDelay(interval: Duration, elapsed: Duration) -> Duration? {
+    guard elapsed < interval else { return nil }
+    return interval - elapsed
   }
 }

--- a/Sources/Capture/CaptureFeature.swift
+++ b/Sources/Capture/CaptureFeature.swift
@@ -15,13 +15,12 @@ struct CaptureFeature {
   // MARK: Internal
 
   enum CancelID {
-    case background
     case live
     case translation
   }
 
-  /// One live capture: the screenshot (for the Window-mode blurred backdrop)
-  /// plus the recognized lines.
+  /// One live capture: the screenshot (for the detached Window mode) plus the
+  /// recognized lines and their sampled source appearance.
   struct LiveCapture: Sendable {
     var imageData: Data?
     var imageSize: CGSize
@@ -35,9 +34,13 @@ struct CaptureFeature {
     var text: String
   }
 
+  struct TranslationRequestContext: Equatable, Sendable {
+    var strategy: TranslationStrategy
+    var target: String
+  }
+
   @ObservableState
-  struct State {
-    var excludedWindowIDs = [CGWindowID]()
+  struct State: Equatable {
     var isCapturing = false
     var isLive = false
     var isTranslating = false
@@ -50,12 +53,9 @@ struct CaptureFeature {
     /// Drives the "open Settings" hint in the menu bar.
     var translationUnavailable = false
     var overlayLines = [OverlayLine]()
-    /// Window-mode backdrop: the screenshot with each box blurred. Nil in
-    /// In-place mode (the chips draw directly on the overlay).
-    var backgroundImageData: Data?
-    /// A backdrop blur is in flight. Live ticks skip queueing another while it
-    /// is set, so a blur slower than the capture interval still finishes.
-    var isBlurringBackground = false
+    /// Raw screenshot shown by the detached Window mode. In-place mode only
+    /// needs the sampled appearance carried by each OCR line.
+    var sourceImageData: Data?
     var imageSize = CGSize.zero
     /// Whether a live overlay is currently placed on screen. There's no overlay
     /// until the user selects a region/window; `dismissOverlay` clears it.
@@ -63,14 +63,18 @@ struct CaptureFeature {
     /// Bumped each time the overlay is (re)placed, so the window controller knows
     /// to snap to the new frame even when it's already on screen.
     var overlayPlacementID = 0
-    var translationCache = [TranslationCacheKey: String]()
+    /// Invalidates late responses from a cancelled live tick. Line IDs are
+    /// deliberately reused for visual stability, so identity alone cannot tell
+    /// an old translation from the current request.
+    var translationGeneration = 0
+    var translationCache = [TranslationCacheKey: TranslatedText]()
+    var translationRequestContext: TranslationRequestContext?
 
     @Shared(.overlayFrame) var overlayFrame
     @Shared(.settings) var settings
   }
 
   enum Action {
-    case backgroundReady(Data?)
     case captureIsTakingLong
     case captureResponse(Result<LiveCapture, any Error>)
     case copyTranslationRequested
@@ -78,13 +82,11 @@ struct CaptureFeature {
     case selectRegionRequested
     case liveSelectRequested
     case overlayPlaced(CGRect)
-    case setExcludedWindowIDs([CGWindowID])
     case setLive(Bool)
     case toggleLiveRequested
     case toggleLiveOverlayRequested
-    case translationCompleted
-    case translationFailed(String)
-    case translationResponse(lineID: UUID, key: TranslationCacheKey, translated: String)
+    case translationUnavailable(generation: Int, lineIDs: Set<UUID>, message: String?)
+    case translationResponse(generation: Int, lineID: UUID, key: TranslationCacheKey, translation: TranslatedText)
   }
 
   @Dependency(\.continuousClock) var clock
@@ -100,20 +102,20 @@ struct CaptureFeature {
     Reduce { state, action in
       switch action {
       case .dismissOverlay:
+        state.translationGeneration += 1
         state.overlayActive = false
         state.isLive = false
         state.isCapturing = false
         state.isTranslating = false
+        state.translationRequestContext = nil
         state.overlayLines = []
-        state.backgroundImageData = nil
-        state.isBlurringBackground = false
+        state.sourceImageData = nil
         state.isPreparingRecognition = false
         state.lastError = nil
         state.translationUnavailable = false
         return .merge(
           .cancel(id: CancelID.live),
-          .cancel(id: CancelID.translation),
-          .cancel(id: CancelID.background)
+          .cancel(id: CancelID.translation)
         )
 
       case .selectRegionRequested:
@@ -159,11 +161,6 @@ struct CaptureFeature {
         }
         return .none
 
-      case .backgroundReady(let data):
-        state.isBlurringBackground = false
-        state.backgroundImageData = data
-        return .none
-
       case .captureResponse(.success(let capture)):
         state.isCapturing = false
         state.isPreparingRecognition = false
@@ -173,17 +170,14 @@ struct CaptureFeature {
 
       case .copyTranslationRequested:
         let text = state.overlayLines
-          .compactMap { $0.translated ?? ($0.sourceText.isEmpty ? nil : $0.sourceText) }
+          .map(\.displayedText)
+          .filter { !$0.isEmpty }
           .joined(separator: "\n")
         guard !text.isEmpty else { return .none }
         return .run { _ in
           NSPasteboard.general.clearContents()
           NSPasteboard.general.setString(text, forType: .string)
         }
-
-      case .setExcludedWindowIDs(let ids):
-        state.excludedWindowIDs = ids
-        return .none
 
       case .setLive(let isLive):
         if isLive, !state.overlayActive {
@@ -196,13 +190,14 @@ struct CaptureFeature {
         // Toggling Live discards stale results so the overlay doesn't keep
         // showing the previous capture across the transition.
         state.overlayLines = []
+        state.translationGeneration += 1
         state.isTranslating = false
+        state.translationRequestContext = nil
         state.isPreparingRecognition = false
         state.translationUnavailable = false
         if isLive {
           return .merge(
             .cancel(id: CancelID.translation),
-            warmUpVision(),
             .run { [clock] send in
               // If the first capture hasn't landed by now, say why instead of
               // leaving an empty frame with a spinner on it.
@@ -210,10 +205,14 @@ struct CaptureFeature {
               await send(.captureIsTakingLong)
             },
             .run { [
+              ocr,
               settings = state.$settings,
-              overlayFrame = state.$overlayFrame,
-              excludedWindowIDs = state.excludedWindowIDs
+              overlayFrame = state.$overlayFrame
             ] send in
+              // Serialize the probe and first real recognition. Starting both
+              // against a cold Vision daemon made the first capture slower and
+              // could leave two expensive document requests competing.
+              await ocr.warmUp()
               while !Task.isCancelled {
                 let snapshot = settings.wrappedValue
                 let frame = overlayFrame.wrappedValue
@@ -224,8 +223,7 @@ struct CaptureFeature {
                 let result = await Result {
                   try await runCapture(
                     settings: snapshot,
-                    overlayFrame: frame,
-                    excludedWindowIDs: excludedWindowIDs
+                    overlayFrame: frame
                   )
                 }
                 if case .failure(let error) = result {
@@ -249,7 +247,7 @@ struct CaptureFeature {
         // Flip the live overlay on/off on the last-used region without
         // re-selecting. When it's up, tear it down via dismissOverlay — that
         // cancels the live-capture loop, the translation task group, and the
-        // background blur, so no capture/OCR/translation keeps running while
+        // source restoration, so no capture/OCR/translation keeps running while
         // it's off. Otherwise re-place it on the remembered frame (persisted in
         // overlay-frame.json) and go live.
         if state.overlayActive {
@@ -257,21 +255,58 @@ struct CaptureFeature {
         }
         return .send(.overlayPlaced(state.overlayFrame.rect))
 
-      case .translationCompleted:
-        state.isTranslating = false
+      case .translationUnavailable(let generation, let lineIDs, let message):
+        guard generation == state.translationGeneration else { return .none }
+        for index in state.overlayLines.indices where lineIDs.contains(state.overlayLines[index].id) {
+          state.overlayLines[index].showUnavailable()
+        }
+        state.isTranslating = state.overlayLines.contains(where: \.isPending)
+        if !state.isTranslating {
+          state.translationRequestContext = nil
+        }
+        state.lastError = message ?? "Translation did not return every requested line."
+        if message != nil {
+          state.translationUnavailable = true
+        }
         return .none
 
-      case .translationFailed(let message):
-        state.lastError = message
-        state.translationUnavailable = true
-        return .none
-
-      case .translationResponse(let lineID, let key, let translated):
-        state.translationCache[key] = translated
-        // A real translation arrived — the model is installed after all.
-        state.translationUnavailable = false
-        if let index = state.overlayLines.firstIndex(where: { $0.id == lineID }) {
-          state.overlayLines[index].translated = translated
+      case .translationResponse(let generation, let lineID, let key, let translation):
+        guard generation == state.translationGeneration else { return .none }
+        let text = translation.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+          if let index = state.overlayLines.firstIndex(where: { $0.id == lineID }) {
+            state.overlayLines[index].showUnavailable()
+          }
+          state.isTranslating = state.overlayLines.contains(where: \.isPending)
+          if !state.isTranslating {
+            state.translationRequestContext = nil
+          }
+          state.lastError = "Translation returned empty text."
+          return .none
+        }
+        let translation = TranslatedText(
+          text: text,
+          attributedText: text == translation.text ? translation.attributedText : nil
+        )
+        state.translationCache[key] = translation
+        if
+          let index = state.overlayLines.firstIndex(where: { $0.id == lineID }),
+          state.overlayLines[index].isPending
+        {
+          state.overlayLines[index].showTranslation(
+            translation.text,
+            attributedText: translation.attributedText,
+            language: Locale.Language(identifier: key.target)
+          )
+        }
+        state.isTranslating = state.overlayLines.contains(where: \.isPending)
+        if !state.isTranslating {
+          state.translationRequestContext = nil
+        }
+        if !state.isTranslating, !state.overlayLines.contains(where: \.isUnavailable) {
+          // Every requested line resolved, so a previous missing-model warning
+          // is stale even if this live session started with a failed tick.
+          state.translationUnavailable = false
         }
         return .none
       }
@@ -279,6 +314,10 @@ struct CaptureFeature {
   }
 
   // MARK: Private
+
+  private static func normalizedCenterDistance(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+    hypot(lhs.midX - rhs.midX, lhs.midY - rhs.midY)
+  }
 
   /// Starts loading Vision's document model alongside whatever the user is about
   /// to do. Picking a region takes a second or two, and a cold model costs far
@@ -293,11 +332,12 @@ struct CaptureFeature {
     let windowMode = state.settings.overlay.liveMode == .window
 
     guard !result.lines.isEmpty else {
+      state.translationGeneration += 1
       state.overlayLines = []
       state.isTranslating = false
-      state.backgroundImageData = nil
-      state.isBlurringBackground = false
-      return .merge(.cancel(id: CancelID.translation), .cancel(id: CancelID.background))
+      state.translationRequestContext = nil
+      state.sourceImageData = nil
+      return .cancel(id: CancelID.translation)
     }
 
     let configured = state.settings.languages.source
@@ -309,13 +349,48 @@ struct CaptureFeature {
     // lines); an explicit source applies to every line. A line already in the
     // target language shows its source text instead of being translated.
     let lineSources = languageDetection.resolveSources(for: result.lines.map(\.text), configured: configured)
+    let previousMatches = matchedPreviousLines(
+      for: result.lines,
+      languages: lineSources,
+      in: state.overlayLines
+    )
+    let stableSources = result.lines.indices.map { index in
+      let source = OverlayLine.Source(
+        recognized: result.lines[index],
+        language: lineSources[index].localeLanguage
+      )
+      guard let previous = previousMatches[index] else { return source }
+      return source.stabilized(relativeTo: previous.source, imageSize: capture.imageSize)
+    }
+    let preservesSource = stableSources.indices.map {
+      OverlayTranslationPolicy.preservesSource(at: $0, in: stableSources)
+    }
+    let sourceSetIsUnchanged = result.lines.count == state.overlayLines.count
+      && previousMatches.allSatisfy { $0 != nil }
+    if
+      state.isTranslating,
+      sourceSetIsUnchanged,
+      state.translationRequestContext == TranslationRequestContext(
+        strategy: strategy,
+        target: targetLanguage.code
+      )
+    {
+      // Keep the in-flight batch alive. Replacing it every live tick meant a
+      // batch slower than the capture interval could be cancelled and restarted
+      // forever. Geometry/style may still change, so refresh only the source
+      // side while preserving each line's pending/translated content and id.
+      state.overlayLines = result.lines.indices.compactMap { index in
+        guard var previous = previousMatches[index] else { return nil }
+        previous.source = stableSources[index]
+        return previous
+      }
+      state.sourceImageData = windowMode ? capture.imageData : nil
+      return .none
+    }
 
-    // Reuse line identity when the source text matches the previous OCR
-    // pass, so SwiftUI's transitions stay stable across live captures.
-    let previousByText = Dictionary(grouping: state.overlayLines, by: \.sourceText)
-      .mapValues { Array($0.reversed()) }
+    state.translationGeneration += 1
+    let generation = state.translationGeneration
 
-    var reused = previousByText
     var newLines = [OverlayLine]()
     var keys = [UUID: TranslationCacheKey]()
     // Pending translations grouped by source language (one session per group).
@@ -323,115 +398,138 @@ struct CaptureFeature {
 
     for (index, line) in result.lines.enumerated() {
       let source = lineSources[index].localeLanguage
-      let sameLanguage = source.languageCode == target.languageCode
+      let sameLanguage = source.usesSameWritingSystem(as: target)
       let key = TranslationCacheKey(
         source: source.maximalIdentifier,
         strategy: strategy,
         target: targetLanguage.code,
         text: line.text
       )
-      let cached = sameLanguage ? line.text : cache[key]
+      let needsTranslation = !sameLanguage && !preservesSource[index]
+      let cached = needsTranslation ? cache[key] : nil
 
-      var overlayLine: OverlayLine
-      if var bucket = reused[line.text], let recycled = bucket.popLast() {
-        overlayLine = recycled
-        overlayLine.box = line.boundingBoxNormalized
-        overlayLine.rowCount = line.rowCount
-        overlayLine.isVerticalBlock = line.isVerticalBlock
-        overlayLine.verticalLayout = line.isVerticalBlock && target.usesVerticalScript
-        overlayLine.verticalCharScale = line.verticalCharScale
-        if let cached {
-          overlayLine.translated = cached
-        }
-        reused[line.text] = bucket
-      } else {
-        overlayLine = OverlayLine(
-          id: uuid(),
-          box: line.boundingBoxNormalized,
-          sourceText: line.text,
-          translated: cached,
-          rowCount: line.rowCount,
-          isVerticalBlock: line.isVerticalBlock,
-          verticalLayout: line.isVerticalBlock && target.usesVerticalScript,
-          verticalCharScale: line.verticalCharScale
+      var overlayLine = OverlayLine(
+        id: previousMatches[index]?.id ?? uuid(),
+        source: stableSources[index],
+        initialContent: needsTranslation ? .pending : .source
+      )
+      if let cached {
+        overlayLine.showTranslation(
+          cached.text,
+          attributedText: cached.attributedText,
+          language: target
         )
       }
 
       newLines.append(overlayLine)
-      if overlayLine.translated == nil {
+      if overlayLine.isPending {
         keys[overlayLine.id] = key
         groups[source.maximalIdentifier, default: (source, [])].items
-          .append(TranslationLine(id: overlayLine.id, text: overlayLine.sourceText))
+          .append(TranslationLine(
+            id: overlayLine.id,
+            text: overlayLine.source.text,
+            attributedText: overlayLine.source.attributedTextForTranslation()
+          ))
       }
     }
 
     state.overlayLines = newLines
-
-    // Window mode draws a blurred screenshot backdrop in the detached window;
-    // In-place mode draws chips directly on the overlay, so no backdrop.
-    let background: Effect<Action>
-    if windowMode, let data = capture.imageData {
-      if state.isBlurringBackground {
-        // Leave the running blur alone. Restarting it on every tick (what
-        // cancelInFlight did) meant a blur slower than the capture interval
-        // never finished at all — and the detached window shows a spinner until
-        // the first backdrop lands, so it spun forever. Skipping instead makes
-        // the backdrop trail the capture by at most one blur.
-        background = .none
-      } else {
-        state.isBlurringBackground = true
-        let lines = newLines
-        let size = capture.imageSize
-        background = .run { send in
-          // Pure Core Graphics / Core Image — runs off the main actor.
-          let bg = blurredBackground(baseData: data, lines: lines, pixelSize: size)
-          await send(.backgroundReady(bg))
-        }
-        .cancellable(id: CancelID.background)
-      }
-    } else {
-      state.backgroundImageData = nil
-      state.isBlurringBackground = false
-      background = .cancel(id: CancelID.background)
-    }
+    state.sourceImageData = windowMode ? capture.imageData : nil
 
     state.isTranslating = !groups.isEmpty
     if groups.isEmpty {
-      return .merge(background, .cancel(id: CancelID.translation))
+      state.translationRequestContext = nil
+      state.translationUnavailable = false
+      return .cancel(id: CancelID.translation)
     }
 
     let batches = Array(groups.values)
-    let translate = Effect<Action>.run { send in
-      // One session per source language; chips update as results stream back.
-      // translationCompleted clears the spinner once every batch finishes.
+    let translationKeys = keys
+    state.translationRequestContext = TranslationRequestContext(
+      strategy: strategy,
+      target: targetLanguage.code
+    )
+    return Effect<Action>.run { send in
+      // One session per source language; each response or explicit fallback
+      // resolves a replacement and the last pending line clears the spinner.
       await withTaskGroup(of: Void.self) { group in
         for batch in batches {
           group.addTask {
+            var remaining = Set(batch.items.map(\.id))
             do {
               for try await result in translation.translateBatch(batch.items, batch.source, target, strategy) {
-                if let key = keys[result.id] {
-                  await send(.translationResponse(lineID: result.id, key: key, translated: result.text))
+                remaining.remove(result.id)
+                if let key = translationKeys[result.id] {
+                  await send(
+                    .translationResponse(
+                      generation: generation,
+                      lineID: result.id,
+                      key: key,
+                      translation: TranslatedText(
+                        text: result.text,
+                        attributedText: result.attributedText
+                      )
+                    )
+                  )
                 }
               }
+            } catch is CancellationError {
+              return
             } catch {
-              await send(.translationFailed(error.localizedDescription))
+              guard !remaining.isEmpty else { return }
+              await send(
+                .translationUnavailable(
+                  generation: generation,
+                  lineIDs: remaining,
+                  message: error.localizedDescription
+                )
+              )
+              return
+            }
+            if !remaining.isEmpty {
+              await send(.translationUnavailable(generation: generation, lineIDs: remaining, message: nil))
             }
           }
         }
       }
-      await send(.translationCompleted)
     }
     .cancellable(id: CancelID.translation, cancelInFlight: true)
-    return .merge(background, translate)
+  }
+
+  /// Matches duplicate source strings by geometry rather than array position.
+  /// Vision is free to change observation order between frames; positional
+  /// matching swapped identities on repeated labels and made SwiftUI replace
+  /// otherwise stable text views.
+  private func matchedPreviousLines(
+    for lines: [OCRResult.Line],
+    languages: [Language],
+    in previousLines: [OverlayLine]
+  ) -> [OverlayLine?] {
+    var remaining = Array(previousLines.indices)
+    return lines.indices.map { index in
+      let language = languages[index].localeLanguage.maximalIdentifier
+      let candidates = remaining.filter { previousIndex in
+        let previous = previousLines[previousIndex]
+        return previous.source.text == lines[index].text
+          && previous.source.language.maximalIdentifier == language
+      }
+      guard
+        let match = candidates.min(by: { lhs, rhs in
+          Self.normalizedCenterDistance(lines[index].boundingBoxNormalized, previousLines[lhs].source.box)
+            < Self.normalizedCenterDistance(lines[index].boundingBoxNormalized, previousLines[rhs].source.box)
+        })
+      else { return nil }
+      remaining.removeAll { $0 == match }
+      return previousLines[match]
+    }
   }
 
   private func runCapture(
     settings: AppSettings,
-    overlayFrame: OverlayFrame,
-    excludedWindowIDs: [CGWindowID]
+    overlayFrame: OverlayFrame
   ) async throws -> LiveCapture {
-    // The live overlay is always placed over a region while running, so capture
-    // that region (excluding our own windows via the bundle id below).
+    // The live overlay is always placed over a region while running. Exclude
+    // this process so the transparent overlay never becomes the next OCR input.
     //
     // Both stages are bounded separately so the log names whichever one stalled:
     // ScreenCaptureKit and Vision each talk to a daemon that is cold on the first
@@ -443,15 +541,14 @@ struct CaptureFeature {
     ) { [screenCapture] in
       try await screenCapture.captureImage(
         overlayFrame.rect,
-        excludedWindowIDs,
         displayID(coveringMostOf: overlayFrame.rect),
-        Bundle.main.bundleIdentifier
+        ProcessInfo.processInfo.processIdentifier
       )
     }
     let result = try await withDeadline(CaptureDeadline.ocr, stage: .ocr, clock: clock) { [ocr] in
       try await ocr.recognizeText(image, settings.languages.source)
     }
-    // Only carry the screenshot when Window mode needs it for the backdrop.
+    // Only carry the screenshot when Window mode displays a detached result.
     let needsImage = settings.overlay.liveMode == .window
     return LiveCapture(
       imageData: needsImage ? image.pngData : nil,

--- a/Sources/Capture/CaptureFeature.swift
+++ b/Sources/Capture/CaptureFeature.swift
@@ -399,17 +399,23 @@ struct CaptureFeature {
     for (index, line) in result.lines.enumerated() {
       let source = lineSources[index].localeLanguage
       let sameLanguage = source.usesSameWritingSystem(as: target)
+      let translationLine = TranslationLine(
+        id: previousMatches[index]?.id ?? uuid(),
+        text: line.text,
+        attributedText: stableSources[index].attributedTextForTranslation(),
+        trailingContext: OverlayTranslationPolicy.trailingContext(at: index, in: stableSources)
+      )
       let key = TranslationCacheKey(
         source: source.maximalIdentifier,
         strategy: strategy,
         target: targetLanguage.code,
-        text: line.text
+        text: translationLine.requestText
       )
       let needsTranslation = !sameLanguage && !preservesSource[index]
       let cached = needsTranslation ? cache[key] : nil
 
       var overlayLine = OverlayLine(
-        id: previousMatches[index]?.id ?? uuid(),
+        id: translationLine.id,
         source: stableSources[index],
         initialContent: needsTranslation ? .pending : .source
       )
@@ -425,11 +431,7 @@ struct CaptureFeature {
       if overlayLine.isPending {
         keys[overlayLine.id] = key
         groups[source.maximalIdentifier, default: (source, [])].items
-          .append(TranslationLine(
-            id: overlayLine.id,
-            text: overlayLine.source.text,
-            attributedText: overlayLine.source.attributedTextForTranslation()
-          ))
+          .append(translationLine)
       }
     }
 

--- a/Sources/Capture/RegionCaptureFeature.swift
+++ b/Sources/Capture/RegionCaptureFeature.swift
@@ -4,10 +4,8 @@
 import AppKit
 import ComposableArchitecture
 import CoreGraphics
-import CoreImage
 import DependenciesMacros
 import Foundation
-import ImageIO
 import Sharing
 import SwiftUI
 
@@ -24,9 +22,6 @@ struct RegionCaptureFeature {
     var imageData: Data?
     var imageSize = CGSize.zero
     var overlayLines = [OverlayLine]()
-    /// Screenshot with each recognized box blurred (no text) — the backdrop the
-    /// glass translation chips are drawn over, so the original text is hidden.
-    var backgroundImageData: Data?
     var isTranslating = false
     /// The capture is taking long enough that it needs explaining — practically
     /// always Vision loading a cold document model, which takes tens of seconds.
@@ -48,9 +43,8 @@ struct RegionCaptureFeature {
     case task
     case captureIsTakingLong
     case captured(Result<CapturedRegion, any Error>)
-    case translated(id: UUID, text: String)
-    case translationUnavailable
-    case backgroundReady(Data?)
+    case translationResponse(id: UUID, translation: TranslatedText, target: Locale.Language)
+    case translationUnavailable(lineIDs: Set<UUID>, message: String?)
     case copyOriginalRequested
     case copyTranslationRequested
   }
@@ -92,101 +86,130 @@ struct RegionCaptureFeature {
         // Auto resolves a source per line (with a whole-capture fallback for
         // short lines). Lines already in the target language show their source.
         let lineSources = languageDetection.resolveSources(for: captured.lines.map(\.text), configured: configured)
+        let sourceLines = captured.lines.indices.map {
+          OverlayLine.Source(
+            recognized: captured.lines[$0],
+            language: lineSources[$0].localeLanguage
+          )
+        }
+        let preservesSource = sourceLines.indices.map {
+          OverlayTranslationPolicy.preservesSource(at: $0, in: sourceLines)
+        }
 
         var newLines = [OverlayLine]()
         // Lines to translate, grouped by source language (one session per group).
         var groups = [String: (source: Locale.Language, items: [TranslationLine])]()
         for (index, line) in captured.lines.enumerated() {
           let source = lineSources[index].localeLanguage
-          let sameLanguage = source.languageCode == target.languageCode
+          let sameLanguage = source.usesSameWritingSystem(as: target)
+          let sourceLine = sourceLines[index]
+          let needsTranslation = !sameLanguage && !preservesSource[index]
           let overlayLine = OverlayLine(
             id: uuid(),
-            box: line.boundingBoxNormalized,
-            sourceText: line.text,
-            translated: sameLanguage ? line.text : nil,
-            rowCount: line.rowCount,
-            isVerticalBlock: line.isVerticalBlock,
-            verticalLayout: line.isVerticalBlock && target.usesVerticalScript,
-            verticalCharScale: line.verticalCharScale
+            source: sourceLine,
+            initialContent: needsTranslation ? .pending : .source
           )
           newLines.append(overlayLine)
-          if !sameLanguage {
+          if needsTranslation {
             groups[source.maximalIdentifier, default: (source, [])].items
-              .append(TranslationLine(id: overlayLine.id, text: line.text))
+              .append(TranslationLine(
+                id: overlayLine.id,
+                text: line.text,
+                attributedText: overlayLine.source.attributedTextForTranslation()
+              ))
           }
         }
         state.overlayLines = newLines
 
-        guard !state.overlayLines.isEmpty, let data = captured.pngData else { return .none }
-        let lines = state.overlayLines
-        let size = state.imageSize
-        // Build the blurred backdrop (boxes blurred, no text) once up front; the
-        // glass chips are drawn over it live as translations arrive.
-        let background = Effect<Action>.run { send in
-          // Pure Core Graphics / Core Image — runs off the main actor.
-          let bg = blurredBackground(baseData: data, lines: lines, pixelSize: size)
-          await send(.backgroundReady(bg))
-        }
-        // Every line already in the target language — just build the backdrop.
-        guard !groups.isEmpty else { return background }
+        guard !state.overlayLines.isEmpty, !groups.isEmpty else { return .none }
         state.isTranslating = true
         let batches = Array(groups.values)
-        let translate = Effect<Action>.run { send in
+        return Effect<Action>.run { send in
           await withTaskGroup(of: Void.self) { group in
             for batch in batches {
               group.addTask {
-                // Any line the batch doesn't return (or an error) falls back to
-                // its source text, so every chip resolves and the spinner clears.
                 var remaining = Set(batch.items.map(\.id))
                 do {
                   for try await result in translation.translateBatch(batch.items, batch.source, target, strategy) {
                     remaining.remove(result.id)
-                    await send(.translated(id: result.id, text: result.text))
+                    await send(.translationResponse(
+                      id: result.id,
+                      translation: TranslatedText(
+                        text: result.text,
+                        attributedText: result.attributedText
+                      ),
+                      target: target
+                    ))
                   }
                 } catch is CancellationError {
                   // Window closed mid-flight — nothing to report.
+                  return
                 } catch {
                   // The model for this language likely isn't installed; show the
                   // hint pointing the user to System Settings to download it.
-                  await send(.translationUnavailable)
+                  guard !remaining.isEmpty else { return }
+                  await send(.translationUnavailable(lineIDs: remaining, message: error.localizedDescription))
+                  return
                 }
-                for item in batch.items where remaining.contains(item.id) {
-                  await send(.translated(id: item.id, text: item.text))
+                if !remaining.isEmpty {
+                  await send(.translationUnavailable(lineIDs: remaining, message: nil))
                 }
               }
             }
           }
         }
-        return .merge(background, translate)
 
       case .captured(.failure(let error)):
         state.isTakingLong = false
         state.lastError = error.localizedDescription
         return .none
 
-      case .backgroundReady(let data):
-        state.backgroundImageData = data
-        return .none
-
-      case .translated(let id, let text):
-        if let index = state.overlayLines.firstIndex(where: { $0.id == id }) {
-          state.overlayLines[index].translated = text
+      case .translationResponse(let id, let translation, let target):
+        let text = translation.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+          if let index = state.overlayLines.firstIndex(where: { $0.id == id }) {
+            state.overlayLines[index].showUnavailable()
+          }
+          state.isTranslating = state.overlayLines.contains(where: \.isPending)
+          state.lastError = "Translation returned empty text."
+          return .none
         }
-        state.isTranslating = state.overlayLines.contains { $0.translated == nil }
+        if
+          let index = state.overlayLines.firstIndex(where: { $0.id == id }),
+          state.overlayLines[index].isPending
+        {
+          state.overlayLines[index].showTranslation(
+            text,
+            attributedText: text == translation.text ? translation.attributedText : nil,
+            language: target
+          )
+        }
+        state.isTranslating = state.overlayLines.contains(where: \.isPending)
         return .none
 
-      case .translationUnavailable:
-        state.translationUnavailable = true
+      case .translationUnavailable(let lineIDs, let message):
+        for index in state.overlayLines.indices where lineIDs.contains(state.overlayLines[index].id) {
+          state.overlayLines[index].showUnavailable()
+        }
+        state.isTranslating = state.overlayLines.contains(where: \.isPending)
+        state.lastError = message ?? "Translation did not return every requested line."
+        if message != nil {
+          state.translationUnavailable = true
+        }
         return .none
 
       case .copyOriginalRequested:
-        let text = state.overlayLines.map(\.sourceText).joined(separator: "\n")
+        let text = state.overlayLines.map(\.source.text).joined(separator: "\n")
         guard !text.isEmpty else { return .none }
         state.finished = true
         return .run { _ in await pasteboard.copyString(text) }
 
       case .copyTranslationRequested:
-        let text = state.overlayLines.compactMap(\.translated).joined(separator: "\n")
+        guard !state.overlayLines.contains(where: \.isPending) else { return .none }
+        let text = state.overlayLines
+          .map(\.displayedText)
+          .filter { !$0.isEmpty }
+          .joined(separator: "\n")
         guard !text.isEmpty else { return .none }
         state.finished = true
         return .run { _ in await pasteboard.copyString(text) }
@@ -213,9 +236,8 @@ struct RegionCaptureFeature {
             case .region(let region):
               try await screenCapture.captureImage(
                 region,
-                [],
                 displayID(coveringMostOf: region),
-                Bundle.main.bundleIdentifier
+                ProcessInfo.processInfo.processIdentifier
               )
 
             case .window(let id, _):
@@ -257,77 +279,6 @@ extension CGImage {
   }
 }
 
-// MARK: - Blurred backdrop
-
-/// The screenshot with each recognized box gaussian blurred (rounded), so the
-/// original text behind the translation chips is obscured. The glass chips are
-/// drawn over this on screen.
-///
-/// Built entirely with thread-safe Core Graphics / Core Image (no AppKit
-/// `lockFocus`), so it runs off the main actor and doesn't stall the UI while
-/// the gaussian blur and per-box compositing happen.
-func blurredBackground(baseData: Data, lines: [OverlayLine], pixelSize: CGSize) -> Data? {
-  guard
-    pixelSize.width > 0, pixelSize.height > 0,
-    let source = CGImageSourceCreateWithData(baseData as CFData, nil),
-    let baseCG = CGImageSourceCreateImageAtIndex(source, 0, nil)
-  else { return nil }
-
-  let width = baseCG.width
-  let height = baseCG.height
-  let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
-  guard
-    let context = CGContext(
-      data: nil,
-      width: width,
-      height: height,
-      bitsPerComponent: 8,
-      bytesPerRow: 0,
-      space: colorSpace,
-      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-    )
-  else { return nil }
-
-  let w = CGFloat(width)
-  let h = CGFloat(height)
-  context.draw(baseCG, in: CGRect(x: 0, y: 0, width: w, height: h))
-
-  // Blur the whole image once, then crop each box region out of it.
-  let ciContext = CIContext()
-  let ciBase = CIImage(cgImage: baseCG)
-  let blurred = ciBase
-    .clampedToExtent()
-    .applyingGaussianBlur(sigma: max(6, h * 0.012))
-    .cropped(to: ciBase.extent)
-  let blurredCG = ciContext.createCGImage(blurred, from: ciBase.extent)
-
-  for line in lines where !(line.translated ?? line.sourceText).isEmpty {
-    // box is top-left normalized; convert to the context's bottom-left space.
-    let rect = CGRect(
-      x: line.box.minX * w,
-      y: (1 - line.box.maxY) * h,
-      width: line.box.width * w,
-      height: line.box.height * h
-    )
-    // CGImage cropping is top-left, matching the normalized box directly.
-    let cropRect = CGRect(
-      x: line.box.minX * w,
-      y: line.box.minY * h,
-      width: line.box.width * w,
-      height: line.box.height * h
-    )
-    guard let blurredCG, let cropped = blurredCG.cropping(to: cropRect) else { continue }
-    let corner = min(6, rect.height * 0.2)
-    context.saveGState()
-    context.addPath(CGPath(roundedRect: rect, cornerWidth: corner, cornerHeight: corner, transform: nil))
-    context.clip()
-    context.draw(cropped, in: rect)
-    context.restoreGState()
-  }
-
-  return context.makeImage()?.pngData
-}
-
 // MARK: - RegionResultClient
 
 @DependencyClient
@@ -344,8 +295,7 @@ extension RegionResultClient: DependencyKey {
   static let liveValue: RegionResultClient = {
     // The controller touches AppKit, so build it lazily on the main actor.
     nonisolated(unsafe) var controller: RegionResultWindowController?
-    @MainActor
-    func resolve() -> RegionResultWindowController {
+    let resolve: @MainActor @Sendable () -> RegionResultWindowController = {
       if let controller { return controller }
       let new = RegionResultWindowController()
       controller = new
@@ -473,7 +423,11 @@ private final class RegionResultWindowController {
     let f = imageContentFrame
     let windowRect = CGRect(x: f.minX, y: contentView.bounds.height - f.maxY, width: f.width, height: f.height)
     let screenRect = panel.convertToScreen(windowRect)
-    let image = try? await screenCapture.captureImage(screenRect, [], displayID(coveringMostOf: screenRect), nil)
+    let image = try? await screenCapture.captureImage(
+      screenRect,
+      displayID(coveringMostOf: screenRect),
+      nil
+    )
     let data = image?.pngData
 
     if didResize {

--- a/Sources/Capture/RegionCaptureFeature.swift
+++ b/Sources/Capture/RegionCaptureFeature.swift
@@ -115,7 +115,11 @@ struct RegionCaptureFeature {
               .append(TranslationLine(
                 id: overlayLine.id,
                 text: line.text,
-                attributedText: overlayLine.source.attributedTextForTranslation()
+                attributedText: overlayLine.source.attributedTextForTranslation(),
+                trailingContext: OverlayTranslationPolicy.trailingContext(
+                  at: index,
+                  in: sourceLines
+                )
               ))
           }
         }

--- a/Sources/Capture/RegionResultView.swift
+++ b/Sources/Capture/RegionResultView.swift
@@ -23,6 +23,13 @@ struct RegionResultView: View {
       Divider().opacity(0.4)
       if store.translationUnavailable {
         TranslationModelHint()
+      } else if let error = store.lastError, store.imageData != nil {
+        Label(error, systemImage: "exclamationmark.triangle.fill")
+          .font(.caption)
+          .foregroundStyle(.red)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.horizontal, 14)
+          .padding(.vertical, 8)
       }
       content
     }
@@ -42,18 +49,16 @@ struct RegionResultView: View {
   @State private var hoveredHelp: String?
   @State private var keyMonitor: Any?
 
-  /// Blurred screenshot (original text hidden) when ready, else the raw capture
-  /// while the backdrop is being built; glass translation chips on top — the
-  /// same TranslationOverlayLayer the live overlay uses.
+  /// The original screenshot with source-replacement surfaces and translated
+  /// glyphs composited by the same overlay layer used in live mode.
   @ViewBuilder
   private var translatedImage: some View {
-    let backdrop = store.backgroundImageData.flatMap(NSImage.init(data:))
-      ?? store.imageData.flatMap(NSImage.init(data:))
+    let backdrop = store.imageData.flatMap(NSImage.init(data:))
     if let backdrop {
       ZStack {
         Image(nsImage: backdrop)
           .resizable()
-        TranslationOverlayLayer(lines: store.overlayLines, glass: true)
+        TranslationOverlayLayer(lines: store.overlayLines)
       }
       .aspectRatio(aspectRatio, contentMode: .fit)
       .background(
@@ -89,6 +94,7 @@ struct RegionResultView: View {
       toolbarButton("character.bubble", help: helpText("Copy translation", shortcuts.regionCopyTranslation)) {
         store.send(.copyTranslationRequested)
       }
+      .disabled(store.isTranslating || store.overlayLines.isEmpty)
       toolbarButton("xmark", help: "Close (Esc)", action: onClose)
     }
     .padding(.horizontal, 14)
@@ -159,25 +165,34 @@ struct RegionResultView: View {
   private func installMonitor() {
     guard keyMonitor == nil else { return }
     keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-      MainActor.assumeIsolated {
-        if event.keyCode == 53 { // Escape
+      let keyCode = Int(event.keyCode)
+      var carbonModifiers = 0
+      let flags = event.modifierFlags
+      if flags.contains(.command) { carbonModifiers |= 256 }
+      if flags.contains(.shift) { carbonModifiers |= 512 }
+      if flags.contains(.option) { carbonModifiers |= 2048 }
+      if flags.contains(.control) { carbonModifiers |= 4096 }
+      let consumed = MainActor.assumeIsolated {
+        if keyCode == 53 { // Escape
           onClose()
-          return nil
+          return true
         }
-        if matches(event, shortcuts.regionSave) { onSaveImage()
-          return nil
+        if matches(keyCode, carbonModifiers, shortcuts.regionSave) { onSaveImage()
+          return true
         }
-        if matches(event, shortcuts.regionCopyImage) { onCopyImage()
-          return nil
+        if matches(keyCode, carbonModifiers, shortcuts.regionCopyImage) { onCopyImage()
+          return true
         }
-        if matches(event, shortcuts.regionCopyOriginal) { store.send(.copyOriginalRequested)
-          return nil
+        if matches(keyCode, carbonModifiers, shortcuts.regionCopyOriginal) { store.send(.copyOriginalRequested)
+          return true
         }
-        if matches(event, shortcuts.regionCopyTranslation) { store.send(.copyTranslationRequested)
-          return nil
+        if matches(keyCode, carbonModifiers, shortcuts.regionCopyTranslation) {
+          store.send(.copyTranslationRequested)
+          return true
         }
-        return event
+        return false
       }
+      return consumed ? nil : event
     }
   }
 
@@ -188,14 +203,8 @@ struct RegionResultView: View {
     }
   }
 
-  private func matches(_ event: NSEvent, _ hotKey: HotKey?) -> Bool {
-    guard let hotKey, Int(event.keyCode) == hotKey.carbonKeyCode else { return false }
-    var carbon = 0
-    let flags = event.modifierFlags
-    if flags.contains(.command) { carbon |= 256 }
-    if flags.contains(.shift) { carbon |= 512 }
-    if flags.contains(.option) { carbon |= 2048 }
-    if flags.contains(.control) { carbon |= 4096 }
-    return carbon == hotKey.carbonModifiers
+  private func matches(_ keyCode: Int, _ carbonModifiers: Int, _ hotKey: HotKey?) -> Bool {
+    guard let hotKey, keyCode == hotKey.carbonKeyCode else { return false }
+    return carbonModifiers == hotKey.carbonModifiers
   }
 }

--- a/Sources/Capture/RegionSelector.swift
+++ b/Sources/Capture/RegionSelector.swift
@@ -49,8 +49,7 @@ extension RegionSelectorClient: DependencyKey {
   static let liveValue: RegionSelectorClient = {
     // The controller touches AppKit, so build it lazily on the main actor.
     nonisolated(unsafe) var controller: RegionSelectorController?
-    @MainActor
-    func resolve() -> RegionSelectorController {
+    let resolve: @MainActor @Sendable () -> RegionSelectorController = {
       if let controller { return controller }
       let new = RegionSelectorController()
       controller = new
@@ -187,21 +186,23 @@ private final class RegionSelectorController {
     }
     // Space toggles mode; Escape cancels. Consume both so they don't beep.
     let key = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-      MainActor.assumeIsolated {
-        guard let self else { return event }
-        switch event.keyCode {
+      let keyCode = event.keyCode
+      let consumed = MainActor.assumeIsolated {
+        guard let self else { return false }
+        switch keyCode {
         case 49: // Space
           self.toggleMode()
-          return nil
+          return true
 
         case 53: // Escape
           self.finish(nil)
-          return nil
+          return true
 
         default:
-          return event
+          return false
         }
       }
+      return consumed ? nil : event
     }
     mouseMonitors = [mouse, global].compactMap { $0 }
     keyMonitor = key

--- a/Sources/Dependencies/JapaneseRubyOCRCorrector.swift
+++ b/Sources/Dependencies/JapaneseRubyOCRCorrector.swift
@@ -1,0 +1,382 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import Foundation
+import Vision
+
+// MARK: - JapaneseRubyOCRCorrector
+
+/// Re-reads the base-glyph portion of large horizontal Japanese rows in one
+/// contact sheet. `RecognizeDocumentsRequest` is excellent at page structure,
+/// but dense furigana can be fused with the base characters. A single accurate
+/// `RecognizeTextRequest` over the lower part of those rows preserves the page
+/// geometry while giving Apple's Japanese recognizer a clean glyph image.
+enum JapaneseRubyOCRCorrector {
+
+  // MARK: Internal
+
+  static func correcting(
+    _ lines: [OCRResult.Line],
+    in image: CGImage
+  ) async throws -> [OCRResult.Line] {
+    let inputs = lines.indices.compactMap { index in
+      input(for: lines[index], index: index, image: image)
+    }
+    guard !inputs.isEmpty else { return lines }
+
+    var recognizedCorrections = [Int: Candidate]()
+    for start in stride(from: 0, to: inputs.count, by: maximumBatchSize) {
+      let end = min(inputs.count, start + maximumBatchSize)
+      recognizedCorrections.merge(
+        try await corrections(in: Array(inputs[start ..< end])),
+        uniquingKeysWith: { current, candidate in
+          quality(candidate, comparedWith: lines[candidate.lineIndex].text)
+            > quality(current, comparedWith: lines[current.lineIndex].text)
+            ? candidate
+            : current
+        }
+      )
+    }
+
+    var result = lines
+    var correctionCount = 0
+    for (index, candidate) in recognizedCorrections {
+      let originalText = result[index].text
+      guard
+        let corrected = preferredCorrection(
+          original: originalText,
+          candidate: candidate.text,
+          confidence: candidate.confidence
+        )
+      else { continue }
+      result[index].text = corrected
+      result[index].styleRuns = remappedStyleRuns(
+        result[index].styleRuns,
+        from: originalText,
+        to: corrected
+      )
+      correctionCount += 1
+    }
+    if correctionCount > 0 {
+      Log.ocr.debug(
+        "Base-glyph OCR corrected \(correctionCount, privacy: .public) Japanese rows"
+      )
+    }
+    return result
+  }
+
+  static func preferredCorrection(
+    original: String,
+    candidate: String,
+    confidence: Float
+  ) -> String? {
+    let original = original.trimmingCharacters(in: .whitespacesAndNewlines)
+    let candidate = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !original.isEmpty, !candidate.isEmpty, original != candidate else { return nil }
+    let acceptsCompactHanCorrection = confidence >= 0.3
+      && original.count <= 4
+      && candidate.count == original.count
+      && containsHan(original)
+      && containsHan(candidate)
+    guard confidence >= 0.45 || acceptsCompactHanCorrection else { return nil }
+    guard containsHan(original) || confidence >= 0.9 && containsHan(candidate) else {
+      return nil
+    }
+    let ratio = Double(candidate.count) / Double(max(1, original.count))
+    guard ratio >= 0.6, ratio <= 1.5 else { return nil }
+    // Cropping can simply omit the top of an otherwise correct glyph. A pure
+    // deletion is not evidence that the base pass improved the transcript.
+    guard !isSubsequence(candidate, of: original) else { return nil }
+    let similarity = editSimilarity(original, candidate)
+    guard similarity >= 0.42 || confidence >= 0.9 || acceptsCompactHanCorrection else {
+      return nil
+    }
+    return preservingOriginalKana(in: candidate, comparedWith: original)
+  }
+
+  static func remappedStyleRuns(
+    _ runs: [OverlaySourceStyleRun],
+    from original: String,
+    to corrected: String
+  ) -> [OverlaySourceStyleRun] {
+    let original = original as NSString
+    let corrected = corrected as NSString
+    var occupied = [NSRange]()
+    return runs.compactMap { run in
+      guard NSMaxRange(run.range) <= original.length else { return nil }
+      let token = original.substring(with: run.range)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !token.isEmpty else { return nil }
+      var candidates = [NSRange]()
+      var searchLocation = 0
+      while searchLocation < corrected.length {
+        let search = NSRange(
+          location: searchLocation,
+          length: corrected.length - searchLocation
+        )
+        let match = corrected.range(
+          of: token,
+          options: [.caseInsensitive, .widthInsensitive],
+          range: search
+        )
+        guard match.location != NSNotFound else { break }
+        if !occupied.contains(where: { NSIntersectionRange($0, match).length > 0 }) {
+          candidates.append(match)
+        }
+        searchLocation = NSMaxRange(match)
+      }
+      guard !candidates.isEmpty else { return nil }
+      let sourceMidpoint = Double(run.range.location * 2 + run.range.length)
+        / Double(max(1, original.length * 2))
+      guard
+        let match = candidates.min(by: { lhs, rhs in
+          let lhsMidpoint = Double(lhs.location * 2 + lhs.length)
+            / Double(max(1, corrected.length * 2))
+          let rhsMidpoint = Double(rhs.location * 2 + rhs.length)
+            / Double(max(1, corrected.length * 2))
+          return abs(lhsMidpoint - sourceMidpoint) < abs(rhsMidpoint - sourceMidpoint)
+        })
+      else { return nil }
+      occupied.append(match)
+      var result = run
+      result.range = match
+      return result
+    }
+  }
+
+  // MARK: Private
+
+  private struct Input {
+    var lineIndex: Int
+    var original: String
+    var crop: CGImage
+  }
+
+  private struct Slot {
+    var lineIndex: Int
+    var original: String
+    var frame: CGRect
+  }
+
+  private struct Candidate {
+    var lineIndex: Int
+    var text: String
+    var confidence: Float
+    var rank: Int
+  }
+
+  private static let maximumBatchSize = 24
+  private static let imageScale = 3
+  private static let padding = 64
+
+  private static func input(
+    for line: OCRResult.Line,
+    index: Int,
+    image: CGImage
+  ) -> Input? {
+    guard !line.isVerticalBlock, line.text.count >= 3 else { return nil }
+    guard containsJapaneseText(line.text) else { return nil }
+    let box = line.boundingBoxNormalized.standardized
+    let pixelHeight = box.height * CGFloat(image.height)
+    let pixelWidth = box.width * CGFloat(image.width)
+    guard pixelHeight >= 32, pixelHeight <= 180, pixelWidth >= pixelHeight * 1.8 else {
+      return nil
+    }
+
+    let baseBox = CGRect(
+      x: max(0, box.minX - box.height * 0.08),
+      y: box.minY + box.height * 0.28,
+      width: min(1 - box.minX, box.width + box.height * 0.16),
+      height: box.height * 0.72
+    )
+    let imageBounds = CGRect(
+      x: 0,
+      y: 0,
+      width: CGFloat(image.width),
+      height: CGFloat(image.height)
+    )
+    let pixels = CGRect(
+      x: baseBox.minX * CGFloat(image.width),
+      y: baseBox.minY * CGFloat(image.height),
+      width: baseBox.width * CGFloat(image.width),
+      height: baseBox.height * CGFloat(image.height)
+    ).integral.intersection(imageBounds)
+    guard !pixels.isNull, !pixels.isEmpty, let crop = image.cropping(to: pixels) else {
+      return nil
+    }
+    return Input(lineIndex: index, original: line.text, crop: crop)
+  }
+
+  private static func corrections(in inputs: [Input]) async throws -> [Int: Candidate] {
+    guard let sheet = contactSheet(for: inputs) else { return [:] }
+    var request = RecognizeTextRequest()
+    request.recognitionLevel = .accurate
+    request.recognitionLanguages = [Locale.Language(identifier: "ja-JP")]
+    request.usesLanguageCorrection = true
+    let observations = try await request.perform(on: sheet.image)
+
+    var candidates = [Int: [Candidate]]()
+    for observation in observations {
+      let box = observation.boundingRegion.boundingBox.cgRect
+      let center = CGPoint(
+        x: box.midX * CGFloat(sheet.image.width),
+        y: box.midY * CGFloat(sheet.image.height)
+      )
+      guard
+        let slot = sheet.slots.first(where: {
+          $0.frame.insetBy(dx: -CGFloat(padding), dy: -CGFloat(padding) / 2).contains(center)
+        })
+      else { continue }
+      for (rank, recognized) in observation.topCandidates(3).enumerated() {
+        candidates[slot.lineIndex, default: []].append(Candidate(
+          lineIndex: slot.lineIndex,
+          text: recognized.string,
+          confidence: recognized.confidence,
+          rank: rank
+        ))
+      }
+    }
+
+    return candidates.compactMapValues { values in
+      guard let first = values.first else { return nil }
+      return values.dropFirst().reduce(first) { best, candidate in
+        quality(candidate, comparedWith: inputs.first {
+          $0.lineIndex == candidate.lineIndex
+        }?.original ?? "") > quality(best, comparedWith: inputs.first {
+          $0.lineIndex == best.lineIndex
+        }?.original ?? "")
+          ? candidate
+          : best
+      }
+    }
+  }
+
+  private static func contactSheet(for inputs: [Input]) -> (image: CGImage, slots: [Slot])? {
+    let scaledSizes = inputs.map {
+      CGSize(
+        width: CGFloat($0.crop.width * imageScale),
+        height: CGFloat($0.crop.height * imageScale)
+      )
+    }
+    guard let maximumWidth = scaledSizes.map(\.width).max() else { return nil }
+    let width = Int(ceil(maximumWidth)) + padding * 2
+    let height = Int(ceil(scaledSizes.reduce(0) { $0 + $1.height }))
+      + padding * (inputs.count + 1)
+    guard width > 0, height > 0 else { return nil }
+    guard
+      let context = CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    else { return nil }
+    context.setFillColor(CGColor(gray: 1, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: CGFloat(width), height: CGFloat(height)))
+
+    var slots = [Slot]()
+    var y = CGFloat(padding)
+    for (input, size) in zip(inputs, scaledSizes) {
+      let frame = CGRect(x: CGFloat(padding), y: y, width: size.width, height: size.height)
+      context.interpolationQuality = .high
+      context.draw(input.crop, in: frame)
+      slots.append(Slot(lineIndex: input.lineIndex, original: input.original, frame: frame))
+      y += size.height + CGFloat(padding)
+    }
+    guard let image = context.makeImage() else { return nil }
+    return (image, slots)
+  }
+
+  private static func quality(_ candidate: Candidate, comparedWith original: String) -> Double {
+    let similarity = editSimilarity(original, candidate.text)
+    let lengthRatio = Double(candidate.text.count) / Double(max(1, original.count))
+    return Double(candidate.confidence) * 100
+      + min(1.5, lengthRatio) * 10
+      + similarity
+      - Double(candidate.rank) * 0.01
+  }
+
+  private static func editSimilarity(_ lhs: String, _ rhs: String) -> Double {
+    let lhs = Array(lhs)
+    let rhs = Array(rhs)
+    guard !lhs.isEmpty || !rhs.isEmpty else { return 1 }
+    var previous = Array(0 ... rhs.count)
+    for (lhsIndex, lhsCharacter) in lhs.enumerated() {
+      var current = [lhsIndex + 1]
+      current.reserveCapacity(rhs.count + 1)
+      for (rhsIndex, rhsCharacter) in rhs.enumerated() {
+        current.append(min(
+          current[rhsIndex] + 1,
+          previous[rhsIndex + 1] + 1,
+          previous[rhsIndex] + (lhsCharacter == rhsCharacter ? 0 : 1)
+        ))
+      }
+      previous = current
+    }
+    return 1 - Double(previous[rhs.count]) / Double(max(lhs.count, rhs.count))
+  }
+
+  private static func isSubsequence(_ candidate: String, of original: String) -> Bool {
+    var cursor = original.startIndex
+    for character in candidate {
+      guard let match = original[cursor...].firstIndex(of: character) else { return false }
+      cursor = original.index(after: match)
+    }
+    return candidate.count < original.count
+  }
+
+  private static func preservingOriginalKana(in candidate: String, comparedWith original: String) -> String {
+    let candidateCharacters = Array(candidate)
+    let originalCharacters = Array(original)
+    guard candidateCharacters.count == originalCharacters.count else { return candidate }
+    return String(zip(originalCharacters, candidateCharacters).map { original, candidate in
+      isKana(original) && isKana(candidate) ? original : candidate
+    })
+  }
+
+  private static func isKana(_ character: Character) -> Bool {
+    !character.unicodeScalars.isEmpty && character.unicodeScalars.allSatisfy { scalar in
+      switch scalar.value {
+      case 0x3040 ... 0x30FF,
+           0x31F0 ... 0x31FF:
+        true
+      default:
+        false
+      }
+    }
+  }
+
+  private static func containsHan(_ text: String) -> Bool {
+    text.unicodeScalars.contains { scalar in
+      switch scalar.value {
+      case 0x3400 ... 0x4DBF,
+           0x4E00 ... 0x9FFF,
+           0xF900 ... 0xFAFF,
+           0x20000 ... 0x2FA1F:
+        true
+      default:
+        false
+      }
+    }
+  }
+
+  private static func containsJapaneseText(_ text: String) -> Bool {
+    text.unicodeScalars.contains { scalar in
+      switch scalar.value {
+      case 0x3040 ... 0x30FF,
+           0x31F0 ... 0x31FF,
+           0x3400 ... 0x4DBF,
+           0x4E00 ... 0x9FFF,
+           0xF900 ... 0xFAFF,
+           0x20000 ... 0x2FA1F:
+        true
+      default:
+        false
+      }
+    }
+  }
+}

--- a/Sources/Dependencies/OCRClient.swift
+++ b/Sources/Dependencies/OCRClient.swift
@@ -170,7 +170,7 @@ extension OCRClient: DependencyKey {
       } else {
         correctedLines = lines
       }
-      let result = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      let result = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
         to: OCRResult(lines: correctedLines).removingNestedDuplicates(),
         from: image
       ).coalescingParagraphFragments()

--- a/Sources/Dependencies/OCRClient.swift
+++ b/Sources/Dependencies/OCRClient.swift
@@ -23,6 +23,9 @@ struct OCRClient {
 extension OCRClient: DependencyKey {
   static let liveValue = OCRClient(
     recognizeText: { image, language in
+      // A capture that starts while the proactive probe is loading the model
+      // joins that work instead of issuing a second cold Vision request.
+      await VisionWarmUp.shared.waitForInFlight()
       var request = RecognizeDocumentsRequest()
       if language.isAuto {
         request.textRecognitionOptions.automaticallyDetectLanguage = true
@@ -41,37 +44,461 @@ extension OCRClient: DependencyKey {
         Log.ocr.debug("Recognition took \(elapsed.loggedSeconds, privacy: .public)s")
       }
 
-      // Each paragraph is already grouped in reading order by Vision's document
-      // layout analysis — it separates titles, ruby (furigana), and body, orders
-      // vertical CJK columns right-to-left, and reports the text direction — so we
-      // map each paragraph to one line/block at its own location.
-      let lines: [OCRResult.Line] = observations.flatMap(\.document.paragraphs).compactMap { paragraph in
-        let transcript = paragraph.transcript.trimmed
-        guard !transcript.isEmpty else { return nil }
-        let cg = paragraph.boundingRegion.boundingBox.cgRect
-        let box = CGRect(x: cg.minX, y: 1 - cg.maxY, width: cg.width, height: cg.height)
-
-        // A paragraph is vertical when most of its lines read top-to-bottom.
-        let verticalLineCount = paragraph.lines.filter { $0.textDirection == .topToBottom }.count
-        let isVertical = !paragraph.lines.isEmpty && verticalLineCount * 2 >= paragraph.lines.count
-
-        // For a vertical block each line is a column whose width tracks the
-        // character size — average it so the renderer keeps the font scale.
-        let charScale = isVertical
-          ? paragraph.lines.map { $0.boundingRegion.boundingBox.cgRect.width }.reduce(0, +) / CGFloat(max(paragraph.lines.count, 1))
-          : 0
-        return OCRResult.Line(
-          boundingBoxNormalized: box,
-          text: transcript,
-          rowCount: max(1, paragraph.lines.count),
-          isVerticalBlock: isVertical,
-          verticalCharScale: charScale
+      // Vision's paragraph grouping is semantic, not typographic. A large title
+      // and a smaller subtitle can therefore arrive as one paragraph even
+      // though they need different font scale, color, and translation frames.
+      // Start from Vision's line geometry and conservatively stitch only lines
+      // with matching scale/alignment below.
+      let postProcessingStarted = clock.now
+      let paragraphs = observations.flatMap(\.document.paragraphs)
+      var nextRecognitionGroupID = 0
+      var lines = paragraphs.flatMap { paragraph in
+        let alignment = paragraph.textAlignment?.overlayTextAlignment
+        let paragraphWords = paragraph.words?.compactMap { observation -> RecognizedWord? in
+          guard let text = observation.topCandidates(1).first?.string.trimmed, !text.isEmpty else {
+            return nil
+          }
+          return RecognizedWord(
+            text: text,
+            box: Self.topLeftBox(observation.boundingRegion.boundingBox.cgRect)
+          )
+        } ?? []
+        let recognizedLines = paragraph.lines.compactMap { observation -> (
+          observation: RecognizedTextObservation,
+          candidate: RecognizedText,
+          transcript: String
+        )? in
+          guard
+            let candidate = observation.topCandidates(1).first,
+            !candidate.string.trimmed.isEmpty
+          else {
+            return nil
+          }
+          return (
+            observation: observation,
+            candidate: candidate,
+            transcript: candidate.string.trimmed
+          )
+        }
+        let segmentIndices = OCRParagraphLineGrouping.segmentIndices(
+          paragraphTranscript: paragraph.transcript,
+          lineTranscripts: recognizedLines.map(\.transcript)
         )
+        let groupBase = nextRecognitionGroupID
+        nextRecognitionGroupID += max(1, (segmentIndices.max() ?? 0) + 1)
+        let mapped = recognizedLines.enumerated().map { lineIndex, recognizedLine -> OCRResult.Line in
+          let observation = recognizedLine.observation
+          let transcript = recognizedLine.transcript
+          let box = Self.topLeftBox(observation.boundingRegion.boundingBox.cgRect)
+          let isVertical = observation.textDirection == .topToBottom
+          let documentWords = paragraphWords.filter { word in
+            let intersection = box.intersection(word.box)
+            return !intersection.isNull
+              && intersection.width * intersection.height
+              / max(0.000_001, word.box.width * word.box.height) >= 0.72
+          }
+          // Document paragraphs do not always expose `words` (notably dense
+          // Japanese educational pages). The line candidate still provides
+          // Apple's exact range geometry, so use it to retain punctuation,
+          // mixed colors, and inline styles instead of flattening the line.
+          let geometricWords = Self.geometricWords(in: recognizedLine.candidate)
+          let words = geometricWords.isEmpty ? documentWords : geometricWords
+          let wordBoxes = words.map(\.box)
+          let patches = (wordBoxes.isEmpty ? [box] : wordBoxes).map {
+            OverlaySourcePatch(box: $0)
+          }
+          let horizontalGlyphScale = isVertical
+            ? 0
+            : Self.median(wordBoxes.map(\.height)) ?? box.height
+          return OCRResult.Line(
+            boundingBoxNormalized: box,
+            text: transcript,
+            isVerticalBlock: isVertical,
+            verticalCharScale: isVertical ? box.width : 0,
+            horizontalGlyphScale: horizontalGlyphScale,
+            recognitionGroupID: groupBase + segmentIndices[lineIndex],
+            replacementPatches: patches,
+            styleRuns: Self.styleRuns(in: transcript, words: words),
+            alignment: alignment
+          )
+        }
+        guard mapped.isEmpty else { return mapped }
+
+        let transcript = paragraph.transcript.trimmed
+        guard !transcript.isEmpty else { return [] }
+        let box = Self.topLeftBox(paragraph.boundingRegion.boundingBox.cgRect)
+        return [
+          OCRResult.Line(
+            boundingBoxNormalized: box,
+            text: transcript,
+            rowCount: 1,
+            recognitionGroupID: groupBase,
+            replacementPatches: [OverlaySourcePatch(box: box)],
+            alignment: alignment
+          )
+        ]
       }
-      return OCRResult(lines: lines)
+      if Self.shouldRunSupplementalRecognition(for: lines, language: language) {
+        do {
+          let supplementalStarted = clock.now
+          let supplemental = try await Self.supplementalLines(in: image, language: language)
+          let previousCount = lines.count
+          lines = OCRSupplementalMerger.addingUncovered(supplemental, to: lines)
+          Log.ocr.debug(
+            "Supplemental recognition added \(lines.count - previousCount, privacy: .public) lines in \((clock.now - supplementalStarted).loggedSeconds, privacy: .public)s"
+          )
+        } catch {
+          // Document recognition remains a complete result on its own. Surface
+          // the supplemental failure, but do not turn a successful capture into
+          // an error merely because the recall pass was unavailable.
+          Log.ocr.error(
+            "Supplemental recognition failed: \(error.localizedDescription, privacy: .public)"
+          )
+        }
+      }
+      let correctedLines: [OCRResult.Line]
+      let languageCode = language.localeLanguage.languageCode?.identifier
+      if language.isAuto || languageCode == "ja" {
+        do {
+          correctedLines = try await JapaneseRubyOCRCorrector.correcting(lines, in: image)
+        } catch {
+          Log.ocr.error(
+            "Base-glyph OCR failed: \(error.localizedDescription, privacy: .public)"
+          )
+          correctedLines = lines
+        }
+      } else {
+        correctedLines = lines
+      }
+      let result = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+        to: OCRResult(lines: correctedLines).removingNestedDuplicates(),
+        from: image
+      ).coalescingParagraphFragments()
+      let postProcessingElapsed = clock.now - postProcessingStarted
+      Log.ocr.debug(
+        "Post-processing produced \(result.lines.count, privacy: .public) lines in \(postProcessingElapsed.loggedSeconds, privacy: .public)s"
+      )
+      return result
     },
     warmUp: { await VisionWarmUp.shared.run() }
   )
+}
+
+// MARK: - OCRParagraphLineGrouping
+
+/// Preserves explicit semantic breaks that Vision exposes inside a document
+/// paragraph. Visual wraps share a group; lines separated by a transcript
+/// newline do not get stitched back into one translation unit.
+enum OCRParagraphLineGrouping {
+
+  // MARK: Internal
+
+  static func segmentIndices(
+    paragraphTranscript: String,
+    lineTranscripts: [String]
+  ) -> [Int] {
+    guard !lineTranscripts.isEmpty else { return [] }
+    let segments = paragraphTranscript
+      .split(whereSeparator: \.isNewline)
+      .map { normalized(String($0)) }
+      .filter { !$0.isEmpty }
+    guard segments.count > 1 else {
+      return Array(repeating: 0, count: lineTranscripts.count)
+    }
+
+    var segmentIndex = 0
+    var consumed = ""
+    return lineTranscripts.map { transcript in
+      let line = normalized(transcript)
+      while
+        segmentIndex < segments.count - 1,
+        !segments[segmentIndex].hasPrefix(consumed + line)
+      {
+        segmentIndex += 1
+        consumed = ""
+      }
+
+      let result = segmentIndex
+      consumed += line
+      if
+        segmentIndex < segments.count - 1,
+        consumed.count >= segments[segmentIndex].count
+        || !segments[segmentIndex].hasPrefix(consumed)
+      {
+        segmentIndex += 1
+        consumed = ""
+      }
+      return result
+    }
+  }
+
+  // MARK: Private
+
+  private static func normalized(_ value: String) -> String {
+    value.filter { !$0.isWhitespace && !$0.isNewline }
+  }
+}
+
+extension OCRClient {
+  fileprivate struct RecognizedWord {
+    var text: String
+    var box: CGRect
+  }
+
+  fileprivate static func topLeftBox(_ box: CGRect) -> CGRect {
+    CGRect(x: box.minX, y: 1 - box.maxY, width: box.width, height: box.height)
+  }
+
+  fileprivate static func median(_ values: [CGFloat]) -> CGFloat? {
+    guard !values.isEmpty else { return nil }
+    let sorted = values.sorted()
+    let middle = sorted.count / 2
+    if sorted.count.isMultiple(of: 2) {
+      return (sorted[middle - 1] + sorted[middle]) / 2
+    }
+    return sorted[middle]
+  }
+
+  fileprivate static func styleRuns(
+    in transcript: String,
+    words: [RecognizedWord]
+  ) -> [OverlaySourceStyleRun] {
+    guard !transcript.isEmpty, !words.isEmpty else { return [] }
+    let source = transcript as NSString
+    var cursor = 0
+    var runs = [OverlaySourceStyleRun]()
+    for word in words {
+      guard cursor < source.length else { break }
+      let searchRange = NSRange(location: cursor, length: source.length - cursor)
+      var range = source.range(of: word.text, options: [], range: searchRange)
+      if range.location == NSNotFound {
+        range = source.range(of: word.text, options: .caseInsensitive, range: searchRange)
+      }
+      guard range.location != NSNotFound else { continue }
+      runs.append(OverlaySourceStyleRun(range: range, box: word.box))
+      cursor = range.location + range.length
+    }
+    return runs
+  }
+
+  fileprivate static func geometricWords(in candidate: RecognizedText) -> [RecognizedWord] {
+    OCRTextTokenization.ranges(in: candidate.string).compactMap { range in
+      guard let observation = candidate.boundingBox(for: range) else { return nil }
+      return RecognizedWord(
+        text: String(candidate.string[range]),
+        box: topLeftBox(observation.boundingBox.cgRect)
+      )
+    }
+  }
+
+  fileprivate static func supplementalLines(
+    in image: CGImage,
+    language: Language
+  ) async throws -> [OCRResult.Line] {
+    var request = RecognizeTextRequest()
+    request.recognitionLevel = .accurate
+    request.usesLanguageCorrection = true
+    if language.isAuto {
+      request.automaticallyDetectsLanguage = true
+    } else {
+      request.recognitionLanguages = [language.localeLanguage]
+    }
+    return try await request.perform(on: image).compactMap { observation in
+      guard
+        let candidate = observation.topCandidates(1).first,
+        candidate.confidence >= 0.25,
+        !candidate.string.trimmed.isEmpty
+      else { return nil }
+      let text = candidate.string.trimmed
+      let box = topLeftBox(observation.boundingRegion.boundingBox.cgRect)
+      let words = geometricWords(in: candidate)
+      let wordBoxes = words.map(\.box)
+      return OCRResult.Line(
+        boundingBoxNormalized: box,
+        text: text,
+        horizontalGlyphScale: median(wordBoxes.map(\.height)) ?? box.height,
+        replacementPatches: (wordBoxes.isEmpty ? [box] : wordBoxes).map {
+          OverlaySourcePatch(box: $0)
+        },
+        styleRuns: styleRuns(in: text, words: words),
+        alignment: inferredSupplementalAlignment(for: box)
+      )
+    }
+  }
+
+  fileprivate static func shouldRunSupplementalRecognition(
+    for lines: [OCRResult.Line],
+    language: Language
+  ) -> Bool {
+    guard !lines.contains(where: \.isVerticalBlock) else { return false }
+    let languageCode = language.localeLanguage.languageCode?.identifier
+    if !language.isAuto, languageCode == "ja" { return false }
+    if language.isAuto, lines.map(\.text).joined().unicodeScalars.contains(where: isJapaneseScalar) {
+      return false
+    }
+    return true
+  }
+
+  fileprivate static func inferredSupplementalAlignment(for box: CGRect) -> OverlayTextAlignment {
+    box.width >= 0.35 && abs(box.midX - 0.5) <= 0.06 ? .center : .leading
+  }
+
+  fileprivate static func isJapaneseScalar(_ scalar: Unicode.Scalar) -> Bool {
+    switch scalar.value {
+    case 0x3040 ... 0x30FF,
+         0x31F0 ... 0x31FF:
+      true
+    default:
+      false
+    }
+  }
+}
+
+// MARK: - OCRSupplementalMerger
+
+enum OCRSupplementalMerger {
+
+  // MARK: Internal
+
+  /// Adds only text rows that document recognition omitted. RecognizeText is a
+  /// high-recall companion pass; overlapping document rows remain canonical so
+  /// paragraph membership, style, and alignment are not destabilized.
+  static func addingUncovered(
+    _ supplemental: [OCRResult.Line],
+    to primary: [OCRResult.Line]
+  ) -> [OCRResult.Line] {
+    let additions = supplemental.filter { candidate in
+      !primary.contains { covers(candidate, primary: $0) }
+    }
+    return (primary + additions).sorted { lhs, rhs in
+      let lhsBox = lhs.boundingBoxNormalized.standardized
+      let rhsBox = rhs.boundingBoxNormalized.standardized
+      if abs(lhsBox.minY - rhsBox.minY) <= min(lhsBox.height, rhsBox.height) * 0.35 {
+        return lhsBox.minX < rhsBox.minX
+      }
+      return lhsBox.minY < rhsBox.minY
+    }
+  }
+
+  // MARK: Private
+
+  private static func covers(_ candidate: OCRResult.Line, primary: OCRResult.Line) -> Bool {
+    let candidateBox = candidate.boundingBoxNormalized.standardized
+    let primaryBox = primary.boundingBoxNormalized.standardized
+    let intersection = candidateBox.intersection(primaryBox)
+    guard !intersection.isNull, !intersection.isEmpty else { return false }
+    let intersectionArea = intersection.width * intersection.height
+    let candidateCoverage = intersectionArea / max(0.000_001, candidateBox.width * candidateBox.height)
+    if candidateCoverage >= 0.58 { return true }
+
+    let candidateText = normalized(candidate.text)
+    let primaryText = normalized(primary.text)
+    guard
+      !candidateText.isEmpty,
+      candidateText == primaryText || candidateText.contains(primaryText) || primaryText.contains(candidateText)
+    else { return false }
+    return hypot(candidateBox.midX - primaryBox.midX, candidateBox.midY - primaryBox.midY)
+      <= max(candidateBox.height, primaryBox.height) * 1.5
+  }
+
+  private static func normalized(_ text: String) -> String {
+    text.lowercased().unicodeScalars
+      .filter { CharacterSet.alphanumerics.contains($0) }
+      .map(String.init)
+      .joined()
+  }
+}
+
+// MARK: - OCRTextTokenization
+
+/// Produces style-sized ranges while leaving their geometry to Vision. Words
+/// remain intact for Latin scripts; CJK text remains contiguous; punctuation is
+/// separate so brackets, links, and emphasized symbols can keep their own style.
+enum OCRTextTokenization {
+
+  // MARK: Internal
+
+  static func ranges(in text: String) -> [Range<String.Index>] {
+    var result = [Range<String.Index>]()
+    var start: String.Index?
+    var currentKind: Kind?
+
+    func finish(at end: String.Index) {
+      if let start, start < end {
+        result.append(start ..< end)
+      }
+      start = nil
+      currentKind = nil
+    }
+
+    var index = text.startIndex
+    while index < text.endIndex {
+      let next = text.index(after: index)
+      guard let kind = Kind(text[index]) else {
+        finish(at: index)
+        index = next
+        continue
+      }
+      if currentKind != kind {
+        finish(at: index)
+        start = index
+        currentKind = kind
+      }
+      index = next
+    }
+    finish(at: text.endIndex)
+    return result
+  }
+
+  // MARK: Private
+
+  private enum Kind: Equatable {
+    case cjk
+    case word
+    case punctuation
+
+    // MARK: Lifecycle
+
+    init?(_ character: Character) {
+      let scalars = character.unicodeScalars
+      guard !scalars.allSatisfy(\.properties.isWhitespace) else { return nil }
+      if scalars.contains(where: { Self.isCJK($0) }) {
+        self = .cjk
+      } else if scalars.allSatisfy({ CharacterSet.alphanumerics.contains($0) || $0 == "_" }) {
+        self = .word
+      } else {
+        self = .punctuation
+      }
+    }
+
+    // MARK: Private
+
+    private static func isCJK(_ scalar: Unicode.Scalar) -> Bool {
+      switch scalar.value {
+      case 0x3040 ... 0x30FF,
+           0x31F0 ... 0x31FF,
+           0x3400 ... 0x4DBF,
+           0x4E00 ... 0x9FFF,
+           0xAC00 ... 0xD7AF,
+           0xF900 ... 0xFAFF,
+           0x20000 ... 0x2FA1F:
+        true
+      default:
+        false
+      }
+    }
+  }
+}
+
+extension DocumentObservation.Container.Text.Alignment {
+  fileprivate var overlayTextAlignment: OverlayTextAlignment {
+    switch self {
+    case .center: .center
+    case .leading: .leading
+    case .trailing: .trailing
+    @unknown default: .center
+    }
+  }
 }
 
 extension DependencyValues {
@@ -126,6 +553,10 @@ private actor VisionWarmUp {
       request.textRecognitionOptions.automaticallyDetectLanguage = true
       do {
         _ = try await request.perform(on: probe)
+        var supplemental = RecognizeTextRequest()
+        supplemental.recognitionLevel = .accurate
+        supplemental.automaticallyDetectsLanguage = true
+        _ = try await supplemental.perform(on: probe)
         let elapsed = clock.now - started
         if elapsed > .seconds(2) {
           Log.ocr.log("Warm-up loaded a cold model in \(elapsed.loggedSeconds, privacy: .public)s")
@@ -139,6 +570,12 @@ private actor VisionWarmUp {
     inFlight = load
     await load.value
     inFlight = nil
+  }
+
+  func waitForInFlight() async {
+    if let inFlight {
+      await inFlight.value
+    }
   }
 
   // MARK: Private

--- a/Sources/Dependencies/OverlayClient.swift
+++ b/Sources/Dependencies/OverlayClient.swift
@@ -14,11 +14,11 @@ struct OverlayRenderState: Equatable, Sendable {
   var hideOnHover: Bool
   var isTranslating: Bool
   var isLive: Bool
-  /// In-place draws chips on the overlay; window draws a thin region frame and
+  /// In-place draws source-restored text on the overlay; window draws a thin region frame and
   /// shows the translation in a detached result window.
   var liveMode: OverlayLiveMode
-  /// Blurred screenshot backdrop for the detached window (window mode only).
-  var backgroundImageData: Data?
+  /// Raw screenshot shown in the detached window (window mode only).
+  var sourceImageData: Data?
   var imageSize: CGSize
   /// Bumped whenever the overlay is (re)placed onto a new selection, so the
   /// controller snaps the window to the stored frame even if it's already shown.
@@ -45,7 +45,6 @@ enum OverlayUserAction: Sendable {
 @DependencyClient
 struct OverlayClient {
   var render: @Sendable (_ state: OverlayRenderState) async -> Void
-  var windowID: @Sendable () async -> CGWindowID?
   var events: @Sendable () -> AsyncStream<OverlayUserAction> = { .finished }
 }
 
@@ -56,8 +55,7 @@ extension OverlayClient: DependencyKey {
     // The controller touches AppKit, so it can only be built on the main
     // actor. Create it lazily the first time the client is used there.
     nonisolated(unsafe) var controller: OverlayWindowController?
-    @MainActor
-    func resolve() -> OverlayWindowController {
+    let resolve: @MainActor @Sendable () -> OverlayWindowController = {
       if let controller { return controller }
       let new = OverlayWindowController()
       controller = new
@@ -67,7 +65,6 @@ extension OverlayClient: DependencyKey {
       render: { state in
         await resolve().update(state)
       },
-      windowID: { await resolve().windowID },
       events: {
         AsyncStream { continuation in
           let task = Task { @MainActor in

--- a/Sources/Dependencies/OverlayClient.swift
+++ b/Sources/Dependencies/OverlayClient.swift
@@ -6,6 +6,21 @@ import CoreGraphics
 import DependenciesMacros
 import Foundation
 
+// MARK: - OverlayBackdrop
+
+/// An immutable capture shared with the detached live-result window.
+///
+/// `CGImage` owns immutable pixel storage and can safely be retained across the
+/// capture and main actors. Identity equality is intentional: every successful
+/// capture produces a new image, while unrelated state updates keep the same one.
+struct OverlayBackdrop: @unchecked Sendable, Equatable {
+  let image: CGImage
+
+  static func ==(lhs: Self, rhs: Self) -> Bool {
+    lhs.image === rhs.image
+  }
+}
+
 // MARK: - OverlayRenderState
 
 struct OverlayRenderState: Equatable, Sendable {
@@ -17,8 +32,8 @@ struct OverlayRenderState: Equatable, Sendable {
   /// In-place draws source-restored text on the overlay; window draws a thin region frame and
   /// shows the translation in a detached result window.
   var liveMode: OverlayLiveMode
-  /// Raw screenshot shown in the detached window (window mode only).
-  var sourceImageData: Data?
+  /// Captured pixels shown in the detached window (window mode only).
+  var backdrop: OverlayBackdrop?
   var imageSize: CGSize
   /// Bumped whenever the overlay is (re)placed onto a new selection, so the
   /// controller snaps the window to the stored frame even if it's already shown.

--- a/Sources/Dependencies/ScreenCaptureClient.swift
+++ b/Sources/Dependencies/ScreenCaptureClient.swift
@@ -18,9 +18,8 @@ struct ScreenCaptureClient {
   /// Pass `nil` to capture the whole display.
   var captureImage: @Sendable (
     _ overlayFrame: CGRect?,
-    _ excludingWindowIDs: [CGWindowID],
     _ displayID: CGDirectDisplayID?,
-    _ excludingBundleIdentifier: String?
+    _ excludingProcessID: pid_t?
   ) async throws -> CGImage
 
   /// Captures a single window by id, independent of what's stacked on top of it
@@ -54,7 +53,7 @@ enum ScreenCaptureError: Error, LocalizedError, Equatable {
 
 extension ScreenCaptureClient: DependencyKey {
   static let liveValue = ScreenCaptureClient(
-    captureImage: { overlayFrame, excludingWindowIDs, displayID, excludingBundleIdentifier in
+    captureImage: { overlayFrame, displayID, excludingProcessID in
       try await ScreenRecordingPermissionTracker.shared.requestIfNeeded()
       let content = try await SCShareableContent.excludingDesktopWindows(
         false,
@@ -76,17 +75,28 @@ extension ScreenCaptureClient: DependencyKey {
       }
       let scale = nsScreen?.backingScaleFactor ?? 1
 
+      // Resolve exclusions from the current ScreenCaptureKit snapshot on every
+      // capture. Passing a window id that was read before the overlay panel was
+      // created made the live loop capture its own previous frame forever. A
+      // process id is stable for this launch and excludes every SwiftyCrow
+      // surface, including panels created after Live starts.
+      let excludedApplications = excludingProcessID.map { processID in
+        content.applications.filter { $0.processID == processID }
+      } ?? []
+      let excludedWindows = excludingProcessID.map { processID in
+        content.windows.filter { $0.owningApplication?.processID == processID }
+      } ?? []
       let filter =
-        if
-          let excludingBundleIdentifier,
-          let excludedApp = content.applications.first(where: { $0.bundleIdentifier == excludingBundleIdentifier })
-        {
-          SCContentFilter(display: display, excludingApplications: [excludedApp], exceptingWindows: [])
-        } else {
+        if !excludedApplications.isEmpty {
           SCContentFilter(
             display: display,
-            excludingWindows: content.windows.filter { excludingWindowIDs.contains($0.windowID) }
+            excludingApplications: excludedApplications,
+            exceptingWindows: []
           )
+        } else {
+          // Some system states omit an application entry while still reporting
+          // its windows. Keep the same process-based contract in that case.
+          SCContentFilter(display: display, excludingWindows: excludedWindows)
         }
 
       let configuration = SCStreamConfiguration()

--- a/Sources/Dependencies/TranslationClient.swift
+++ b/Sources/Dependencies/TranslationClient.swift
@@ -13,15 +13,73 @@ import Translation
 struct TranslationLine: Equatable, Sendable {
   var id: UUID
   var text: String
+  var attributedText: AttributedString? = nil
+}
+
+// MARK: - TranslatedText
+
+struct TranslatedText: Equatable, Sendable {
+  var text: String
+  var attributedText: AttributedString? = nil
+}
+
+// MARK: - TranslationTextStructure
+
+enum TranslationTextStructure {
+
+  // MARK: Internal
+
+  /// Translation may promote one source line break into a paragraph break.
+  /// Keep the target's wording, but cap consecutive newlines to the structure
+  /// that OCR recovered from the source frame.
+  static func matchingSourceBreaks(_ target: String, source: String) -> String {
+    let sourceLimit = maximumConsecutiveNewlines(in: source)
+    guard sourceLimit > 0 else { return target }
+
+    let normalized = target
+      .replacingOccurrences(of: "\r\n", with: "\n")
+      .replacingOccurrences(of: "\r", with: "\n")
+    var result = ""
+    var consecutiveNewlines = 0
+    for character in normalized {
+      if character == "\n" {
+        if consecutiveNewlines < sourceLimit {
+          result.append(character)
+        }
+        consecutiveNewlines += 1
+      } else {
+        consecutiveNewlines = 0
+        result.append(character)
+      }
+    }
+    return result
+  }
+
+  // MARK: Private
+
+  private static func maximumConsecutiveNewlines(in text: String) -> Int {
+    var maximum = 0
+    var current = 0
+    for character in text {
+      if character == "\n" {
+        current += 1
+        maximum = max(maximum, current)
+      } else if character != "\r" {
+        current = 0
+      }
+    }
+    return maximum
+  }
 }
 
 // MARK: - TranslationClient
 
 @DependencyClient
 struct TranslationClient {
-  /// Translates all `lines` in a single `TranslationSession`, yielding each
-  /// result as soon as it's ready (order isn't guaranteed; match by `id`).
-  /// One session for the whole batch avoids per-line session setup.
+  /// Translates all `lines` in one source-language session, yielding each result
+  /// as soon as it's ready (order isn't guaranteed; match by `id`). Translation
+  /// always comes from the plain batch response. Attributed source text is used
+  /// only to map visual style spans onto that translated string.
   var translateBatch: @Sendable (
     _ lines: [TranslationLine],
     _ source: Locale.Language,
@@ -35,6 +93,9 @@ struct TranslationClient {
 // MARK: DependencyKey
 
 extension TranslationClient: DependencyKey {
+
+  // MARK: Internal
+
   static let liveValue = TranslationClient(
     translateBatch: { lines, source, target, strategy in
       AsyncThrowingStream { continuation in
@@ -45,15 +106,53 @@ extension TranslationClient: DependencyKey {
           } else {
             TranslationSession(installedSource: source, target: target)
           }
+        let linesByID = Dictionary(uniqueKeysWithValues: lines.map { ($0.id, $0) })
         let requests = lines.map {
           TranslationSession.Request(sourceText: $0.text, clientIdentifier: $0.id.uuidString)
         }
         let task = Task {
+          let clock = ContinuousClock()
+          let started = clock.now
+          var receivedFirstResponse = false
           do {
+            var styledTargets = [UUID: String]()
             for try await response in session.translate(batch: requests) {
-              guard let id = response.clientIdentifier.flatMap(UUID.init(uuidString:)) else { continue }
-              continuation.yield(TranslationLine(id: id, text: response.targetText))
+              if !receivedFirstResponse {
+                receivedFirstResponse = true
+                let elapsed = clock.now - started
+                Log.translation.debug(
+                  "First response for \(pair, privacy: .public) arrived in \(elapsed.loggedSeconds, privacy: .public)s"
+                )
+              }
+              guard
+                let id = response.clientIdentifier.flatMap(UUID.init(uuidString:)),
+                let sourceLine = linesByID[id]
+              else { continue }
+              let targetText = TranslationTextStructure.matchingSourceBreaks(
+                response.targetText,
+                source: sourceLine.text
+              )
+              if #available(macOS 26.4, *), sourceLine.attributedText != nil {
+                styledTargets[id] = targetText
+                continue
+              }
+              continuation.yield(TranslationLine(
+                id: id,
+                text: targetText
+              ))
             }
+            if #available(macOS 26.4, *), !styledTargets.isEmpty {
+              try await Self.yieldStyledTranslations(
+                styledTargets,
+                linesByID: linesByID,
+                session: session,
+                continuation: continuation
+              )
+            }
+            let elapsed = clock.now - started
+            Log.translation.debug(
+              "Batch of \(lines.count, privacy: .public) lines (\(pair, privacy: .public)) finished in \(elapsed.loggedSeconds, privacy: .public)s"
+            )
             continuation.finish()
           } catch {
             continuation.finish(throwing: error)
@@ -64,7 +163,11 @@ extension TranslationClient: DependencyKey {
         // else bounds this stream, so without a watchdog the caller's spinner
         // runs forever.
         let watchdog = Task {
-          try? await ContinuousClock().sleep(for: CaptureDeadline.translationBatch)
+          do {
+            try await ContinuousClock().sleep(for: CaptureDeadline.translationBatch)
+          } catch {
+            return
+          }
           Log.translation.error("Batch of \(lines.count, privacy: .public) lines (\(pair, privacy: .public)) stalled")
           continuation.finish(throwing: DeadlineExceededError(stage: .translation))
         }
@@ -81,6 +184,65 @@ extension TranslationClient: DependencyKey {
       }
     }
   )
+
+  // MARK: Private
+
+  @available(macOS 26.4, *)
+  private static func yieldStyledTranslations(
+    _ targets: [UUID: String],
+    linesByID: [UUID: TranslationLine],
+    session: TranslationSession,
+    continuation: AsyncThrowingStream<TranslationLine, any Error>.Continuation
+  ) async throws {
+    var alternatives = [UUID: [URL: String]]()
+    var snippetOwners = [UUID: (lineID: UUID, link: URL)]()
+    var snippetRequests = [TranslationSession.Request]()
+
+    for (lineID, targetText) in targets {
+      guard let source = linesByID[lineID]?.attributedText else { continue }
+      let alignment = TranslationStyleMapper.align(source: source, target: targetText)
+      for span in alignment.unmatched {
+        let requestID = UUID()
+        snippetOwners[requestID] = (lineID, span.link)
+        snippetRequests.append(TranslationSession.Request(
+          sourceText: span.text,
+          clientIdentifier: requestID.uuidString
+        ))
+      }
+    }
+
+    if !snippetRequests.isEmpty {
+      for try await response in session.translate(batch: snippetRequests) {
+        guard
+          let requestID = response.clientIdentifier.flatMap(UUID.init(uuidString:)),
+          let owner = snippetOwners[requestID]
+        else { continue }
+        alternatives[owner.lineID, default: [:]][owner.link] = response.targetText
+      }
+    }
+
+    for (lineID, targetText) in targets {
+      guard
+        let sourceLine = linesByID[lineID],
+        let attributedSource = sourceLine.attributedText
+      else { continue }
+      let alignment = TranslationStyleMapper.align(
+        source: attributedSource,
+        target: targetText,
+        alternatives: alternatives[lineID] ?? [:]
+      )
+      if !alignment.unmatched.isEmpty {
+        Log.translation.debug(
+          "Dropping \(alignment.unmatched.count, privacy: .public) unaligned style runs while preserving the plain translation"
+        )
+      }
+      continuation.yield(TranslationLine(
+        id: lineID,
+        text: targetText,
+        attributedText: alignment.target
+      ))
+    }
+  }
 }
 
 extension DependencyValues {

--- a/Sources/Dependencies/TranslationClient.swift
+++ b/Sources/Dependencies/TranslationClient.swift
@@ -14,6 +14,14 @@ struct TranslationLine: Equatable, Sendable {
   var id: UUID
   var text: String
   var attributedText: AttributedString? = nil
+  /// Neighboring compact value used only to disambiguate this label. It is
+  /// never rendered as part of the label's translated output.
+  var trailingContext: String? = nil
+
+  var requestText: String {
+    guard let trailingContext else { return text }
+    return "\(text): \(trailingContext)"
+  }
 }
 
 // MARK: - TranslatedText
@@ -53,6 +61,18 @@ enum TranslationTextStructure {
       }
     }
     return result
+  }
+
+  /// Extracts the label from a contextual `label: value` translation. Apple
+  /// Translation retains either the ASCII or full-width colon for supported
+  /// language pairs; returning nil keeps a malformed response visible instead
+  /// of silently guessing where the label ends.
+  static func label(fromContextualTranslation target: String) -> String? {
+    guard let separator = target.firstIndex(where: { $0 == ":" || $0 == "：" }) else {
+      return nil
+    }
+    let label = target[..<separator].trimmingCharacters(in: .whitespacesAndNewlines)
+    return label.isEmpty ? nil : label
   }
 
   // MARK: Private
@@ -108,7 +128,7 @@ extension TranslationClient: DependencyKey {
           }
         let linesByID = Dictionary(uniqueKeysWithValues: lines.map { ($0.id, $0) })
         let requests = lines.map {
-          TranslationSession.Request(sourceText: $0.text, clientIdentifier: $0.id.uuidString)
+          TranslationSession.Request(sourceText: $0.requestText, clientIdentifier: $0.id.uuidString)
         }
         let task = Task {
           let clock = ContinuousClock()
@@ -128,8 +148,12 @@ extension TranslationClient: DependencyKey {
                 let id = response.clientIdentifier.flatMap(UUID.init(uuidString:)),
                 let sourceLine = linesByID[id]
               else { continue }
+              let translatedLabel = sourceLine.trailingContext == nil
+                ? response.targetText
+                : TranslationTextStructure.label(fromContextualTranslation: response.targetText)
+                  ?? response.targetText
               let targetText = TranslationTextStructure.matchingSourceBreaks(
-                response.targetText,
+                translatedLabel,
                 source: sourceLine.text
               )
               if #available(macOS 26.4, *), sourceLine.attributedText != nil {

--- a/Sources/Models/Language.swift
+++ b/Sources/Models/Language.swift
@@ -30,17 +30,13 @@ struct Language: Codable, Equatable, Hashable, Identifiable, Sendable {
 }
 
 extension Locale.Language {
-  /// Whether text in this language is conventionally set in vertical columns.
-  /// Vertical CJK column layout only reads correctly when the text itself is
-  /// CJK — a Latin translation stacked one character per row is unreadable.
-  var usesVerticalScript: Bool {
-    switch languageCode?.identifier {
-    case "ja",
-         "zh",
-         "ko",
-         "yue": true
-    default: false
-    }
+  /// Region variants share the same written language, while script variants
+  /// such as Simplified and Traditional Chinese do not. Maximizing both tags
+  /// lets Foundation fill in omitted scripts before we compare them.
+  func usesSameWritingSystem(as other: Locale.Language) -> Bool {
+    let lhs = Locale.Language(identifier: maximalIdentifier)
+    let rhs = Locale.Language(identifier: other.maximalIdentifier)
+    return lhs.languageCode == rhs.languageCode && lhs.script == rhs.script
   }
 }
 
@@ -73,9 +69,7 @@ extension Language {
     var ids = Set(translationLangs.map(\.maximalIdentifier))
     if intersectedWithOCR {
       let request = RecognizeTextRequest()
-      if let ocr = try? request.supportedRecognitionLanguages {
-        ids.formIntersection(ocr.map(\.maximalIdentifier))
-      }
+      ids.formIntersection(request.supportedRecognitionLanguages.map(\.maximalIdentifier))
     }
     return ids
       .filter { !$0.isEmpty }

--- a/Sources/Models/OCRResult.swift
+++ b/Sources/Models/OCRResult.swift
@@ -30,6 +30,10 @@ struct OCRResult: Equatable, Sendable {
     /// Pixel-measured foreground ink height, normalized to the captured image.
     /// Preferred over Vision box height when available.
     var horizontalInkScale: CGFloat = 0
+    /// Median center-to-center advance between source rows, normalized to the
+    /// captured image. This preserves the source's visual line-height rather
+    /// than inheriting the target font's usually tighter default leading.
+    var horizontalLineAdvanceScale: CGFloat = 0
     /// Paragraph membership supplied by Vision for this recognition pass.
     /// Used only while rebuilding wrapped rows; it is not a persistent id.
     var recognitionGroupID: Int? = nil
@@ -133,6 +137,9 @@ struct OCRResult: Equatable, Sendable {
       let weightedHorizontalInkScale = horizontalInkFragments.reduce(0) {
         $0 + $1.horizontalInkScale * CGFloat(max(1, $1.rowCount))
       } / CGFloat(max(1, horizontalInkRows))
+      let horizontalLineAdvanceScale = Self.horizontalLineAdvanceScale(
+        in: fragments.filter { !$0.isVerticalBlock }
+      )
       let appearance = Self.representativeAppearance(in: fragments)
       let groupIDs = Set(fragments.compactMap(\.recognitionGroupID))
       return (
@@ -145,6 +152,7 @@ struct OCRResult: Equatable, Sendable {
           verticalCharScale: weightedScale,
           horizontalGlyphScale: weightedHorizontalScale,
           horizontalInkScale: weightedHorizontalInkScale,
+          horizontalLineAdvanceScale: horizontalLineAdvanceScale,
           // Keep a stable representative after crossing a Vision paragraph
           // boundary. Dropping the id made a second coalescing pass treat the
           // merged block as ungrouped and absorb an adjacent title/body row.
@@ -405,6 +413,40 @@ struct OCRResult: Equatable, Sendable {
   }
 
   private static func horizontalVisualRowCount(_ lines: [Line]) -> Int {
+    horizontalVisualRows(lines).reduce(0) { total, row in
+      total + (row.map(\.rowCount).max() ?? 1)
+    }
+  }
+
+  private static func horizontalLineAdvanceScale(in lines: [Line]) -> CGFloat {
+    var advances = lines.flatMap { line -> [CGFloat] in
+      guard line.horizontalLineAdvanceScale > 0 else { return [] }
+      return Array(
+        repeating: line.horizontalLineAdvanceScale,
+        count: max(1, line.rowCount - 1)
+      )
+    }
+    let atomicRows = horizontalVisualRows(lines.filter { $0.rowCount == 1 })
+      .map { row in
+        row.dropFirst().reduce(row[0].boundingBoxNormalized.standardized) {
+          $0.union($1.boundingBoxNormalized.standardized)
+        }
+      }
+      .sorted { $0.midY < $1.midY }
+    advances.append(contentsOf: zip(atomicRows, atomicRows.dropFirst()).compactMap { previous, next in
+      let advance = next.midY - previous.midY
+      return advance > 0 ? advance : nil
+    })
+
+    guard !advances.isEmpty else { return 0 }
+    let sorted = advances.sorted()
+    let middle = sorted.count / 2
+    return sorted.count.isMultiple(of: 2)
+      ? (sorted[middle - 1] + sorted[middle]) / 2
+      : sorted[middle]
+  }
+
+  private static func horizontalVisualRows(_ lines: [Line]) -> [[Line]] {
     var rows = [[Line]]()
     for line in lines.sorted(by: { $0.boundingBoxNormalized.minY < $1.boundingBoxNormalized.minY }) {
       if
@@ -417,9 +459,7 @@ struct OCRResult: Equatable, Sendable {
         rows.append([line])
       }
     }
-    return rows.reduce(0) { total, row in
-      total + (row.map(\.rowCount).max() ?? 1)
-    }
+    return rows
   }
 
   private static func representativeAppearance(in lines: [Line]) -> OverlaySourceAppearance {
@@ -596,6 +636,14 @@ struct OCRResult: Equatable, Sendable {
     let a = lhs.boundingBoxNormalized.standardized
     let b = rhs.boundingBoxNormalized.standardized
     guard a.width > 0, a.height > 0, b.width > 0, b.height > 0 else { return false }
+    let lowerLine = a.minY <= b.minY ? rhs : lhs
+    // A list marker is a semantic paragraph boundary even when the neighboring
+    // item is multiline, shares the same appearance, and sits at ordinary CSS
+    // line spacing. Without this boundary, connected-component coalescing can
+    // link `item -> continuation -> next item` and translate an entire list as
+    // one oversized paragraph. The unmarked continuation is still free to join
+    // the item above it.
+    guard !beginsListItem(lowerLine.text) else { return false }
     let crossesVisionParagraphBoundary = lhs.recognitionGroupID != nil
       && rhs.recognitionGroupID != nil
       && lhs.recognitionGroupID != rhs.recognitionGroupID
@@ -677,6 +725,31 @@ struct OCRResult: Equatable, Sendable {
         || abs(a.maxX - b.maxX) <= alignmentTolerance
         || abs(a.midX - b.midX) <= alignmentTolerance
     }
+  }
+
+  private static func beginsListItem(_ text: String) -> Bool {
+    let trimmed = text.drop(while: \Character.isWhitespace)
+    guard let first = trimmed.first else { return false }
+
+    if "•◦▪▫‣⁃·".contains(first) {
+      return true
+    }
+
+    let tokens = trimmed.split(maxSplits: 1, whereSeparator: \Character.isWhitespace)
+    guard tokens.count == 2 else { return false }
+    let marker = tokens[0]
+    if ["-", "–", "—", "*", "+"].contains(String(marker)) {
+      return true
+    }
+
+    if marker.first == "(", marker.last == ")" {
+      let number = marker.dropFirst().dropLast()
+      return !number.isEmpty && number.count <= 4 && number.allSatisfy(\.isNumber)
+    }
+
+    guard marker.last == "." || marker.last == ")" else { return false }
+    let number = marker.dropLast()
+    return !number.isEmpty && number.count <= 4 && number.allSatisfy(\.isNumber)
   }
 
   private static func mergedAlignment(

--- a/Sources/Models/OCRResult.swift
+++ b/Sources/Models/OCRResult.swift
@@ -73,6 +73,7 @@ struct OCRResult: Equatable, Sendable {
   func coalescingParagraphFragments() -> OCRResult {
     guard lines.count > 1 else { return self }
 
+    let compactPeerIndices = Self.compactPeerFragmentIndices(in: lines)
     var visited = Array(repeating: false, count: lines.count)
     var groups = [[Int]]()
     for start in lines.indices where !visited[start] {
@@ -81,7 +82,15 @@ struct OCRResult: Equatable, Sendable {
       var group = [start]
       while let index = queue.popLast() {
         for candidate in lines.indices where !visited[candidate] {
-          guard Self.areAdjacentFragments(lines[index], lines[candidate]) else { continue }
+          let suppressesInlineMerge = compactPeerIndices.contains(index)
+            && compactPeerIndices.contains(candidate)
+          guard
+            Self.areAdjacentFragments(
+              lines[index],
+              lines[candidate],
+              suppressesInlineMerge: suppressesInlineMerge
+            )
+          else { continue }
           visited[candidate] = true
           queue.append(candidate)
           group.append(candidate)
@@ -278,7 +287,11 @@ struct OCRResult: Equatable, Sendable {
     } ?? candidates.max(by: { $0.confidence < $1.confidence })
   }
 
-  private static func areAdjacentFragments(_ lhs: Line, _ rhs: Line) -> Bool {
+  private static func areAdjacentFragments(
+    _ lhs: Line,
+    _ rhs: Line,
+    suppressesInlineMerge: Bool
+  ) -> Bool {
     switch (lhs.isVerticalBlock, rhs.isVerticalBlock) {
     case (true, true):
       areNeighboringVerticalColumns(lhs, rhs)
@@ -287,8 +300,67 @@ struct OCRResult: Equatable, Sendable {
     case (false, true):
       isShortVerticalContinuation(lhs, of: rhs)
     case (false, false):
-      areNeighboringHorizontalRows(lhs, rhs) || areNeighboringInlineFragments(lhs, rhs)
+      areNeighboringHorizontalRows(lhs, rhs)
+        || (!suppressesInlineMerge && areNeighboringInlineFragments(lhs, rhs))
     }
+  }
+
+  /// A run of compact peers (badges, segmented labels, or key/value pills) is
+  /// visual structure, not one sentence. Vision can assign every peer to one
+  /// recognition group, while surface analysis only finds some of the rounded
+  /// halves. Detect the whole row before graph coalescing so an undetected half
+  /// cannot bridge otherwise independent controls transitively.
+  private static func compactPeerFragmentIndices(in lines: [Line]) -> Set<Int> {
+    var rows = [[Int]]()
+    for index in lines.indices {
+      let line = lines[index]
+      guard !line.isVerticalBlock, line.rowCount == 1 else { continue }
+      if
+        let rowIndex = rows.lastIndex(where: { row in
+          row.contains { isOnSameVisualRow(line, lines[$0]) }
+        })
+      {
+        rows[rowIndex].append(index)
+      } else {
+        rows.append([index])
+      }
+    }
+
+    return Set(rows.filter { isCompactPeerRow($0, in: lines) }.flatMap { $0 })
+  }
+
+  private static func isCompactPeerRow(_ indices: [Int], in lines: [Line]) -> Bool {
+    guard indices.count >= 4 else { return false }
+    let fragments = indices.map { lines[$0] }
+    let boxes = fragments.map(\.boundingBoxNormalized).map(\.standardized)
+    guard
+      zip(fragments, boxes).allSatisfy({ fragment, box in
+        let text = fragment.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !text.isEmpty
+          && !text.contains("\n")
+          && text.count <= 24
+          && box.width > 0
+          && box.width <= 0.16
+          && box.height > 0
+      })
+    else { return false }
+
+    let ordered = indices.sorted {
+      lines[$0].boundingBoxNormalized.midX < lines[$1].boundingBoxNormalized.midX
+    }
+    let formsOneCompactRun = zip(ordered, ordered.dropFirst()).allSatisfy { lhs, rhs in
+      let a = lines[lhs].boundingBoxNormalized.standardized
+      let b = lines[rhs].boundingBoxNormalized.standardized
+      let gap = max(0, b.minX - a.maxX)
+      return gap <= max(a.height, b.height) * 0.8
+    }
+    guard formsOneCompactRun else { return false }
+
+    let compactSurfaceCount = fragments.count(where: hasCompactSurface)
+    let appearanceTransitions = zip(ordered, ordered.dropFirst()).count { lhs, rhs in
+      colorDistance(lines[lhs].appearance.background, lines[rhs].appearance.background) >= 0.12
+    }
+    return compactSurfaceCount >= 2 || appearanceTransitions >= 3
   }
 
   private static func mergedStyleRuns(

--- a/Sources/Models/OCRResult.swift
+++ b/Sources/Models/OCRResult.swift
@@ -4,6 +4,9 @@
 import Foundation
 
 struct OCRResult: Equatable, Sendable {
+
+  // MARK: Internal
+
   /// A single recognized line with its position on the captured frame.
   struct Line: Equatable, Sendable, Hashable {
     /// Top-left origin, 0–1 normalized to the captured frame.
@@ -20,11 +23,826 @@ struct OCRResult: Equatable, Sendable {
     /// normalized) — lets the renderer match the original font scale so titles
     /// stay large and annotations small, preserving the page's text hierarchy.
     var verticalCharScale: CGFloat = 0
+    /// Median Vision word-box height for horizontal text, normalized to the
+    /// captured image. Line boxes can include icons or control chrome (for
+    /// example "+ Add bypass") and substantially overstate the glyph size.
+    var horizontalGlyphScale: CGFloat = 0
+    /// Pixel-measured foreground ink height, normalized to the captured image.
+    /// Preferred over Vision box height when available.
+    var horizontalInkScale: CGFloat = 0
+    /// Paragraph membership supplied by Vision for this recognition pass.
+    /// Used only while rebuilding wrapped rows; it is not a persistent id.
+    var recognitionGroupID: Int? = nil
+    /// True after two or more Vision observations have been rebuilt into one
+    /// visual text region. Appearance analysis uses the union only in this
+    /// case, so an inline chip cannot become the paragraph's base style.
+    var wasCoalesced = false
+    /// Dominant local background and readable foreground sampled from the
+    /// original pixels, used to redraw the translation as an in-place replacement.
+    var appearance = OverlaySourceAppearance.fallback
+    /// Tighter Vision word/line regions that contain the source glyphs. The
+    /// paragraph box remains the layout anchor; only these patches are painted.
+    var replacementPatches = [OverlaySourcePatch]()
+    /// Vision word ranges retained separately from restoration patches. Patches
+    /// may be consolidated on a flat surface, while these runs must stay intact
+    /// for mixed foreground, weight, underline, and inline-code styling.
+    var styleRuns = [OverlaySourceStyleRun]()
+    /// Alignment inferred by Vision from the original paragraph.
+    var alignment: OverlayTextAlignment?
+    /// Pixel-inferred closed region that may safely contain replacement text.
+    var surface: OverlaySourceSurface?
   }
 
   var lines: [Line]
 
   var joinedText: String {
     lines.map(\.text).joined(separator: "\n")
+  }
+
+  /// Joins fragments that Vision occasionally returns as separate paragraphs
+  /// even though their boxes form one contiguous text block.
+  ///
+  /// The test is intentionally geometric and conservative. Vertical fragments
+  /// must be neighboring columns; horizontal fragments must be aligned rows
+  /// with matching line scale. Connected components join longer blocks without
+  /// widening either threshold.
+  func coalescingParagraphFragments() -> OCRResult {
+    guard lines.count > 1 else { return self }
+
+    var visited = Array(repeating: false, count: lines.count)
+    var groups = [[Int]]()
+    for start in lines.indices where !visited[start] {
+      visited[start] = true
+      var queue = [start]
+      var group = [start]
+      while let index = queue.popLast() {
+        for candidate in lines.indices where !visited[candidate] {
+          guard Self.areAdjacentFragments(lines[index], lines[candidate]) else { continue }
+          visited[candidate] = true
+          queue.append(candidate)
+          group.append(candidate)
+        }
+      }
+      groups.append(group.sorted())
+    }
+
+    let merged = groups.map { indices -> (firstIndex: Int, line: Line) in
+      guard indices.count > 1 else { return (indices[0], lines[indices[0]]) }
+      let fragments = indices.map { lines[$0] }
+      let isVertical = fragments.contains(where: \.isVerticalBlock)
+      let script = OverlayTextFlowResolver.scriptEvidence(
+        in: fragments.map(\.text).joined()
+      ).dominantScript
+      let ordered: [Line] =
+        if isVertical {
+          fragments.sorted { lhs, rhs in
+            if lhs.boundingBoxNormalized.midX == rhs.boundingBoxNormalized.midX {
+              return lhs.boundingBoxNormalized.minY < rhs.boundingBoxNormalized.minY
+            }
+            return script == "Mong"
+              ? lhs.boundingBoxNormalized.midX < rhs.boundingBoxNormalized.midX
+              : lhs.boundingBoxNormalized.midX > rhs.boundingBoxNormalized.midX
+          }
+        } else {
+          Self.orderedHorizontalFragments(fragments, script: script)
+        }
+      // Vision rows inside one paragraph are visual wraps, not semantic line
+      // breaks. Feeding them to Translation as newlines can turn a wrapped row
+      // into a new paragraph and add a blank line in the target. Preserve row
+      // count for layout, but reconstruct the sentence as continuous text.
+      let joined = Self.joinedTextAndSeparators(in: ordered, isVertical: isVertical, script: script)
+      let text = joined.text
+      let box = fragments.dropFirst().reduce(fragments[0].boundingBoxNormalized) {
+        $0.union($1.boundingBoxNormalized)
+      }
+      let totalRows = isVertical
+        ? fragments.reduce(0) { $0 + max(1, $1.rowCount) }
+        : Self.horizontalVisualRowCount(fragments)
+      let verticalFragments = fragments.filter { $0.verticalCharScale > 0 }
+      let verticalRows = verticalFragments.reduce(0) { $0 + max(1, $1.rowCount) }
+      let weightedScale = verticalFragments.reduce(0) {
+        $0 + $1.verticalCharScale * CGFloat(max(1, $1.rowCount))
+      } / CGFloat(max(1, verticalRows))
+      let horizontalFragments = fragments.filter { $0.horizontalGlyphScale > 0 }
+      let horizontalRows = horizontalFragments.reduce(0) { $0 + max(1, $1.rowCount) }
+      let weightedHorizontalScale = horizontalFragments.reduce(0) {
+        $0 + $1.horizontalGlyphScale * CGFloat(max(1, $1.rowCount))
+      } / CGFloat(max(1, horizontalRows))
+      let horizontalInkFragments = fragments.filter { $0.horizontalInkScale > 0 }
+      let horizontalInkRows = horizontalInkFragments.reduce(0) { $0 + max(1, $1.rowCount) }
+      let weightedHorizontalInkScale = horizontalInkFragments.reduce(0) {
+        $0 + $1.horizontalInkScale * CGFloat(max(1, $1.rowCount))
+      } / CGFloat(max(1, horizontalInkRows))
+      let appearance = Self.representativeAppearance(in: fragments)
+      let groupIDs = Set(fragments.compactMap(\.recognitionGroupID))
+      return (
+        indices[0],
+        Line(
+          boundingBoxNormalized: box,
+          text: text,
+          rowCount: totalRows,
+          isVerticalBlock: isVertical,
+          verticalCharScale: weightedScale,
+          horizontalGlyphScale: weightedHorizontalScale,
+          horizontalInkScale: weightedHorizontalInkScale,
+          // Keep a stable representative after crossing a Vision paragraph
+          // boundary. Dropping the id made a second coalescing pass treat the
+          // merged block as ungrouped and absorb an adjacent title/body row.
+          recognitionGroupID: groupIDs.min(),
+          wasCoalesced: true,
+          appearance: appearance,
+          replacementPatches: fragments.flatMap(\.replacementPatches),
+          styleRuns: Self.mergedStyleRuns(in: ordered, separators: joined.separators),
+          alignment: Self.mergedAlignment(for: ordered, isVertical: isVertical),
+          surface: Self.preferredSurface(containing: box, among: fragments)
+        )
+      )
+    }
+
+    return OCRResult(lines: merged.sorted { $0.firstIndex < $1.firstIndex }.map(\.line))
+  }
+
+  /// Removes nested observations emitted for the same pixels. Dense controls
+  /// can be reported once as a complete row ("Teams | Apps | Users") and again
+  /// as an inner word ("Apps"). Rendering both creates overlapping translations
+  /// even though each individual Vision observation is valid.
+  func removingNestedDuplicates() -> OCRResult {
+    guard lines.count > 1 else { return self }
+    let kept = lines.indices.filter { candidateIndex in
+      let candidate = lines[candidateIndex]
+      let candidateBox = candidate.boundingBoxNormalized.standardized
+      let candidateText = Self.comparableText(candidate.text)
+      guard !candidateBox.isEmpty, !candidateText.isEmpty else { return true }
+
+      return !lines.indices.contains { otherIndex in
+        guard otherIndex != candidateIndex else { return false }
+        let other = lines[otherIndex]
+        guard candidate.isVerticalBlock == other.isVerticalBlock else { return false }
+        let otherBox = other.boundingBoxNormalized.standardized
+        let intersection = candidateBox.intersection(otherBox)
+        guard
+          !intersection.isNull,
+          intersection.width * intersection.height
+          / max(0.000_001, candidateBox.width * candidateBox.height) >= 0.82
+        else { return false }
+
+        let otherText = Self.comparableText(other.text)
+        if otherText.count > candidateText.count, otherText.contains(candidateText) {
+          return true
+        }
+        guard otherText == candidateText else { return false }
+        let candidateArea = candidateBox.width * candidateBox.height
+        let otherArea = otherBox.width * otherBox.height
+        return otherArea < candidateArea || (abs(otherArea - candidateArea) < 0.000_001 && otherIndex < candidateIndex)
+      }
+    }
+    return OCRResult(lines: kept.map { lines[$0] })
+  }
+
+  /// Japanese ruby is sometimes emitted as a separate tiny horizontal line
+  /// immediately above its base ideographs. It is pronunciation metadata, not a
+  /// second sentence. Erase it with the base run while retaining the base glyph
+  /// scale and text so translation and layout happen exactly once.
+  func absorbingRubyAnnotations() -> OCRResult {
+    guard lines.count > 1 else { return self }
+    var result = lines
+    var removed = Set<Int>()
+
+    for rubyIndex in result.indices {
+      guard !removed.contains(rubyIndex), Self.isLikelyRuby(result[rubyIndex]) else { continue }
+      let ruby = result[rubyIndex]
+      let rubyBox = ruby.boundingBoxNormalized.standardized
+      let baseIndex = result.indices
+        .filter { $0 != rubyIndex && !removed.contains($0) }
+        .filter { Self.canBeRubyBase(result[$0], for: rubyBox) }
+        .min { lhs, rhs in
+          Self.rubyBaseDistance(result[lhs].boundingBoxNormalized, rubyBox)
+            < Self.rubyBaseDistance(result[rhs].boundingBoxNormalized, rubyBox)
+        }
+      guard let baseIndex else { continue }
+
+      var base = result[baseIndex]
+      let baseBox = base.boundingBoxNormalized.standardized
+      base.boundingBoxNormalized = baseBox.union(rubyBox)
+      base.replacementPatches.append(contentsOf: ruby.replacementPatches.isEmpty
+        ? [OverlaySourcePatch(box: rubyBox, appearance: ruby.appearance)]
+        : ruby.replacementPatches)
+      base.surface = Self.preferredSurface(
+        containing: base.boundingBoxNormalized,
+        among: [base, ruby]
+      ) ?? base.surface
+      result[baseIndex] = base
+      removed.insert(rubyIndex)
+    }
+
+    return OCRResult(lines: result.indices.compactMap { removed.contains($0) ? nil : result[$0] })
+  }
+
+  // MARK: Private
+
+  private struct AppearanceSample {
+    var appearance: OverlaySourceAppearance
+    var weight: CGFloat
+  }
+
+  private static func preferredSurface(
+    containing sourceBox: CGRect,
+    among fragments: [Line]
+  ) -> OverlaySourceSurface? {
+    let source = sourceBox.standardized
+    let sourceArea = max(0.000_001, source.width * source.height)
+    let candidates = fragments.compactMap(\.surface)
+    let enclosing = candidates.filter { surface in
+      let bounds = (surface.clippingBox ?? surface.box).standardized
+      let intersection = bounds.intersection(source)
+      guard !intersection.isNull, !intersection.isEmpty else { return false }
+      return intersection.width * intersection.height / sourceArea >= 0.94
+    }
+    return enclosing.min { lhs, rhs in
+      let lhsBounds = (lhs.clippingBox ?? lhs.box).standardized
+      let rhsBounds = (rhs.clippingBox ?? rhs.box).standardized
+      let lhsArea = lhsBounds.width * lhsBounds.height
+      let rhsArea = rhsBounds.width * rhsBounds.height
+      if abs(lhsArea - rhsArea) > sourceArea * 0.05 {
+        return lhsArea < rhsArea
+      }
+      return lhs.confidence > rhs.confidence
+    } ?? candidates.max(by: { $0.confidence < $1.confidence })
+  }
+
+  private static func areAdjacentFragments(_ lhs: Line, _ rhs: Line) -> Bool {
+    switch (lhs.isVerticalBlock, rhs.isVerticalBlock) {
+    case (true, true):
+      areNeighboringVerticalColumns(lhs, rhs)
+    case (true, false):
+      isShortVerticalContinuation(rhs, of: lhs)
+    case (false, true):
+      isShortVerticalContinuation(lhs, of: rhs)
+    case (false, false):
+      areNeighboringHorizontalRows(lhs, rhs) || areNeighboringInlineFragments(lhs, rhs)
+    }
+  }
+
+  private static func mergedStyleRuns(
+    in lines: [Line],
+    separators: [String]
+  ) -> [OverlaySourceStyleRun] {
+    var result = [OverlaySourceStyleRun]()
+    var utf16Offset = 0
+    for (index, line) in lines.enumerated() {
+      result.append(contentsOf: line.styleRuns.map { run in
+        var run = run
+        run.range.location += utf16Offset
+        return run
+      })
+      utf16Offset += line.text.utf16.count
+      if separators.indices.contains(index) {
+        utf16Offset += separators[index].utf16.count
+      }
+    }
+    return result
+  }
+
+  private static func joinedTextAndSeparators(
+    in lines: [Line],
+    isVertical: Bool,
+    script: String?
+  ) -> (text: String, separators: [String]) {
+    let texts = lines.map { $0.text.trimmingCharacters(in: .whitespacesAndNewlines) }
+    guard let first = texts.first else { return ("", []) }
+    var text = first
+    var separators = [String]()
+    for index in texts.indices.dropFirst() {
+      let separator = isVertical
+        ? (script == "Mong" ? " " : "")
+        : horizontalSeparator(
+          after: lines[index - 1],
+          before: lines[index],
+          nextText: texts[index],
+          among: lines
+        )
+      separators.append(separator)
+      text += separator + texts[index]
+    }
+    return (text, separators)
+  }
+
+  private static func horizontalSeparator(
+    after previous: Line,
+    before next: Line,
+    nextText: String,
+    among lines: [Line]
+  ) -> String {
+    if preservesSemanticLineBreak(after: previous, before: next, among: lines) {
+      return "\n"
+    }
+    let text = nextText
+    guard let first = text.first else { return " " }
+    let noLeadingSpace = CharacterSet(charactersIn: ",;:!?、。！？）」』】")
+    guard first.unicodeScalars.allSatisfy(noLeadingSpace.contains) else { return " " }
+    let next = text.index(after: text.startIndex)
+    return next == text.endIndex || text[next].isWhitespace ? "" : " "
+  }
+
+  /// Vision sometimes flattens an explicit `<br>` into ordinary wrapped rows.
+  /// A non-final row that ends a sentence despite having enough room for the
+  /// next token is a semantic break, not automatic wrapping. Preserve it for
+  /// Translation and Core Text so emphasis does not collapse two rows into one.
+  private static func preservesSemanticLineBreak(
+    after previous: Line,
+    before next: Line,
+    among lines: [Line]
+  ) -> Bool {
+    guard
+      !previous.isVerticalBlock,
+      !next.isVerticalBlock,
+      previous.alignment != .center,
+      previous.alignment != .trailing,
+      next.alignment != .center,
+      next.alignment != .trailing
+    else { return false }
+
+    let previousBox = previous.boundingBoxNormalized.standardized
+    let nextBox = next.boundingBoxNormalized.standardized
+    let boxes = lines.map(\.boundingBoxNormalized).map(\.standardized)
+    guard
+      previousBox.width > 0,
+      previousBox.height > 0,
+      nextBox.width > 0,
+      nextBox.height > 0,
+      let commonLeadingEdge = boxes.map(\.minX).sorted().dropFirst(boxes.count / 2).first,
+      let commonTrailingEdge = boxes.map(\.maxX).max()
+    else { return false }
+
+    let rowHeight = max(previousBox.height, nextBox.height)
+    let leadingTolerance = max(0.002, rowHeight * 0.8)
+    guard
+      abs(previousBox.minX - commonLeadingEdge) <= leadingTolerance,
+      abs(nextBox.minX - commonLeadingEdge) <= leadingTolerance
+    else { return false }
+
+    let columnWidth = commonTrailingEdge - commonLeadingEdge
+    let unusedTail = commonTrailingEdge - previousBox.maxX
+    guard columnWidth > 0, unusedTail / columnWidth >= 0.16 else { return false }
+
+    let nextTokenWidth = next.styleRuns
+      .min(by: { $0.range.location < $1.range.location })?
+      .box.width ?? min(nextBox.width, rowHeight * 4)
+    guard unusedTail >= max(nextTokenWidth * 1.45, rowHeight * 1.8) else { return false }
+
+    let trimmed = previous.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    let endsSentence = trimmed.last?.unicodeScalars.allSatisfy(
+      CharacterSet(charactersIn: ".!?:。！？：").contains
+    ) == true
+    let previousScale = previous.horizontalGlyphScale > 0
+      ? previous.horizontalGlyphScale
+      : previousBox.height / CGFloat(max(1, previous.rowCount))
+    let nextScale = next.horizontalGlyphScale > 0
+      ? next.horizontalGlyphScale
+      : nextBox.height / CGFloat(max(1, next.rowCount))
+    let scaleRatio = max(previousScale, nextScale) / max(0.000_001, min(previousScale, nextScale))
+    return endsSentence || scaleRatio >= 1.3
+  }
+
+  private static func horizontalVisualRowCount(_ lines: [Line]) -> Int {
+    var rows = [[Line]]()
+    for line in lines.sorted(by: { $0.boundingBoxNormalized.minY < $1.boundingBoxNormalized.minY }) {
+      if
+        let index = rows.lastIndex(where: { row in
+          row.contains { isOnSameVisualRow(line, $0) }
+        })
+      {
+        rows[index].append(line)
+      } else {
+        rows.append([line])
+      }
+    }
+    return rows.reduce(0) { total, row in
+      total + (row.map(\.rowCount).max() ?? 1)
+    }
+  }
+
+  private static func representativeAppearance(in lines: [Line]) -> OverlaySourceAppearance {
+    let containerLines = lines.filter { !hasCompactSurface($0) }
+    let sampledLines = containerLines.isEmpty ? lines : containerLines
+    let samples = sampledLines.flatMap { line -> [AppearanceSample] in
+      guard !line.styleRuns.isEmpty else {
+        return [AppearanceSample(
+          appearance: line.appearance,
+          weight: CGFloat(max(1, line.text.utf16.count))
+        )]
+      }
+      return line.styleRuns.map {
+        AppearanceSample(
+          appearance: $0.appearance,
+          weight: CGFloat(max(1, $0.range.length))
+        )
+      }
+    }
+    guard
+      let best = samples.max(by: { lhs, rhs in
+        let lhsScore = appearanceClusterScore(for: lhs, among: samples)
+        let rhsScore = appearanceClusterScore(for: rhs, among: samples)
+        if lhsScore == rhsScore {
+          return lhs.appearance.confidence < rhs.appearance.confidence
+        }
+        return lhsScore < rhsScore
+      })
+    else { return .fallback }
+    return best.appearance
+  }
+
+  private static func hasCompactSurface(_ line: Line) -> Bool {
+    guard let surface = line.surface else { return false }
+    let source = line.boundingBoxNormalized.standardized
+    let bounds = (surface.clippingBox ?? surface.box).standardized
+    guard bounds.contains(CGPoint(x: source.midX, y: source.midY)) else { return false }
+    return bounds.width <= source.width * 2.2
+      && bounds.height <= source.height * 3
+  }
+
+  private static func appearanceClusterScore(
+    for candidate: AppearanceSample,
+    among samples: [AppearanceSample]
+  ) -> CGFloat {
+    samples.reduce(0) { score, sample in
+      guard
+        colorDistance(candidate.appearance.background, sample.appearance.background) <= 0.06,
+        colorDistance(candidate.appearance.foreground, sample.appearance.foreground) <= 0.15
+      else { return score }
+      return score + sample.weight
+    }
+  }
+
+  private static func comparableText(_ text: String) -> String {
+    text.lowercased().unicodeScalars
+      .filter { CharacterSet.alphanumerics.contains($0) }
+      .map(String.init)
+      .joined()
+  }
+
+  private static func areNeighboringVerticalColumns(_ lhs: Line, _ rhs: Line) -> Bool {
+    let a = lhs.boundingBoxNormalized.standardized
+    let b = rhs.boundingBoxNormalized.standardized
+    guard a.width > 0, a.height > 0, b.width > 0, b.height > 0 else { return false }
+
+    let minimumWidth = min(a.width, b.width)
+    let horizontalOverlap = max(0, min(a.maxX, b.maxX) - max(a.minX, b.minX))
+    guard horizontalOverlap <= minimumWidth * 0.15 else { return false }
+
+    let horizontalGap = max(0, max(a.minX, b.minX) - min(a.maxX, b.maxX))
+    let sameRecognitionGroup = lhs.recognitionGroupID != nil
+      && lhs.recognitionGroupID == rhs.recognitionGroupID
+    let knownSharedSurface = sharesSourceSurface(lhs, rhs)
+    let gapScale: CGFloat = sameRecognitionGroup || knownSharedSurface ? 0.75 : 0.25
+    guard horizontalGap <= minimumWidth * gapScale else { return false }
+
+    let verticalOverlap = max(0, min(a.maxY, b.maxY) - max(a.minY, b.minY))
+    guard verticalOverlap / min(a.height, b.height) >= 0.7 else { return false }
+
+    let scales = [lhs.verticalCharScale, rhs.verticalCharScale].filter { $0 > 0 }
+    guard scales.count < 2 || scales.min()! / scales.max()! >= 0.65 else { return false }
+    return true
+  }
+
+  private static func orderedHorizontalFragments(_ fragments: [Line], script: String?) -> [Line] {
+    let topToBottom = fragments.sorted {
+      let lhs = $0.boundingBoxNormalized.standardized
+      let rhs = $1.boundingBoxNormalized.standardized
+      if lhs.minY == rhs.minY { return lhs.minX < rhs.minX }
+      return lhs.minY < rhs.minY
+    }
+    var rows = [[Line]]()
+    for fragment in topToBottom {
+      if
+        let index = rows.lastIndex(where: { row in
+          row.contains { isOnSameVisualRow(fragment, $0) }
+        })
+      {
+        rows[index].append(fragment)
+      } else {
+        rows.append([fragment])
+      }
+    }
+    return rows.flatMap { row in
+      row.sorted {
+        let lhs = $0.boundingBoxNormalized.standardized
+        let rhs = $1.boundingBoxNormalized.standardized
+        return script == "Arab" ? lhs.midX > rhs.midX : lhs.midX < rhs.midX
+      }
+    }
+  }
+
+  private static func isOnSameVisualRow(_ lhs: Line, _ rhs: Line) -> Bool {
+    let a = lhs.boundingBoxNormalized.standardized
+    let b = rhs.boundingBoxNormalized.standardized
+    guard a.height > 0, b.height > 0 else { return false }
+    let verticalOverlap = max(0, min(a.maxY, b.maxY) - max(a.minY, b.minY))
+    return verticalOverlap / min(a.height, b.height) >= 0.55
+  }
+
+  private static func areNeighboringInlineFragments(_ lhs: Line, _ rhs: Line) -> Bool {
+    guard lhs.rowCount == 1, rhs.rowCount == 1 else { return false }
+    let a = lhs.boundingBoxNormalized.standardized
+    let b = rhs.boundingBoxNormalized.standardized
+    guard a.width > 0, a.height > 0, b.width > 0, b.height > 0 else { return false }
+    let verticalOverlap = max(0, min(a.maxY, b.maxY) - max(a.minY, b.minY))
+    guard verticalOverlap / min(a.height, b.height) >= 0.65 else { return false }
+    guard min(a.height, b.height) / max(a.height, b.height) >= 0.6 else { return false }
+
+    let minimumWidth = min(a.width, b.width)
+    let horizontalOverlap = max(0, min(a.maxX, b.maxX) - max(a.minX, b.minX))
+    guard horizontalOverlap <= minimumWidth * 0.15 else { return false }
+    let horizontalGap = max(0, max(a.minX, b.minX) - min(a.maxX, b.maxX))
+    guard horizontalGap <= max(a.height, b.height) * 0.6 else { return false }
+
+    if lhs.surface != nil, rhs.surface != nil, !sharesSourceSurface(lhs, rhs) {
+      return false
+    }
+    return true
+  }
+
+  private static func isShortVerticalContinuation(_ fragment: Line, of vertical: Line) -> Bool {
+    guard !fragment.isVerticalBlock, vertical.isVerticalBlock, fragment.text.count <= 3 else { return false }
+    let evidence = OverlayTextFlowResolver.scriptEvidence(in: fragment.text)
+    let punctuationOnly = fragment.text.unicodeScalars.allSatisfy {
+      CharacterSet.punctuationCharacters.contains($0) || CharacterSet.symbols.contains($0)
+    }
+    guard evidence.verticalCharacterCount > 0 || punctuationOnly else { return false }
+
+    let shortBox = fragment.boundingBoxNormalized.standardized
+    let verticalBox = vertical.boundingBoxNormalized.standardized
+    guard shortBox.height <= verticalBox.height * 0.4 else { return false }
+    if sharesSourceSurface(fragment, vertical) {
+      let horizontalGap = max(
+        0,
+        max(shortBox.minX, verticalBox.minX) - min(shortBox.maxX, verticalBox.maxX)
+      )
+      let verticalOverlap = max(
+        0,
+        min(shortBox.maxY, verticalBox.maxY) - max(shortBox.minY, verticalBox.minY)
+      )
+      if
+        horizontalGap <= min(shortBox.width, verticalBox.width) * 0.75,
+        verticalOverlap / min(shortBox.height, verticalBox.height) >= 0.7
+      {
+        return true
+      }
+    }
+    return areSideBySide(shortBox, verticalBox, requiredVerticalOverlap: 0.7)
+  }
+
+  private static func areNeighboringHorizontalRows(_ lhs: Line, _ rhs: Line) -> Bool {
+    let a = lhs.boundingBoxNormalized.standardized
+    let b = rhs.boundingBoxNormalized.standardized
+    guard a.width > 0, a.height > 0, b.width > 0, b.height > 0 else { return false }
+    let crossesVisionParagraphBoundary = lhs.recognitionGroupID != nil
+      && rhs.recognitionGroupID != nil
+      && lhs.recognitionGroupID != rhs.recognitionGroupID
+    if hasMaterialTypographyBreak(lhs, rhs), !isLowContrastBodyWeightNoise(lhs, rhs) {
+      return false
+    }
+    let hasContinuousBodyAppearance = hasCompatibleBodyAppearance(lhs, rhs)
+    let continuesAcrossParagraphBoundary = crossesVisionParagraphBoundary
+      && sharesSourceSurface(lhs, rhs)
+      && (hasCompatibleAppearance(lhs, rhs) || hasContinuousBodyAppearance)
+
+    let horizontalOverlap = max(0, min(a.maxX, b.maxX) - max(a.minX, b.minX))
+    guard horizontalOverlap / min(a.width, b.width) >= 0.78 else { return false }
+
+    let rowHeightA = a.height / CGFloat(max(1, lhs.rowCount))
+    let rowHeightB = b.height / CGFloat(max(1, rhs.rowCount))
+    guard min(rowHeightA, rowHeightB) / max(rowHeightA, rowHeightB) >= 0.62 else { return false }
+    // Apple can split one continuous card-body paragraph into several
+    // document paragraphs even when no closed source surface is detectable.
+    // Rejoin only established multiline body copy on the same visual edge;
+    // keeping single-row fragments excluded protects table rows and adjacent
+    // labels that merely share typography.
+    let edgeTolerance = max(rowHeightA, rowHeightB) * 0.6
+    let sharesTextColumn = abs(a.minX - b.minX) <= edgeTolerance
+      || (lhs.alignment == .center
+        && rhs.alignment == .center
+        && abs(a.midX - b.midX) <= edgeTolerance)
+    let continuesUnsurfacedBodyBlock = crossesVisionParagraphBoundary
+      && lhs.surface == nil
+      && rhs.surface == nil
+      && max(lhs.rowCount, rhs.rowCount) > 1
+      && sharesTextColumn
+      && (hasCompatibleAppearance(lhs, rhs) || hasContinuousBodyAppearance)
+
+    if crossesVisionParagraphBoundary {
+      // Different paragraph IDs normally represent real structure. Keep
+      // overlapping manga fragments together, and also continue web body rows
+      // when pixel analysis says they occupy the same surface with the same
+      // foreground/background treatment.
+      let verticalOverlap = max(0, min(a.maxY, b.maxY) - max(a.minY, b.minY))
+      guard
+        verticalOverlap / min(rowHeightA, rowHeightB) >= 0.04
+        || continuesAcrossParagraphBoundary
+        || continuesUnsurfacedBodyBlock
+      else { return false }
+    }
+
+    let verticalGap = max(0, max(a.minY, b.minY) - min(a.maxY, b.maxY))
+    // Vision's line boxes hug visible glyphs, so ascenders/descenders make the
+    // apparent inter-row gap vary even when CSS line-height is constant. A
+    // little over half a row still joins wrapped body copy, while the much
+    // larger title-to-body spacing remains separate.
+    let gapScale: CGFloat =
+      switch (lhs.recognitionGroupID, rhs.recognitionGroupID) {
+      case (.some(let lhs), .some(let rhs)) where lhs == rhs: 1.15
+      case _ where continuesAcrossParagraphBoundary || continuesUnsurfacedBodyBlock: 1
+      default: 0.55
+      }
+    guard verticalGap <= min(rowHeightA, rowHeightB) * gapScale else { return false }
+    if continuesAcrossParagraphBoundary || continuesUnsurfacedBodyBlock { return true }
+    let alignmentTolerance = edgeTolerance
+    switch (lhs.alignment, rhs.alignment) {
+    case (.leading?, .leading?):
+      return abs(a.minX - b.minX) <= alignmentTolerance
+
+    case (.trailing?, .trailing?):
+      return abs(a.maxX - b.maxX) <= alignmentTolerance
+
+    case (.center?, .center?):
+      // Vision often labels a paragraph centered even when its wrapped rows
+      // share a leading edge. Trust the actual row geometry so a shorter final
+      // row is not detached from the preceding lines.
+      return abs(a.midX - b.midX) <= alignmentTolerance
+        || abs(a.minX - b.minX) <= alignmentTolerance
+        || abs(a.maxX - b.maxX) <= alignmentTolerance
+
+    default:
+      return abs(a.minX - b.minX) <= alignmentTolerance
+        || abs(a.maxX - b.maxX) <= alignmentTolerance
+        || abs(a.midX - b.midX) <= alignmentTolerance
+    }
+  }
+
+  private static func mergedAlignment(
+    for lines: [Line],
+    isVertical: Bool
+  ) -> OverlayTextAlignment? {
+    let fallback = lines.compactMap(\.alignment).first
+    guard !isVertical, lines.count > 1 else { return fallback }
+    let boxes = lines.map(\.boundingBoxNormalized).map(\.standardized)
+    let rowScale = boxes.map(\.height).sorted()[boxes.count / 2]
+    let candidates: [(alignment: OverlayTextAlignment, spread: CGFloat)] = [
+      (.leading, spread(boxes.map(\.minX))),
+      (.center, spread(boxes.map(\.midX))),
+      (.trailing, spread(boxes.map(\.maxX))),
+    ].sorted { $0.spread < $1.spread }
+    guard let best = candidates.first else { return fallback }
+    let tolerance = max(0.001, rowScale * 0.4)
+    guard best.spread <= tolerance else { return fallback }
+    if candidates.count > 1, best.spread + tolerance * 0.15 >= candidates[1].spread {
+      return fallback
+    }
+    return best.alignment
+  }
+
+  private static func spread(_ values: [CGFloat]) -> CGFloat {
+    guard let minimum = values.min(), let maximum = values.max() else { return .greatestFiniteMagnitude }
+    return maximum - minimum
+  }
+
+  private static func sharesSourceSurface(_ lhs: Line, _ rhs: Line) -> Bool {
+    guard let lhs = lhs.surface?.box.standardized, let rhs = rhs.surface?.box.standardized else {
+      return false
+    }
+    let intersection = lhs.intersection(rhs)
+    guard !intersection.isNull, !intersection.isEmpty else { return false }
+    let intersectionArea = intersection.width * intersection.height
+    let minimumArea = min(lhs.width * lhs.height, rhs.width * rhs.height)
+    return intersectionArea / max(0.000_001, minimumArea) >= 0.85
+  }
+
+  private static func hasCompatibleAppearance(_ lhs: Line, _ rhs: Line) -> Bool {
+    let lhs = lhs.appearance
+    let rhs = rhs.appearance
+    guard
+      lhs.confidence >= 0.2,
+      rhs.confidence >= 0.2,
+      lhs.foregroundConfidence >= 0.05,
+      rhs.foregroundConfidence >= 0.05
+    else { return false }
+    return colorDistance(lhs.background, rhs.background) <= 0.06
+      && colorDistance(lhs.foreground, rhs.foreground) <= 0.12
+      && lhs.fontDesign == rhs.fontDesign
+  }
+
+  private static func hasCompatibleBodyAppearance(_ lhs: Line, _ rhs: Line) -> Bool {
+    guard isBodyCopy(lhs), isBodyCopy(rhs) else { return false }
+    return colorDistance(lhs.appearance.background, rhs.appearance.background) <= 0.08
+      && colorDistance(lhs.appearance.foreground, rhs.appearance.foreground) <= 0.18
+      && lhs.appearance.fontDesign == rhs.appearance.fontDesign
+  }
+
+  private static func hasMaterialTypographyBreak(_ lhs: Line, _ rhs: Line) -> Bool {
+    let lhsAppearance = lhs.appearance
+    let rhsAppearance = rhs.appearance
+    guard lhsAppearance.confidence >= 0.2, rhsAppearance.confidence >= 0.2 else {
+      return false
+    }
+    if colorDistance(lhsAppearance.background, rhsAppearance.background) > 0.08 { return true }
+    if colorDistance(lhsAppearance.foreground, rhsAppearance.foreground) > 0.25 { return true }
+    if lhsAppearance.fontDesign != rhsAppearance.fontDesign { return true }
+
+    let weightDifference = abs(lhsAppearance.fontWeight.rawValue - rhsAppearance.fontWeight.rawValue)
+    if
+      lhsAppearance.foregroundConfidence >= 0.05,
+      rhsAppearance.foregroundConfidence >= 0.05,
+      weightDifference >= 2
+    {
+      return true
+    }
+    // A compact semibold heading and low-contrast body can share Vision's
+    // paragraph id and nearly identical glyph height. The confidence step is
+    // the reliable boundary; low-confidence body rows still tolerate the same
+    // one-weight sampling jitter through isLowContrastBodyWeightNoise.
+    return weightDifference >= 1
+      && max(lhsAppearance.foregroundConfidence, rhsAppearance.foregroundConfidence) >= 0.45
+      && abs(lhsAppearance.foregroundConfidence - rhsAppearance.foregroundConfidence) >= 0.25
+  }
+
+  private static func isLowContrastBodyWeightNoise(_ lhs: Line, _ rhs: Line) -> Bool {
+    hasCompatibleBodyAppearance(lhs, rhs)
+  }
+
+  private static func isBodyCopy(_ line: Line) -> Bool {
+    line.appearance.confidence >= 0.2
+      && line.appearance.foregroundConfidence >= 0.02
+      && line.appearance.foregroundConfidence <= 0.3
+      && line.appearance.fontWeight != .bold
+  }
+
+  private static func isLikelyRuby(_ line: Line) -> Bool {
+    guard !line.isVerticalBlock else { return false }
+    let scalars = line.text.unicodeScalars.filter {
+      !CharacterSet.whitespacesAndNewlines.contains($0)
+    }
+    guard !scalars.isEmpty, scalars.count <= 24 else { return false }
+    let kanaCount = scalars.count(where: isKana)
+    let nonPunctuationCount = scalars.count {
+      !CharacterSet.punctuationCharacters.contains($0)
+        && !CharacterSet.symbols.contains($0)
+    }
+    return kanaCount > 0 && kanaCount * 4 >= max(1, nonPunctuationCount) * 3
+  }
+
+  private static func canBeRubyBase(_ line: Line, for rubyBox: CGRect) -> Bool {
+    guard !line.isVerticalBlock, line.text.unicodeScalars.contains(where: isHan) else { return false }
+    let base = line.boundingBoxNormalized.standardized
+    guard rubyBox.height <= base.height * 0.7, rubyBox.midY <= base.midY else { return false }
+    let overlap = max(0, min(rubyBox.maxX, base.maxX) - max(rubyBox.minX, base.minX))
+    guard overlap / max(0.000_001, rubyBox.width) >= 0.7 else { return false }
+    let verticalGap = max(0, base.minY - rubyBox.maxY)
+    return verticalGap <= max(rubyBox.height, base.height * 0.25)
+  }
+
+  private static func rubyBaseDistance(_ base: CGRect, _ ruby: CGRect) -> CGFloat {
+    let base = base.standardized
+    return abs(base.midX - ruby.midX) + max(0, base.minY - ruby.maxY)
+  }
+
+  private static func isKana(_ scalar: Unicode.Scalar) -> Bool {
+    switch scalar.value {
+    case 0x3040 ... 0x30FF,
+         0x31F0 ... 0x31FF:
+      true
+    default:
+      false
+    }
+  }
+
+  private static func isHan(_ scalar: Unicode.Scalar) -> Bool {
+    switch scalar.value {
+    case 0x3400 ... 0x4DBF,
+         0x4E00 ... 0x9FFF,
+         0xF900 ... 0xFAFF,
+         0x20000 ... 0x2FA1F:
+      true
+    default:
+      false
+    }
+  }
+
+  private static func colorDistance(_ lhs: OverlayColor, _ rhs: OverlayColor) -> CGFloat {
+    max(abs(lhs.red - rhs.red), abs(lhs.green - rhs.green), abs(lhs.blue - rhs.blue))
+  }
+
+  private static func areSideBySide(
+    _ lhs: CGRect,
+    _ rhs: CGRect,
+    requiredVerticalOverlap: CGFloat
+  ) -> Bool {
+    guard lhs.width > 0, lhs.height > 0, rhs.width > 0, rhs.height > 0 else { return false }
+    let minimumWidth = min(lhs.width, rhs.width)
+    let horizontalOverlap = max(0, min(lhs.maxX, rhs.maxX) - max(lhs.minX, rhs.minX))
+    guard horizontalOverlap <= minimumWidth * 0.15 else { return false }
+    let horizontalGap = max(0, max(lhs.minX, rhs.minX) - min(lhs.maxX, rhs.maxX))
+    guard horizontalGap <= minimumWidth * 0.25 else { return false }
+    let verticalOverlap = max(0, min(lhs.maxY, rhs.maxY) - max(lhs.minY, rhs.minY))
+    return verticalOverlap / min(lhs.height, rhs.height) >= requiredVerticalOverlap
   }
 }

--- a/Sources/Models/OverlayLine.swift
+++ b/Sources/Models/OverlayLine.swift
@@ -4,24 +4,609 @@
 import CoreGraphics
 import Foundation
 
-/// A recognized line together with whatever translation is currently known.
-/// `translated == nil` means the line is still in flight. `box` is top-left
-/// origin, 0–1 normalized to the captured frame.
+// MARK: - OverlaySourceLayout
+
+enum OverlaySourceLayout: Equatable, Sendable {
+  case horizontal(rows: Int)
+  case vertical(characterScale: CGFloat, progression: OverlayColumnProgression)
+}
+
+// MARK: - OverlayLine
+
+/// A recognized source region and the explicit state of the text drawn over it.
+/// Geometry belongs to the source; writing flow belongs to the displayed text.
+/// Keeping those contracts separate prevents pending and failed translations
+/// from being mistaken for completed target-language output.
 struct OverlayLine: Equatable, Identifiable, Sendable {
+
+  // MARK: Lifecycle
+
+  init(id: UUID, source: Source, initialContent: InitialContent = .source) {
+    self.id = id
+    self.source = source
+    content = initialContent == .pending ? .pending : .source
+  }
+
+  // MARK: Internal
+
+  struct Source: Equatable, Sendable {
+
+    // MARK: Lifecycle
+
+    init(recognized line: OCRResult.Line, language: Locale.Language) {
+      box = line.boundingBoxNormalized
+      text = line.text
+      self.language = language
+      appearance = line.appearance
+      horizontalGlyphScale = line.horizontalGlyphScale
+      horizontalInkScale = line.horizontalInkScale
+      replacementPatches = line.replacementPatches.isEmpty
+        ? [OverlaySourcePatch(box: line.boundingBoxNormalized, appearance: line.appearance)]
+        : line.replacementPatches
+      styleRuns = line.styleRuns
+      alignment = line.alignment
+      surface = line.surface
+      if line.isVerticalBlock {
+        layout = .vertical(
+          characterScale: max(0, line.verticalCharScale),
+          progression: OverlayTextFlowResolver.columnProgression(for: language)
+        )
+      } else {
+        layout = .horizontal(rows: max(1, line.rowCount))
+      }
+    }
+
+    // MARK: Internal
+
+    /// Top-left origin, 0–1 normalized to the captured frame.
+    var box: CGRect
+    var text: String
+    var language: Locale.Language
+    var layout: OverlaySourceLayout
+    var appearance: OverlaySourceAppearance
+    var horizontalGlyphScale: CGFloat
+    var horizontalInkScale: CGFloat
+    var replacementPatches: [OverlaySourcePatch]
+    var styleRuns: [OverlaySourceStyleRun]
+    var alignment: OverlayTextAlignment?
+    var surface: OverlaySourceSurface?
+
+    /// Code-only labels are semantic literals, not natural-language copy. Keep
+    /// their original pixels untouched so paths/keys retain exact spelling,
+    /// monospace metrics, and native rounded backgrounds while also avoiding a
+    /// needless translation request.
+    var isProtectedLiteral: Bool {
+      guard case .horizontal = layout, appearance.fontDesign == .monospaced else { return false }
+      let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+      let words = text.split(whereSeparator: \.isWhitespace)
+      guard !text.isEmpty, words.count <= 3 else { return false }
+      let compact = String(text.filter { !$0.isWhitespace })
+      return compact.hasPrefix(".")
+        || compact.hasSuffix(":")
+        || compact.contains("/")
+        || compact.contains("*")
+        || compact.contains("=")
+    }
+
+    /// Compact rows beginning with a colored bullet are visual metadata (for
+    /// example GitHub's repository language and counts), not prose. Keeping the
+    /// source pixels preserves the marker color, icon spacing, and exact numerals.
+    var isProtectedVisualMetadata: Bool {
+      guard case .horizontal = layout else { return false }
+      let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard text.count <= 48 else { return false }
+      guard let marker = ["•", "●", "◉", "∙"].first(where: { text.hasPrefix($0) }) else {
+        return false
+      }
+      let value = text.dropFirst(marker.count).trimmingCharacters(in: .whitespacesAndNewlines)
+      let words = value.split(whereSeparator: \.isWhitespace)
+      guard !words.isEmpty, words.count <= 4 else { return false }
+      if words.count == 1 { return true }
+      return value.unicodeScalars.contains(where: CharacterSet.decimalDigits.contains)
+    }
+
+    /// Removes sub-pixel Vision noise without pinning text that genuinely moved.
+    /// A live capture is normally the same static pixels every tick, but Vision's
+    /// boxes can wander by a few capture pixels and make the replacement visibly
+    /// breathe. Small changes use a dead band, moderate changes are damped, and
+    /// a real layout/scroll jump is accepted immediately.
+    func stabilized(relativeTo previous: Self, imageSize: CGSize) -> Self {
+      guard
+        text == previous.text,
+        language.maximalIdentifier == previous.language.maximalIdentifier,
+        Self.hasSameOrientation(layout, previous.layout),
+        imageSize.width > 0,
+        imageSize.height > 0,
+        Self.maximumEdgeDelta(box, previous.box, imageSize: imageSize) <= 24
+      else { return self }
+
+      var result = self
+      result.box = Self.stabilizedRect(box, previous.box, imageSize: imageSize)
+      result.layout = previous.layout
+      result.horizontalGlyphScale = previous.horizontalGlyphScale
+      result.horizontalInkScale = previous.horizontalInkScale
+      result.alignment = previous.alignment ?? alignment
+      result.replacementPatches = Self.stabilizedPatches(
+        replacementPatches,
+        previous.replacementPatches,
+        imageSize: imageSize
+      )
+      result.styleRuns = Self.stabilizedStyleRuns(
+        styleRuns,
+        previous.styleRuns,
+        imageSize: imageSize
+      )
+
+      // Ink coverage sits close to the weight thresholds on anti-aliased UI
+      // fonts. Keep the established weight while the sampled colors still
+      // describe the same source style, but retain the current colors so a real
+      // hover/theme/background change is restored accurately.
+      if
+        Self.colorDistance(appearance.background, previous.appearance.background) <= 0.04,
+        Self.colorDistance(appearance.foreground, previous.appearance.foreground) <= 0.08
+      {
+        result.appearance.fontWeight = previous.appearance.fontWeight
+      }
+
+      let backgroundMatchesPrevious = Self.colorDistance(
+        appearance.background,
+        previous.appearance.background
+      ) <= 0.04
+      switch (surface, previous.surface) {
+      case (.some(var current), .some(let previousSurface)):
+        current.box = Self.stabilizedRect(current.box, previousSurface.box, imageSize: imageSize)
+        result.surface = current
+
+      case (.none, .some(let previousSurface)) where backgroundMatchesPrevious:
+        result.surface = previousSurface
+
+      default:
+        break
+      }
+      return result
+    }
+
+    /// Apple Translation 26.4+ aligns link metadata from source ranges to the
+    /// corresponding target words. Private links carry only a style-run index;
+    /// they are removed before rendering and are never exposed as real links.
+    func attributedTextForTranslation() -> AttributedString? {
+      guard !text.isEmpty, !styleRuns.isEmpty else { return nil }
+      var attributed = AttributedString(text)
+      var spans = [AttributedStyleSpan]()
+      for (index, run) in styleRuns.enumerated() {
+        guard Self.isMateriallyDifferent(run.appearance, from: appearance) else { continue }
+        guard !Self.isBoundaryPunctuationBleed(run, in: text) else { continue }
+        guard
+          let stringRange = Range(run.range, in: text),
+          Self.shouldCarryStyle(String(text[stringRange]), appearance: run.appearance, base: appearance)
+        else { continue }
+        let next = AttributedStyleSpan(
+          index: index,
+          range: run.range,
+          box: run.box,
+          appearance: run.appearance
+        )
+        if
+          let previous = spans.last,
+          Self.canCoalesce(previous, with: next, in: text)
+        {
+          spans[spans.count - 1].range = NSUnionRange(previous.range, next.range)
+          spans[spans.count - 1].box = previous.box.union(next.box)
+          if
+            previous.appearance.fontDesign != .monospaced,
+            next.appearance.fontDesign == .monospaced
+          {
+            spans[spans.count - 1].index = index
+            spans[spans.count - 1].appearance = next.appearance
+          }
+        } else {
+          spans.append(next)
+        }
+      }
+      for span in spans {
+        guard
+          let stringRange = Range(span.range, in: text),
+          let lowerBound = AttributedString.Index(stringRange.lowerBound, within: attributed),
+          let upperBound = AttributedString.Index(stringRange.upperBound, within: attributed),
+          let link = URL(string: "\(Self.styleLinkScheme)://run/\(span.index)")
+        else { continue }
+        attributed[lowerBound ..< upperBound].link = link
+      }
+      return spans.isEmpty ? nil : attributed
+    }
+
+    // MARK: Fileprivate
+
+    fileprivate static let styleLinkScheme = "swiftycrow-style"
+
+    // MARK: Private
+
+    private struct AttributedStyleSpan {
+      var index: Int
+      var range: NSRange
+      var box: CGRect
+      var appearance: OverlaySourceAppearance
+    }
+
+    private static func hasSameOrientation(_ lhs: OverlaySourceLayout, _ rhs: OverlaySourceLayout) -> Bool {
+      switch (lhs, rhs) {
+      case (.horizontal, .horizontal),
+           (.vertical, .vertical): true
+      default: false
+      }
+    }
+
+    private static func stabilizedPatches(
+      _ current: [OverlaySourcePatch],
+      _ previous: [OverlaySourcePatch],
+      imageSize: CGSize
+    ) -> [OverlaySourcePatch] {
+      guard current.count == previous.count else { return current }
+      var remaining = Array(previous.indices)
+      return current.map { patch in
+        guard
+          let match = remaining.min(by: {
+            centerDistance(patch.box, previous[$0].box, imageSize: imageSize)
+              < centerDistance(patch.box, previous[$1].box, imageSize: imageSize)
+          })
+        else { return patch }
+        remaining.removeAll { $0 == match }
+        var patch = patch
+        patch.box = stabilizedRect(patch.box, previous[match].box, imageSize: imageSize)
+        return patch
+      }
+    }
+
+    private static func stabilizedStyleRuns(
+      _ current: [OverlaySourceStyleRun],
+      _ previous: [OverlaySourceStyleRun],
+      imageSize: CGSize
+    ) -> [OverlaySourceStyleRun] {
+      current.map { run in
+        guard let previous = previous.first(where: { $0.range == run.range }) else { return run }
+        var result = run
+        result.box = stabilizedRect(run.box, previous.box, imageSize: imageSize)
+        if
+          colorDistance(run.appearance.background, previous.appearance.background) <= 0.04,
+          colorDistance(run.appearance.foreground, previous.appearance.foreground) <= 0.08
+        {
+          result.appearance.fontWeight = previous.appearance.fontWeight
+          result.appearance.fontDesign = previous.appearance.fontDesign
+          result.appearance.isUnderlined = previous.appearance.isUnderlined
+        }
+        return result
+      }
+    }
+
+    private static func stabilizedRect(_ current: CGRect, _ previous: CGRect, imageSize: CGSize) -> CGRect {
+      let delta = maximumEdgeDelta(current, previous, imageSize: imageSize)
+      guard delta <= 24 else { return current }
+      guard delta > 4 else { return previous }
+      let currentWeight: CGFloat = 0.35
+      return CGRect(
+        x: previous.minX + (current.minX - previous.minX) * currentWeight,
+        y: previous.minY + (current.minY - previous.minY) * currentWeight,
+        width: previous.width + (current.width - previous.width) * currentWeight,
+        height: previous.height + (current.height - previous.height) * currentWeight
+      )
+    }
+
+    private static func maximumEdgeDelta(_ lhs: CGRect, _ rhs: CGRect, imageSize: CGSize) -> CGFloat {
+      max(
+        abs(lhs.minX - rhs.minX) * imageSize.width,
+        abs(lhs.maxX - rhs.maxX) * imageSize.width,
+        abs(lhs.minY - rhs.minY) * imageSize.height,
+        abs(lhs.maxY - rhs.maxY) * imageSize.height
+      )
+    }
+
+    private static func centerDistance(_ lhs: CGRect, _ rhs: CGRect, imageSize: CGSize) -> CGFloat {
+      hypot(
+        (lhs.midX - rhs.midX) * imageSize.width,
+        (lhs.midY - rhs.midY) * imageSize.height
+      )
+    }
+
+    private static func colorDistance(_ lhs: OverlayColor, _ rhs: OverlayColor) -> CGFloat {
+      max(abs(lhs.red - rhs.red), abs(lhs.green - rhs.green), abs(lhs.blue - rhs.blue))
+    }
+
+    private static func canCoalesce(
+      _ lhs: AttributedStyleSpan,
+      with rhs: AttributedStyleSpan,
+      in text: String
+    ) -> Bool {
+      guard NSMaxRange(lhs.range) <= rhs.range.location else { return false }
+      let gap = NSRange(
+        location: NSMaxRange(lhs.range),
+        length: rhs.range.location - NSMaxRange(lhs.range)
+      )
+      let separator = (text as NSString).substring(with: gap)
+      guard !separator.contains(where: \.isNewline) else { return false }
+      let technicalPunctuation = CharacterSet(charactersIn: "._/#@+:-")
+      guard
+        separator.unicodeScalars.allSatisfy({
+          $0.properties.isWhitespace || technicalPunctuation.contains($0)
+        })
+      else { return false }
+      let intersection = lhs.box.intersection(rhs.box)
+      let minimumArea = min(
+        lhs.box.width * lhs.box.height,
+        rhs.box.width * rhs.box.height
+      )
+      let sharesVisionBox = !intersection.isNull
+        && !intersection.isEmpty
+        && intersection.width * intersection.height / max(0.000_001, minimumArea) >= 0.8
+      let foregroundTolerance: CGFloat = sharesVisionBox ? 0.25 : 0.08
+      return colorDistance(lhs.appearance.background, rhs.appearance.background) <= 0.04
+        && colorDistance(lhs.appearance.foreground, rhs.appearance.foreground) <= foregroundTolerance
+        && abs(lhs.appearance.fontWeight.rawValue - rhs.appearance.fontWeight.rawValue) <= 1
+        && lhs.appearance.isUnderlined == rhs.appearance.isUnderlined
+    }
+
+    private static func isBoundaryPunctuationBleed(
+      _ run: OverlaySourceStyleRun,
+      in text: String
+    ) -> Bool {
+      guard let range = Range(run.range, in: text) else { return false }
+      let token = text[range]
+      let sentencePunctuation = CharacterSet(charactersIn: ".,!?;")
+      guard
+        !token.isEmpty,
+        token.unicodeScalars.allSatisfy(sentencePunctuation.contains),
+        range.upperBound == text.endIndex || text[range.upperBound].isWhitespace
+      else { return false }
+      // A punctuation box immediately after an inline chip can sample the
+      // chip fill even though the glyph belongs to the surrounding sentence.
+      // Enclosing punctuation remains style-aware; terminal sentence marks
+      // follow the containing line and must not become movable code spans.
+      return text[..<range.lowerBound].unicodeScalars.contains {
+        CharacterSet.alphanumerics.contains($0)
+      }
+    }
+
+    private static func isMateriallyDifferent(
+      _ candidate: OverlaySourceAppearance,
+      from base: OverlaySourceAppearance
+    ) -> Bool {
+      colorDistance(candidate.foreground, base.foreground) >= 0.1
+        || colorDistance(candidate.background, base.background) >= 0.025
+        || candidate.fontDesign != base.fontDesign
+        || candidate.isUnderlined != base.isUnderlined
+        || candidate.fontWeight.rawValue - base.fontWeight.rawValue >= 2
+    }
+
+    private static func shouldCarryStyle(
+      _ text: String,
+      appearance: OverlaySourceAppearance,
+      base: OverlaySourceAppearance
+    ) -> Bool {
+      let containsText = text.unicodeScalars.contains {
+        CharacterSet.alphanumerics.contains($0)
+      }
+      guard !containsText else { return true }
+      return Self.isEnclosingPunctuation(text)
+        && colorDistance(appearance.foreground, base.foreground) >= 0.1
+        || colorDistance(appearance.background, base.background) >= 0.025
+        || appearance.fontDesign != base.fontDesign
+        || appearance.isUnderlined != base.isUnderlined
+        || appearance.fontWeight.rawValue - base.fontWeight.rawValue >= 2
+    }
+
+    private static func isEnclosingPunctuation(_ text: String) -> Bool {
+      let punctuation = CharacterSet(charactersIn: "()[]{}<>（）［］｛｝〈〉《》「」『』【】")
+      let scalars = text.unicodeScalars.filter { !$0.properties.isWhitespace }
+      return !scalars.isEmpty && scalars.allSatisfy { punctuation.contains($0) }
+    }
+
+  }
+
+  enum InitialContent: Equatable, Sendable {
+    case source
+    case pending
+  }
+
+  enum Content: Equatable, Sendable {
+    case source
+    case pending
+    case translated(Translation)
+    case unavailable
+  }
+
+  struct Translation: Equatable, Sendable {
+
+    // MARK: Lifecycle
+
+    fileprivate init(
+      text: String,
+      language: Locale.Language,
+      sourceLayout: OverlaySourceLayout,
+      styleRuns: [OverlayTextStyleRun]
+    ) {
+      self.text = text
+      self.language = language
+      self.styleRuns = styleRuns
+      flow = OverlayTextFlowResolver.translatedFlow(
+        text: text,
+        language: language,
+        replacing: sourceLayout
+      )
+    }
+
+    // MARK: Internal
+
+    let text: String
+    let language: Locale.Language
+    let flow: OverlayTextFlow
+    let styleRuns: [OverlayTextStyleRun]
+
+  }
+
   let id: UUID
-  var box: CGRect
-  var sourceText: String
-  var translated: String?
-  /// Number of source rows `box` spans; >1 for sentences stitched from wrapped
-  /// lines, so the renderer wraps the text instead of drawing one giant row.
-  var rowCount = 1
-  /// True when `box` covers a block of stitched vertical CJK columns.
-  var isVerticalBlock = false
-  /// Whether the translation itself should be drawn in vertical columns
-  /// (top-to-bottom, right-to-left). Only true when the target language is
-  /// written vertically; otherwise the block is laid out horizontally.
-  var verticalLayout = false
-  /// Source character size for a vertical block (a column's width, 0–1
-  /// normalized), so the renderer can match the original font scale.
-  var verticalCharScale: CGFloat = 0
+  var source: Source
+  private(set) var content: Content
+
+  var displayedText: String {
+    if case .translated(let translation) = content { return translation.text }
+    return source.text
+  }
+
+  var displayedLanguage: Locale.Language {
+    if case .translated(let translation) = content { return translation.language }
+    return source.language
+  }
+
+  var textFlow: OverlayTextFlow {
+    if case .translated(let translation) = content { return translation.flow }
+    return OverlayTextFlowResolver.sourceFlow(language: source.language, layout: source.layout)
+  }
+
+  var translatedText: String? {
+    guard case .translated(let translation) = content else { return nil }
+    return translation.text
+  }
+
+  var displayedStyleRuns: [OverlayTextStyleRun] {
+    guard case .translated(let translation) = content else { return [] }
+    return translation.styleRuns
+  }
+
+  var isPending: Bool {
+    content == .pending
+  }
+
+  var isUnavailable: Bool {
+    content == .unavailable
+  }
+
+  func textFlow(prefersHorizontalTextLayout: Bool) -> OverlayTextFlow {
+    guard prefersHorizontalTextLayout, case .translated = content, case .vertical = textFlow else {
+      return textFlow
+    }
+    return OverlayTextFlowResolver.horizontalFlow(
+      text: displayedText,
+      language: displayedLanguage
+    )
+  }
+
+  mutating func showTranslation(
+    _ text: String,
+    attributedText: AttributedString? = nil,
+    language: Locale.Language
+  ) {
+    let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !text.isEmpty else {
+      content = .unavailable
+      return
+    }
+    let styleRuns = translatedStyleRuns(in: attributedText, matching: text)
+    content = .translated(Translation(
+      text: text,
+      language: language,
+      sourceLayout: source.layout,
+      styleRuns: styleRuns
+    ))
+  }
+
+  mutating func showUnavailable() {
+    guard content == .pending else { return }
+    content = .unavailable
+  }
+
+  // MARK: Private
+
+  private static func enclosingPair(for token: String) -> (counterpart: String, searchesBefore: Bool)? {
+    switch token {
+    case ")",
+         "）": ("(", true)
+    case "]",
+         "］": ("[", true)
+    case "}",
+         "｝": ("{", true)
+    case ">": ("<", true)
+    case "〉": ("〈", true)
+    case "》": ("《", true)
+    case "」": ("「", true)
+    case "』": ("『", true)
+    case "】": ("【", true)
+    case "(",
+         "（": (")", false)
+    case "[",
+         "［": ("]", false)
+    case "{",
+         "｛": ("}", false)
+    case "<": (">", false)
+    case "〈": ("〉", false)
+    case "《": ("》", false)
+    case "「": ("」", false)
+    case "『": ("』", false)
+    case "【": ("】", false)
+    default: nil
+    }
+  }
+
+  private func translatedStyleRuns(
+    in attributedText: AttributedString?,
+    matching text: String
+  ) -> [OverlayTextStyleRun] {
+    guard
+      let attributedText,
+      String(attributedText.characters) == text
+    else { return [] }
+
+    let mapped: [OverlayTextStyleRun] = attributedText.runs.compactMap { run in
+      guard
+        let link = run.link,
+        link.scheme == Source.styleLinkScheme,
+        link.host == "run",
+        let index = Int(link.lastPathComponent),
+        source.styleRuns.indices.contains(index)
+      else { return nil }
+      let lowerOffset = attributedText.characters.distance(
+        from: attributedText.characters.startIndex,
+        to: run.range.lowerBound
+      )
+      let upperOffset = attributedText.characters.distance(
+        from: attributedText.characters.startIndex,
+        to: run.range.upperBound
+      )
+      let lowerBound = text.index(text.startIndex, offsetBy: lowerOffset)
+      let upperBound = text.index(text.startIndex, offsetBy: upperOffset)
+      return OverlayTextStyleRun(
+        range: NSRange(lowerBound ..< upperBound, in: text),
+        appearance: source.styleRuns[index].appearance
+      )
+    }
+    return mirroredEnclosingPunctuation(in: mapped, text: text)
+  }
+
+  private func mirroredEnclosingPunctuation(
+    in runs: [OverlayTextStyleRun],
+    text: String
+  ) -> [OverlayTextStyleRun] {
+    let source = text as NSString
+    var result = runs
+    for run in runs {
+      guard NSMaxRange(run.range) <= source.length else { continue }
+      let token = source.substring(with: run.range)
+      guard let pair = Self.enclosingPair(for: token) else { continue }
+      let searchRange = pair.searchesBefore
+        ? NSRange(location: 0, length: run.range.location)
+        : NSRange(
+          location: NSMaxRange(run.range),
+          length: source.length - NSMaxRange(run.range)
+        )
+      guard searchRange.length > 0 else { continue }
+      var options = NSString.CompareOptions.widthInsensitive
+      if pair.searchesBefore { options.insert(.backwards) }
+      let match = source.range(of: pair.counterpart, options: options, range: searchRange)
+      guard
+        match.location != NSNotFound,
+        !result.contains(where: { NSIntersectionRange($0.range, match).length > 0 })
+      else { continue }
+      result.append(OverlayTextStyleRun(range: match, appearance: run.appearance))
+    }
+    return result.sorted { $0.range.location < $1.range.location }
+  }
+
 }

--- a/Sources/Models/OverlayLine.swift
+++ b/Sources/Models/OverlayLine.swift
@@ -34,15 +34,20 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
     // MARK: Lifecycle
 
     init(recognized line: OCRResult.Line, language: Locale.Language) {
+      let semanticAppearance = Self.semanticBaseAppearance(
+        for: line.text,
+        styleRuns: line.styleRuns,
+        fallback: line.appearance
+      )
       box = line.boundingBoxNormalized
       text = line.text
       self.language = language
-      appearance = line.appearance
+      appearance = semanticAppearance
       horizontalGlyphScale = line.horizontalGlyphScale
       horizontalInkScale = line.horizontalInkScale
       horizontalLineAdvanceScale = line.horizontalLineAdvanceScale
       replacementPatches = line.replacementPatches.isEmpty
-        ? [OverlaySourcePatch(box: line.boundingBoxNormalized, appearance: line.appearance)]
+        ? [OverlaySourcePatch(box: line.boundingBoxNormalized, appearance: semanticAppearance)]
         : line.replacementPatches
       styleRuns = line.styleRuns
       alignment = line.alignment
@@ -177,7 +182,6 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
       var attributed = AttributedString(text)
       var spans = [AttributedStyleSpan]()
       for (index, run) in styleRuns.enumerated() {
-        guard Self.isMateriallyDifferent(run.appearance, from: appearance) else { continue }
         guard !Self.isBoundaryPunctuationBleed(run, in: text) else { continue }
         guard
           let stringRange = Range(run.range, in: text),
@@ -189,15 +193,29 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
           box: run.box,
           appearance: run.appearance
         )
+        let extendsPreviousStyle = spans.last.map {
+          Self.isMateriallyDifferent($0.appearance, from: appearance)
+            && Self.canCoalesce($0, with: next, in: text, base: appearance)
+        } ?? false
+        guard
+          Self.isMateriallyDifferent(run.appearance, from: appearance)
+          || extendsPreviousStyle
+        else { continue }
         if
           let previous = spans.last,
-          Self.canCoalesce(previous, with: next, in: text)
+          Self.canCoalesce(previous, with: next, in: text, base: appearance)
         {
           spans[spans.count - 1].range = NSUnionRange(previous.range, next.range)
           spans[spans.count - 1].box = previous.box.union(next.box)
           if
             previous.appearance.fontDesign != .monospaced,
             next.appearance.fontDesign == .monospaced
+          {
+            spans[spans.count - 1].index = index
+            spans[spans.count - 1].appearance = next.appearance
+          } else if
+            !previous.appearance.isUnderlined,
+            next.appearance.isUnderlined
           {
             spans[spans.count - 1].index = index
             spans[spans.count - 1].appearance = next.appearance
@@ -229,6 +247,93 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
       var range: NSRange
       var box: CGRect
       var appearance: OverlaySourceAppearance
+    }
+
+    /// A wrapped row can begin with a long bold phrase that occupies more
+    /// characters than the regular prose after it. A character-weighted median
+    /// then mistakes the emphasis for the row's base style, making the entire
+    /// translation bold and leaving no distinct range to map. A stable trailing
+    /// run of two or more regular words is stronger structural evidence of the
+    /// body style than that median.
+    private static func semanticBaseAppearance(
+      for text: String,
+      styleRuns: [OverlaySourceStyleRun],
+      fallback: OverlaySourceAppearance
+    ) -> OverlaySourceAppearance {
+      guard fallback.fontWeight == .medium else { return fallback }
+      let source = text as NSString
+      let lexicalRuns = styleRuns.filter { run in
+        guard
+          run.range.location >= 0,
+          NSMaxRange(run.range) <= source.length
+        else { return false }
+        return source.substring(with: run.range).unicodeScalars.contains {
+          CharacterSet.alphanumerics.contains($0)
+        }
+      }.sorted { $0.range.location < $1.range.location }
+      guard lexicalRuns.count >= 4 else { return fallback }
+
+      var suffixStart = lexicalRuns.endIndex
+      while
+        suffixStart > lexicalRuns.startIndex,
+        lexicalRuns[lexicalRuns.index(before: suffixStart)].appearance.fontWeight == .regular
+      {
+        suffixStart = lexicalRuns.index(before: suffixStart)
+      }
+      let suffix = Array(lexicalRuns[suffixStart...])
+      let prefix = Array(lexicalRuns[..<suffixStart])
+      guard
+        suffix.count >= 2,
+        !prefix.isEmpty,
+        prefix.allSatisfy({ $0.appearance.fontWeight.rawValue >= OverlayFontWeight.medium.rawValue }),
+        prefix.contains(where: { $0.appearance.fontWeight.rawValue >= OverlayFontWeight.semibold.rawValue })
+      else { return fallback }
+
+      let sharesOneTextSurface = lexicalRuns.allSatisfy {
+        colorDistance($0.appearance.background, fallback.background) <= 0.06
+          && colorDistance($0.appearance.foreground, fallback.foreground) <= 0.15
+          && $0.appearance.fontDesign == fallback.fontDesign
+      }
+      guard sharesOneTextSurface, let firstSuffix = suffix.first else { return fallback }
+      let suffixText = source.substring(from: firstSuffix.range.location)
+      let totalVisibleLength = visibleTextLength(text)
+      let suffixVisibleLength = visibleTextLength(suffixText)
+      guard
+        suffixVisibleLength >= 6,
+        suffixVisibleLength * 4 >= totalVisibleLength
+      else { return fallback }
+
+      let totalWeight = suffix.reduce(CGFloat.zero) {
+        $0 + CGFloat(max(1, $1.range.length))
+      }
+      var result = fallback
+      result.foreground = suffix.reduce(
+        OverlayColor(red: 0, green: 0, blue: 0, alpha: 1)
+      ) { color, run in
+        let weight = CGFloat(max(1, run.range.length)) / max(1, totalWeight)
+        return OverlayColor(
+          red: color.red + run.appearance.foreground.red * weight,
+          green: color.green + run.appearance.foreground.green * weight,
+          blue: color.blue + run.appearance.foreground.blue * weight,
+          alpha: 1
+        )
+      }
+      result.foregroundConfidence = suffix.reduce(CGFloat.zero) {
+        $0 + $1.appearance.foregroundConfidence * CGFloat(max(1, $1.range.length)) / max(1, totalWeight)
+      }
+      result.inkCoverage = suffix.reduce(CGFloat.zero) {
+        $0 + $1.appearance.inkCoverage * CGFloat(max(1, $1.range.length)) / max(1, totalWeight)
+      }
+      result.inkHeightScale = suffix.reduce(CGFloat.zero) {
+        $0 + $1.appearance.inkHeightScale * CGFloat(max(1, $1.range.length)) / max(1, totalWeight)
+      }
+      result.fontWeight = .regular
+      result.isUnderlined = suffix.allSatisfy(\.appearance.isUnderlined)
+      return result
+    }
+
+    private static func visibleTextLength(_ text: String) -> Int {
+      text.unicodeScalars.count(where: { CharacterSet.alphanumerics.contains($0) })
     }
 
     private static func hasSameOrientation(_ lhs: OverlaySourceLayout, _ rhs: OverlaySourceLayout) -> Bool {
@@ -317,7 +422,8 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
     private static func canCoalesce(
       _ lhs: AttributedStyleSpan,
       with rhs: AttributedStyleSpan,
-      in text: String
+      in text: String,
+      base: OverlaySourceAppearance
     ) -> Bool {
       guard NSMaxRange(lhs.range) <= rhs.range.location else { return false }
       let gap = NSRange(
@@ -341,10 +447,16 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
         && !intersection.isEmpty
         && intersection.width * intersection.height / max(0.000_001, minimumArea) >= 0.8
       let foregroundTolerance: CGFloat = sharesVisionBox ? 0.25 : 0.08
+      let underlineMatches = lhs.appearance.isUnderlined == rhs.appearance.isUnderlined
+      let sharedDistinctForeground = colorDistance(
+        lhs.appearance.foreground,
+        base.foreground
+      ) >= 0.1
+        && colorDistance(rhs.appearance.foreground, base.foreground) >= 0.1
       return colorDistance(lhs.appearance.background, rhs.appearance.background) <= 0.04
         && colorDistance(lhs.appearance.foreground, rhs.appearance.foreground) <= foregroundTolerance
         && abs(lhs.appearance.fontWeight.rawValue - rhs.appearance.fontWeight.rawValue) <= 1
-        && lhs.appearance.isUnderlined == rhs.appearance.isUnderlined
+        && (underlineMatches || sharedDistinctForeground)
     }
 
     private static func isBoundaryPunctuationBleed(

--- a/Sources/Models/OverlayLine.swift
+++ b/Sources/Models/OverlayLine.swift
@@ -40,6 +40,7 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
       appearance = line.appearance
       horizontalGlyphScale = line.horizontalGlyphScale
       horizontalInkScale = line.horizontalInkScale
+      horizontalLineAdvanceScale = line.horizontalLineAdvanceScale
       replacementPatches = line.replacementPatches.isEmpty
         ? [OverlaySourcePatch(box: line.boundingBoxNormalized, appearance: line.appearance)]
         : line.replacementPatches
@@ -66,6 +67,7 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
     var appearance: OverlaySourceAppearance
     var horizontalGlyphScale: CGFloat
     var horizontalInkScale: CGFloat
+    var horizontalLineAdvanceScale: CGFloat
     var replacementPatches: [OverlaySourcePatch]
     var styleRuns: [OverlaySourceStyleRun]
     var alignment: OverlayTextAlignment?
@@ -125,6 +127,7 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
       result.layout = previous.layout
       result.horizontalGlyphScale = previous.horizontalGlyphScale
       result.horizontalInkScale = previous.horizontalInkScale
+      result.horizontalLineAdvanceScale = previous.horizontalLineAdvanceScale
       result.alignment = previous.alignment ?? alignment
       result.replacementPatches = Self.stabilizedPatches(
         replacementPatches,

--- a/Sources/Models/OverlaySourceAppearance.swift
+++ b/Sources/Models/OverlaySourceAppearance.swift
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import Foundation
+
+// MARK: - OverlayColor
+
+struct OverlayColor: Equatable, Hashable, Sendable {
+  static let black = OverlayColor(red: 0.04, green: 0.04, blue: 0.04, alpha: 1)
+  static let white = OverlayColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1)
+
+  var red: CGFloat
+  var green: CGFloat
+  var blue: CGFloat
+  var alpha: CGFloat
+
+}
+
+// MARK: - OverlayFontWeight
+
+enum OverlayFontWeight: Int, CaseIterable, Equatable, Hashable, Sendable {
+  case regular
+  case medium
+  case semibold
+  case bold
+}
+
+// MARK: - OverlayFontDesign
+
+enum OverlayFontDesign: Int, Equatable, Hashable, Sendable {
+  case standard
+  case monospaced
+}
+
+// MARK: - OverlaySourceAppearance
+
+struct OverlaySourceAppearance: Equatable, Hashable, Sendable {
+  static let fallback = OverlaySourceAppearance(
+    background: .white,
+    foreground: .black,
+    confidence: 0
+  )
+
+  var background: OverlayColor
+  var foreground: OverlayColor
+  /// Share of sampled pixels represented by the dominant background cluster.
+  /// It is diagnostic data, not a rendering-style switch.
+  var confidence: CGFloat
+  /// Composited source-glyph color sampled from the original pixels.
+  var foregroundConfidence: CGFloat = 0
+  /// Ink coverage inside Vision's line box, used to approximate source weight.
+  var inkCoverage: CGFloat = 0
+  /// Height of the high-contrast source ink, normalized to the image. Unlike a
+  /// Vision line/word box this excludes surrounding icon and control padding.
+  var inkHeightScale: CGFloat = 0
+  var fontWeight = OverlayFontWeight.semibold
+  var fontDesign = OverlayFontDesign.standard
+  var isUnderlined = false
+
+}
+
+// MARK: - OverlaySourceStyleRun
+
+/// Appearance and geometry for one source word. The UTF-16 range is retained
+/// so Apple Translation can align the style with its translated counterpart.
+struct OverlaySourceStyleRun: Equatable, Hashable, Sendable {
+  var range: NSRange
+  var box: CGRect
+  var appearance = OverlaySourceAppearance.fallback
+}
+
+// MARK: - OverlayTextStyleRun
+
+/// A source style mapped onto a translated UTF-16 range by Apple Translation.
+struct OverlayTextStyleRun: Equatable, Hashable, Sendable {
+  var range: NSRange
+  var appearance: OverlaySourceAppearance
+}
+
+// MARK: - OverlaySourcePatch
+
+/// A Vision-provided word or line region that contains source glyphs to erase.
+/// Keeping these regions separate from the paragraph bounds avoids painting
+/// over nearby speech-bubble borders and artwork.
+struct OverlaySourcePatch: Equatable, Hashable, Sendable {
+  var box: CGRect
+  var appearance = OverlaySourceAppearance.fallback
+  /// True when this patch removes a compact styled surface embedded inside a
+  /// larger sentence, such as the old position of an inline-code pill. These
+  /// patches must survive flat-row consolidation.
+  var erasesDistinctSurface = false
+}
+
+// MARK: - OverlaySourceSurface
+
+/// A flat, closed source region such as a speech bubble or text panel. The
+/// renderer may reflow translated text inside this box without crossing the
+/// visual container inferred from the original pixels.
+struct OverlaySourceSurface: Equatable, Hashable, Sendable {
+  /// Inset bounds available to translated text.
+  var box: CGRect
+  var confidence: CGFloat
+  /// Full detected interior used to clip source-erasure patches. Keeping this
+  /// separate from `box` prevents the text safety inset from leaving glyphs
+  /// behind near a curved speech-balloon edge.
+  var clippingBox: CGRect? = nil
+  /// Corner radius relative to the surface's shorter side. Pixel flood-fill
+  /// distinguishes balloons and pills from rectangular UI surfaces.
+  var cornerRadiusFraction: CGFloat = 0
+}

--- a/Sources/Models/OverlayTextFlow.swift
+++ b/Sources/Models/OverlayTextFlow.swift
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Foundation
+import NaturalLanguage
+
+// MARK: - OverlayInlineDirection
+
+enum OverlayInlineDirection: Equatable, Sendable {
+  case leftToRight
+  case rightToLeft
+}
+
+// MARK: - OverlayColumnProgression
+
+enum OverlayColumnProgression: Equatable, Sendable {
+  case rightToLeft
+  case leftToRight
+}
+
+// MARK: - OverlayTextFlow
+
+enum OverlayTextFlow: Equatable, Sendable {
+  case horizontal(OverlayInlineDirection)
+  case vertical(OverlayColumnProgression)
+}
+
+// MARK: - OverlayTextFlowResolver
+
+/// Resolves the writing flow from the string that will actually be shown.
+///
+/// A locale tells us the normal inline direction and supplies a useful fallback
+/// for strings made entirely from punctuation or digits. Natural Language adds
+/// the missing piece for translated text: its dominant ISO 15924 script. That
+/// keeps a Latin translation horizontal even when it replaces a vertical CJK
+/// source, while a CJK translation can continue to use the source's columns.
+enum OverlayTextFlowResolver {
+
+  // MARK: Internal
+
+  static func sourceFlow(language: Locale.Language, layout: OverlaySourceLayout) -> OverlayTextFlow {
+    switch layout {
+    case .horizontal:
+      .horizontal(inlineDirection(for: language, dominantScript: nil))
+    case .vertical(_, let progression):
+      .vertical(progression)
+    }
+  }
+
+  static func translatedFlow(
+    text: String,
+    language: Locale.Language,
+    replacing sourceLayout: OverlaySourceLayout
+  ) -> OverlayTextFlow {
+    let evidence = scriptEvidence(in: text)
+    guard case .vertical = sourceLayout else {
+      return .horizontal(inlineDirection(for: language, dominantScript: evidence.dominantScript))
+    }
+
+    let useVertical: Bool =
+      if evidence.verticalCharacterCount != evidence.horizontalCharacterCount {
+        evidence.verticalCharacterCount > evidence.horizontalCharacterCount
+      } else {
+        isVerticalCapable(script: language.script?.identifier)
+      }
+
+    if useVertical {
+      let script = evidence.dominantVerticalScript ?? language.script?.identifier
+      return .vertical(columnProgression(for: language, script: script))
+    }
+    return .horizontal(inlineDirection(for: language, dominantScript: evidence.dominantScript))
+  }
+
+  static func horizontalFlow(text: String, language: Locale.Language) -> OverlayTextFlow {
+    let script = scriptEvidence(in: text).dominantScript
+    return .horizontal(inlineDirection(for: language, dominantScript: script))
+  }
+
+  static func columnProgression(for language: Locale.Language) -> OverlayColumnProgression {
+    columnProgression(for: language, script: language.script?.identifier)
+  }
+
+  static func scriptEvidence(in text: String) -> ScriptEvidence {
+    guard !text.isEmpty else { return ScriptEvidence() }
+
+    let tagger = NLTagger(tagSchemes: [.script])
+    tagger.string = text
+    var counts = [String: Int]()
+    tagger.enumerateTags(
+      in: text.startIndex ..< text.endIndex,
+      unit: .word,
+      scheme: .script,
+      options: [.omitWhitespace, .omitPunctuation]
+    ) { tag, range in
+      guard let script = tag?.rawValue, !commonScripts.contains(script) else { return true }
+      let count = text[range].unicodeScalars.reduce(into: 0) { result, scalar in
+        if CharacterSet.letters.contains(scalar) || CharacterSet.decimalDigits.contains(scalar) {
+          result += 1
+        }
+      }
+      counts[script, default: 0] += count
+      return true
+    }
+
+    return ScriptEvidence(counts: counts)
+  }
+
+  // MARK: Private
+
+  private static let commonScripts: Set = ["Zinh", "Zyyy", "Zzzz"]
+  private static let verticalScripts: Set = [
+    "Bopo",
+    "Hang",
+    "Hani",
+    "Hans",
+    "Hant",
+    "Hira",
+    "Jpan",
+    "Kana",
+    "Kore",
+    "Mong",
+  ]
+
+  private static func isVerticalCapable(script: String?) -> Bool {
+    script.map(verticalScripts.contains) ?? false
+  }
+
+  private static func inlineDirection(
+    for language: Locale.Language,
+    dominantScript: String?
+  ) -> OverlayInlineDirection {
+    let directionalLanguage = dominantScript.map { script in
+      let inferred = Locale.Language(identifier: "und-\(script)")
+      return Locale.Language(identifier: inferred.maximalIdentifier)
+    } ?? language
+    return directionalLanguage.characterDirection == .rightToLeft ? .rightToLeft : .leftToRight
+  }
+
+  private static func columnProgression(
+    for language: Locale.Language,
+    script: String?
+  ) -> OverlayColumnProgression {
+    switch language.lineLayoutDirection {
+    case .leftToRight:
+      .leftToRight
+    case .rightToLeft:
+      .rightToLeft
+    default:
+      // Foundation reports the normal page layout for CJK and Mongolian
+      // locales, not the optional vertical setting selected by Vision. In that
+      // setting Mongolian advances left-to-right; CJK advances right-to-left.
+      script == "Mong" ? .leftToRight : .rightToLeft
+    }
+  }
+}
+
+// MARK: - ScriptEvidence
+
+struct ScriptEvidence: Equatable, Sendable {
+
+  // MARK: Lifecycle
+
+  init(counts: [String: Int] = [:]) {
+    let meaningful = counts.filter { $0.value > 0 }
+    self.counts = meaningful
+    verticalCharacterCount = meaningful
+      .filter { OverlayTextFlowResolver.isVerticalScript($0.key) }
+      .values
+      .reduce(0, +)
+    horizontalCharacterCount = meaningful
+      .filter { !OverlayTextFlowResolver.isVerticalScript($0.key) }
+      .values
+      .reduce(0, +)
+  }
+
+  // MARK: Internal
+
+  let counts: [String: Int]
+  let verticalCharacterCount: Int
+  let horizontalCharacterCount: Int
+
+  var dominantScript: String? {
+    uniqueDominantScript(in: counts)
+  }
+
+  var dominantVerticalScript: String? {
+    uniqueDominantScript(
+      in: counts.filter { OverlayTextFlowResolver.isVerticalScript($0.key) }
+    )
+  }
+
+  // MARK: Private
+
+  private func uniqueDominantScript(in counts: [String: Int]) -> String? {
+    guard let maximum = counts.values.max() else { return nil }
+    let candidates = counts.filter { $0.value == maximum }.map(\.key)
+    return candidates.count == 1 ? candidates[0] : nil
+  }
+}
+
+extension OverlayTextFlowResolver {
+  fileprivate static func isVerticalScript(_ script: String) -> Bool {
+    verticalScripts.contains(script)
+  }
+}

--- a/Sources/Models/OverlayTranslationPolicy.swift
+++ b/Sources/Models/OverlayTranslationPolicy.swift
@@ -16,13 +16,50 @@ enum OverlayTranslationPolicy {
     guard sources.indices.contains(index) else { return false }
     let source = sources[index]
     if source.isProtectedLiteral || source.isProtectedVisualMetadata { return true }
-    if isNonlinguisticMetadata(source.text) { return true }
+    if isNonlinguisticMetadata(source.text) || isVersionedTechnicalMetadata(source.text) {
+      return true
+    }
     guard isCompactMetadata(source.text) else { return false }
     return sources.indices.contains { candidate in
       candidate != index
         && sources[candidate].isProtectedLiteral
         && sharesVisualRow(source.box, sources[candidate].box)
     }
+  }
+
+  /// Supplies a compact trailing value as translation-only context for its
+  /// leading label. The label and value remain independent visual regions, but
+  /// `release: v1.12.0` disambiguates the UI noun from the verb "release" while
+  /// the version itself keeps its original pixels.
+  static func trailingContext(at index: Int, in sources: [OverlayLine.Source]) -> String? {
+    guard sources.indices.contains(index), !preservesSource(at: index, in: sources) else {
+      return nil
+    }
+    let source = sources[index]
+    guard isCompactMetadata(source.text) else { return nil }
+
+    let rowValues = sources.indices.filter { candidate in
+      candidate != index
+        && isContextValue(sources[candidate])
+        && sharesVisualRow(source.box, sources[candidate].box)
+    }
+    // One nearby number can be ordinary prose. Repeated compact values on the
+    // same row are the structural signal for a badge/segmented-control run.
+    guard rowValues.count >= 2 else { return nil }
+
+    return rowValues.compactMap { candidate -> (gap: CGFloat, text: String)? in
+      let value = sources[candidate]
+      let labelBox = source.box.standardized
+      let valueBox = value.box.standardized
+      let gap = valueBox.minX - labelBox.maxX
+      guard
+        gap >= -max(labelBox.height, valueBox.height) * 0.1,
+        gap <= max(labelBox.height, valueBox.height) * 0.35
+      else { return nil }
+      return (gap, value.text.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+    .min(by: { $0.gap < $1.gap })?
+    .text
   }
 
   // MARK: Private
@@ -41,6 +78,31 @@ enum OverlayTranslationPolicy {
     let letters = scalars.count(where: CharacterSet.letters.contains)
     let digits = scalars.count(where: CharacterSet.decimalDigits.contains)
     return digits > 0 && letters <= 1
+  }
+
+  private static func isVersionedTechnicalMetadata(_ text: String) -> Bool {
+    let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard
+      !text.isEmpty,
+      !text.contains("\n"),
+      text.count <= 40,
+      text.unicodeScalars.contains(where: CharacterSet.decimalDigits.contains)
+    else { return false }
+
+    return text.split(whereSeparator: \.isWhitespace).contains { token in
+      let letters = token.unicodeScalars.filter(CharacterSet.letters.contains)
+      guard letters.count >= 2 else { return false }
+      let uppercase = letters.count(where: CharacterSet.uppercaseLetters.contains)
+      let lowercase = letters.count(where: CharacterSet.lowercaseLetters.contains)
+      return uppercase == letters.count || (uppercase >= 2 && lowercase >= 1)
+    }
+  }
+
+  private static func isContextValue(_ source: OverlayLine.Source) -> Bool {
+    source.isProtectedLiteral
+      || source.isProtectedVisualMetadata
+      || isNonlinguisticMetadata(source.text)
+      || isVersionedTechnicalMetadata(source.text)
   }
 
   private static func sharesVisualRow(_ lhs: CGRect, _ rhs: CGRect) -> Bool {

--- a/Sources/Models/OverlayTranslationPolicy.swift
+++ b/Sources/Models/OverlayTranslationPolicy.swift
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Foundation
+
+// MARK: - OverlayTranslationPolicy
+
+enum OverlayTranslationPolicy {
+
+  // MARK: Internal
+
+  /// Preserves code literals and compact metadata cells on the same visual row.
+  /// Product names and schema values next to a path are identifiers, while the
+  /// surrounding table headers and prose remain natural-language translation.
+  static func preservesSource(at index: Int, in sources: [OverlayLine.Source]) -> Bool {
+    guard sources.indices.contains(index) else { return false }
+    let source = sources[index]
+    if source.isProtectedLiteral || source.isProtectedVisualMetadata { return true }
+    if isNonlinguisticMetadata(source.text) { return true }
+    guard isCompactMetadata(source.text) else { return false }
+    return sources.indices.contains { candidate in
+      candidate != index
+        && sources[candidate].isProtectedLiteral
+        && sharesVisualRow(source.box, sources[candidate].box)
+    }
+  }
+
+  // MARK: Private
+
+  private static func isCompactMetadata(_ text: String) -> Bool {
+    let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !text.isEmpty, !text.contains("\n"), text.count <= 40 else { return false }
+    return text.split(whereSeparator: \.isWhitespace).count <= 4
+  }
+
+  private static func isNonlinguisticMetadata(_ text: String) -> Bool {
+    let scalars = text.unicodeScalars.filter {
+      !CharacterSet.whitespacesAndNewlines.contains($0)
+    }
+    guard !scalars.isEmpty, scalars.count <= 16 else { return false }
+    let letters = scalars.count(where: CharacterSet.letters.contains)
+    let digits = scalars.count(where: CharacterSet.decimalDigits.contains)
+    return digits > 0 && letters <= 1
+  }
+
+  private static func sharesVisualRow(_ lhs: CGRect, _ rhs: CGRect) -> Bool {
+    let lhs = lhs.standardized
+    let rhs = rhs.standardized
+    guard lhs.height > 0, rhs.height > 0 else { return false }
+    let overlap = max(0, min(lhs.maxY, rhs.maxY) - max(lhs.minY, rhs.minY))
+    if overlap / min(lhs.height, rhs.height) >= 0.45 { return true }
+    return abs(lhs.midY - rhs.midY) <= max(lhs.height, rhs.height) * 0.65
+  }
+}

--- a/Sources/Models/TranslationStyleMapper.swift
+++ b/Sources/Models/TranslationStyleMapper.swift
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Foundation
+
+// MARK: - TranslationStyleMapper
+
+enum TranslationStyleMapper {
+
+  // MARK: Internal
+
+  struct Span: Equatable {
+    var link: URL
+    var text: String
+    var sourceMidpoint: Double
+  }
+
+  struct Alignment: Equatable {
+    var target: AttributedString
+    var unmatched: [Span]
+  }
+
+  static func align(
+    source: AttributedString,
+    target: String,
+    alternatives: [URL: String] = [:]
+  ) -> Alignment {
+    let spans = sourceSpans(in: source)
+    guard !spans.isEmpty, !target.isEmpty else {
+      return Alignment(target: AttributedString(target), unmatched: spans)
+    }
+
+    var attributedTarget = AttributedString(target)
+    var occupied = [Range<String.Index>]()
+    var unmatched = [Span]()
+    for span in spans {
+      let terms = [span.text, alternatives[span.link]]
+        .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+      let candidates = terms.flatMap { ranges(of: $0, in: target) }
+        .filter { candidate in !occupied.contains(where: { $0.overlaps(candidate) }) }
+      guard
+        let match = candidates.min(by: {
+          abs(midpoint(of: $0, in: target) - span.sourceMidpoint)
+            < abs(midpoint(of: $1, in: target) - span.sourceMidpoint)
+        })
+      else {
+        unmatched.append(span)
+        continue
+      }
+      guard
+        let lowerBound = AttributedString.Index(match.lowerBound, within: attributedTarget),
+        let upperBound = AttributedString.Index(match.upperBound, within: attributedTarget)
+      else {
+        unmatched.append(span)
+        continue
+      }
+      attributedTarget[lowerBound ..< upperBound].link = span.link
+      occupied.append(match)
+    }
+    return Alignment(target: attributedTarget, unmatched: unmatched)
+  }
+
+  // MARK: Private
+
+  private static func sourceSpans(in source: AttributedString) -> [Span] {
+    let count = max(1, source.characters.count)
+    return source.runs.compactMap { run in
+      guard let link = run.link, link.scheme == "swiftycrow-style" else { return nil }
+      let lower = source.characters.distance(from: source.characters.startIndex, to: run.range.lowerBound)
+      let upper = source.characters.distance(from: source.characters.startIndex, to: run.range.upperBound)
+      return Span(
+        link: link,
+        text: String(source.characters[run.range]),
+        sourceMidpoint: Double(lower + upper) / 2 / Double(count)
+      )
+    }
+  }
+
+  private static func ranges(of needle: String, in text: String) -> [Range<String.Index>] {
+    var result = [Range<String.Index>]()
+    var cursor = text.startIndex
+    while
+      cursor < text.endIndex,
+      let range = text.range(
+        of: needle,
+        options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+        range: cursor ..< text.endIndex
+      )
+    {
+      result.append(range)
+      cursor = range.upperBound
+    }
+    return result
+  }
+
+  private static func midpoint(of range: Range<String.Index>, in text: String) -> Double {
+    let count = max(1, text.count)
+    let lower = text.distance(from: text.startIndex, to: range.lowerBound)
+    let upper = text.distance(from: text.startIndex, to: range.upperBound)
+    return Double(lower + upper) / 2 / Double(count)
+  }
+}

--- a/Sources/Overlay/CoreTextTypesetter.swift
+++ b/Sources/Overlay/CoreTextTypesetter.swift
@@ -64,7 +64,8 @@ enum CoreTextTypesetter {
     fontDesign: OverlayFontDesign = .standard,
     constrainedTo size: CGSize,
     preferred: CGFloat,
-    minimum: CGFloat
+    minimum: CGFloat,
+    lineHeightMultiple: CGFloat = 1
   ) -> CGFloat {
     guard !text.isEmpty, size.width > 0, size.height > 0 else { return minimum }
     let lowerBound = max(1, min(minimum, preferred))
@@ -77,7 +78,8 @@ enum CoreTextTypesetter {
         fontSize: upperBound,
         fontWeight: fontWeight,
         fontDesign: fontDesign,
-        in: size
+        in: size,
+        lineHeightMultiple: lineHeightMultiple
       )
     {
       return upperBound
@@ -90,7 +92,8 @@ enum CoreTextTypesetter {
         fontSize: lowerBound,
         fontWeight: fontWeight,
         fontDesign: fontDesign,
-        in: size
+        in: size,
+        lineHeightMultiple: lineHeightMultiple
       )
     else {
       return lowerBound
@@ -108,7 +111,8 @@ enum CoreTextTypesetter {
           fontSize: candidate,
           fontWeight: fontWeight,
           fontDesign: fontDesign,
-          in: size
+          in: size,
+          lineHeightMultiple: lineHeightMultiple
         )
       {
         low = candidate
@@ -126,7 +130,8 @@ enum CoreTextTypesetter {
     fontSize: CGFloat,
     fontWeight: OverlayFontWeight = .semibold,
     fontDesign: OverlayFontDesign = .standard,
-    in size: CGSize
+    in size: CGSize,
+    lineHeightMultiple: CGFloat = 1
   ) -> Bool {
     guard !text.isEmpty else { return true }
     guard size.width > 0, size.height > 0, fontSize > 0 else { return false }
@@ -158,7 +163,8 @@ enum CoreTextTypesetter {
       fontSize: fontSize,
       fontWeight: fontWeight,
       fontDesign: fontDesign,
-      vertical: vertical
+      vertical: vertical,
+      lineHeightMultiple: lineHeightMultiple
     )
     let frame = makeFrame(attributed: attributed, size: size, progression: vertical ? progression : nil)
     let visible = CTFrameGetVisibleStringRange(frame)
@@ -180,13 +186,30 @@ enum CoreTextTypesetter {
     return ceil(CTFontGetAscent(font) + CTFontGetDescent(font) + CTFontGetLeading(font))
   }
 
+  static func lineSpacing(
+    fontSize: CGFloat,
+    language: Locale.Language,
+    fontWeight: OverlayFontWeight = .semibold,
+    fontDesign: OverlayFontDesign = .standard,
+    lineHeightMultiple: CGFloat
+  ) -> CGFloat {
+    let natural = lineHeight(
+      fontSize: fontSize,
+      language: language,
+      fontWeight: fontWeight,
+      fontDesign: fontDesign
+    )
+    return max(0, natural * (max(1, lineHeightMultiple) - 1))
+  }
+
   static func horizontalLineCount(
     text: String,
     language: Locale.Language,
     fontSize: CGFloat,
     fontWeight: OverlayFontWeight = .semibold,
     fontDesign: OverlayFontDesign = .standard,
-    in size: CGSize
+    in size: CGSize,
+    lineHeightMultiple: CGFloat = 1
   ) -> Int {
     guard !text.isEmpty, size.width > 0, size.height > 0 else { return 0 }
     let attributed = attributedString(
@@ -195,7 +218,8 @@ enum CoreTextTypesetter {
       fontSize: fontSize,
       fontWeight: fontWeight,
       fontDesign: fontDesign,
-      vertical: false
+      vertical: false,
+      lineHeightMultiple: lineHeightMultiple
     )
     let frame = makeFrame(attributed: attributed, size: size, progression: nil)
     return CFArrayGetCount(CTFrameGetLines(frame))
@@ -394,7 +418,8 @@ enum CoreTextTypesetter {
     fontSize: CGFloat,
     fontWeight: OverlayFontWeight,
     fontDesign: OverlayFontDesign,
-    vertical: Bool
+    vertical: Bool,
+    lineHeightMultiple: CGFloat = 1
   ) -> NSMutableAttributedString {
     let attributes: [NSAttributedString.Key: Any] = [
       NSAttributedString.Key(kCTFontAttributeName as String): localizedSystemFont(
@@ -412,9 +437,25 @@ enum CoreTextTypesetter {
       NSAttributedString.Key(kCTLanguageAttributeName as String): language.maximalIdentifier,
     ]
     let attributed = NSMutableAttributedString(string: text, attributes: attributes)
+    let wholeRange = NSRange(location: 0, length: attributed.length)
+    if !vertical, lineHeightMultiple > 1 {
+      attributed.addAttribute(
+        NSAttributedString.Key(kCTParagraphStyleAttributeName as String),
+        value: wordWrappingParagraphStyle(
+          lineSpacingAdjustment: lineSpacing(
+            fontSize: fontSize,
+            language: language,
+            fontWeight: fontWeight,
+            fontDesign: fontDesign,
+            lineHeightMultiple: lineHeightMultiple
+          )
+        ),
+        range: wholeRange
+      )
+      return attributed
+    }
     guard vertical else { return attributed }
 
-    let wholeRange = NSRange(location: 0, length: attributed.length)
     attributed.addAttribute(
       NSAttributedString.Key(kCTVerticalFormsAttributeName as String),
       value: true,
@@ -478,15 +519,29 @@ enum CoreTextTypesetter {
     )
   }
 
-  private static func wordWrappingParagraphStyle() -> CTParagraphStyle {
+  private static func wordWrappingParagraphStyle(
+    lineSpacingAdjustment: CGFloat = 0
+  ) -> CTParagraphStyle {
     var lineBreakMode = CTLineBreakMode.byWordWrapping
+    var lineSpacingAdjustment = max(0, lineSpacingAdjustment)
     return withUnsafePointer(to: &lineBreakMode) { pointer in
-      var setting = CTParagraphStyleSetting(
-        spec: .lineBreakMode,
-        valueSize: MemoryLayout<CTLineBreakMode>.size,
-        value: UnsafeRawPointer(pointer)
-      )
-      return CTParagraphStyleCreate(&setting, 1)
+      withUnsafePointer(to: &lineSpacingAdjustment) { spacingPointer in
+        let settings = [
+          CTParagraphStyleSetting(
+            spec: .lineBreakMode,
+            valueSize: MemoryLayout<CTLineBreakMode>.size,
+            value: UnsafeRawPointer(pointer)
+          ),
+          CTParagraphStyleSetting(
+            spec: .lineSpacingAdjustment,
+            valueSize: MemoryLayout<CGFloat>.size,
+            value: UnsafeRawPointer(spacingPointer)
+          ),
+        ]
+        return settings.withUnsafeBufferPointer {
+          CTParagraphStyleCreate($0.baseAddress!, $0.count)
+        }
+      }
     }
   }
 

--- a/Sources/Overlay/CoreTextTypesetter.swift
+++ b/Sources/Overlay/CoreTextTypesetter.swift
@@ -1,0 +1,603 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import AppKit
+import CoreGraphics
+import CoreText
+import Foundation
+import NaturalLanguage
+
+// MARK: - CoreTextTypesetter
+
+/// Core Text is the source of truth for measurement and vertical glyph layout.
+/// The SwiftUI layer only presents the resulting metrics/image, so the text we
+/// measure and the text we draw share the same locale-aware line breaking,
+/// fallback fonts, and vertical OpenType features.
+enum CoreTextTypesetter {
+
+  // MARK: Internal
+
+  struct VerticalLayoutPlan: Equatable {
+    let columns: [NSRange]
+    let glyphExtent: CGFloat
+    let columnAdvance: CGFloat
+    let requiredWidth: CGFloat
+
+    var columnGap: CGFloat {
+      columnAdvance - glyphExtent
+    }
+  }
+
+  static func suggestedHorizontalSize(
+    text: String,
+    language: Locale.Language,
+    fontSize: CGFloat,
+    fontWeight: OverlayFontWeight = .semibold,
+    fontDesign: OverlayFontDesign = .standard,
+    constrainedToWidth width: CGFloat
+  ) -> CGSize {
+    guard !text.isEmpty, width > 0 else { return .zero }
+    let attributed = attributedString(
+      text: text,
+      language: language,
+      fontSize: fontSize,
+      fontWeight: fontWeight,
+      fontDesign: fontDesign,
+      vertical: false
+    )
+    let framesetter = CTFramesetterCreateWithAttributedString(attributed)
+    let size = CTFramesetterSuggestFrameSizeWithConstraints(
+      framesetter,
+      CFRange(location: 0, length: attributed.length),
+      nil,
+      CGSize(width: width, height: 100_000),
+      nil
+    )
+    return CGSize(width: ceil(size.width), height: ceil(size.height))
+  }
+
+  static func fittedFontSize(
+    text: String,
+    language: Locale.Language,
+    flow: OverlayTextFlow,
+    fontWeight: OverlayFontWeight = .semibold,
+    fontDesign: OverlayFontDesign = .standard,
+    constrainedTo size: CGSize,
+    preferred: CGFloat,
+    minimum: CGFloat
+  ) -> CGFloat {
+    guard !text.isEmpty, size.width > 0, size.height > 0 else { return minimum }
+    let lowerBound = max(1, min(minimum, preferred))
+    let upperBound = max(lowerBound, preferred)
+    if
+      fits(
+        text: text,
+        language: language,
+        flow: flow,
+        fontSize: upperBound,
+        fontWeight: fontWeight,
+        fontDesign: fontDesign,
+        in: size
+      )
+    {
+      return upperBound
+    }
+    guard
+      fits(
+        text: text,
+        language: language,
+        flow: flow,
+        fontSize: lowerBound,
+        fontWeight: fontWeight,
+        fontDesign: fontDesign,
+        in: size
+      )
+    else {
+      return lowerBound
+    }
+
+    var low = lowerBound
+    var high = upperBound
+    for _ in 0 ..< 10 {
+      let candidate = (low + high) / 2
+      if
+        fits(
+          text: text,
+          language: language,
+          flow: flow,
+          fontSize: candidate,
+          fontWeight: fontWeight,
+          fontDesign: fontDesign,
+          in: size
+        )
+      {
+        low = candidate
+      } else {
+        high = candidate
+      }
+    }
+    return floor(low * 4) / 4
+  }
+
+  static func fits(
+    text: String,
+    language: Locale.Language,
+    flow: OverlayTextFlow,
+    fontSize: CGFloat,
+    fontWeight: OverlayFontWeight = .semibold,
+    fontDesign: OverlayFontDesign = .standard,
+    in size: CGSize
+  ) -> Bool {
+    guard !text.isEmpty else { return true }
+    guard size.width > 0, size.height > 0, fontSize > 0 else { return false }
+    if case .vertical = flow {
+      let plan = verticalLayoutPlan(
+        text: text,
+        language: language,
+        fontSize: fontSize,
+        fontWeight: fontWeight,
+        fontDesign: fontDesign,
+        constrainedToHeight: size.height
+      )
+      return !plan.columns.isEmpty && plan.requiredWidth <= size.width + 0.5
+    }
+    let vertical: Bool
+    let progression: OverlayColumnProgression
+    switch flow {
+    case .horizontal:
+      vertical = false
+      progression = .rightToLeft
+
+    case .vertical(let value):
+      vertical = true
+      progression = value
+    }
+    let attributed = attributedString(
+      text: text,
+      language: language,
+      fontSize: fontSize,
+      fontWeight: fontWeight,
+      fontDesign: fontDesign,
+      vertical: vertical
+    )
+    let frame = makeFrame(attributed: attributed, size: size, progression: vertical ? progression : nil)
+    let visible = CTFrameGetVisibleStringRange(frame)
+    return visible.location == 0 && visible.length >= attributed.length
+  }
+
+  static func lineHeight(
+    fontSize: CGFloat,
+    language: Locale.Language,
+    fontWeight: OverlayFontWeight = .semibold,
+    fontDesign: OverlayFontDesign = .standard
+  ) -> CGFloat {
+    let font = localizedSystemFont(
+      size: fontSize,
+      language: language,
+      weight: fontWeight,
+      design: fontDesign
+    )
+    return ceil(CTFontGetAscent(font) + CTFontGetDescent(font) + CTFontGetLeading(font))
+  }
+
+  static func horizontalLineCount(
+    text: String,
+    language: Locale.Language,
+    fontSize: CGFloat,
+    fontWeight: OverlayFontWeight = .semibold,
+    fontDesign: OverlayFontDesign = .standard,
+    in size: CGSize
+  ) -> Int {
+    guard !text.isEmpty, size.width > 0, size.height > 0 else { return 0 }
+    let attributed = attributedString(
+      text: text,
+      language: language,
+      fontSize: fontSize,
+      fontWeight: fontWeight,
+      fontDesign: fontDesign,
+      vertical: false
+    )
+    let frame = makeFrame(attributed: attributed, size: size, progression: nil)
+    return CFArrayGetCount(CTFrameGetLines(frame))
+  }
+
+  static func horizontalWordFittedFontSize(
+    text: String,
+    language: Locale.Language,
+    constrainedToWidth width: CGFloat,
+    preferred: CGFloat,
+    minimum: CGFloat,
+    fontWeight: OverlayFontWeight = .semibold,
+    fontDesign: OverlayFontDesign = .standard
+  ) -> CGFloat {
+    guard width > 0, preferred > 0 else { return minimum }
+    guard !usesCharacterWrapping(language) else { return preferred }
+    let tokens = horizontalTokens(in: text, language: language)
+    guard !tokens.isEmpty else { return preferred }
+
+    func longestWidth(at fontSize: CGFloat) -> CGFloat {
+      tokens.reduce(0) { result, token in
+        max(
+          result,
+          suggestedHorizontalSize(
+            text: token,
+            language: language,
+            fontSize: fontSize,
+            fontWeight: fontWeight,
+            fontDesign: fontDesign,
+            constrainedToWidth: 100_000
+          ).width
+        )
+      }
+    }
+
+    let preferredWidth = longestWidth(at: preferred)
+    guard preferredWidth > width else { return preferred }
+    var fitted = max(minimum, floor(preferred * width / preferredWidth * 4) / 4)
+    while fitted > minimum, longestWidth(at: fitted) > width {
+      fitted = max(minimum, fitted - 0.25)
+    }
+    return fitted
+  }
+
+  static func horizontalWordsFit(
+    text: String,
+    language: Locale.Language,
+    fontSize: CGFloat,
+    fontWeight: OverlayFontWeight = .semibold,
+    fontDesign: OverlayFontDesign = .standard,
+    constrainedToWidth width: CGFloat
+  ) -> Bool {
+    guard width > 0, fontSize > 0 else { return false }
+    guard !usesCharacterWrapping(language) else { return true }
+    return horizontalTokens(in: text, language: language).allSatisfy { token in
+      suggestedHorizontalSize(
+        text: token,
+        language: language,
+        fontSize: fontSize,
+        fontWeight: fontWeight,
+        fontDesign: fontDesign,
+        constrainedToWidth: 100_000
+      ).width <= width + 0.5
+    }
+  }
+
+  static func verticalColumnsPreserveWords(
+    text: String,
+    language: Locale.Language,
+    fontSize: CGFloat,
+    fontWeight: OverlayFontWeight = .semibold,
+    fontDesign: OverlayFontDesign = .standard,
+    constrainedToHeight height: CGFloat
+  ) -> Bool {
+    guard !usesCharacterWrapping(language) else { return true }
+    let boundaries = Set(verticalLayoutPlan(
+      text: text,
+      language: language,
+      fontSize: fontSize,
+      fontWeight: fontWeight,
+      fontDesign: fontDesign,
+      constrainedToHeight: height
+    ).columns.dropLast().map { $0.location + $0.length })
+    return horizontalTokenRanges(in: text, language: language).allSatisfy { token in
+      !boundaries.contains(where: { $0 > token.location && $0 < token.location + token.length })
+    }
+  }
+
+  static func verticalGlyphImage(
+    text: String,
+    language: Locale.Language,
+    fontSize: CGFloat,
+    fontWeight: OverlayFontWeight = .semibold,
+    fontDesign: OverlayFontDesign = .standard,
+    size: CGSize,
+    scale: CGFloat,
+    progression: OverlayColumnProgression
+  ) -> CGImage? {
+    guard !text.isEmpty, size.width > 0, size.height > 0, scale > 0 else { return nil }
+    let pixelWidth = max(1, Int(ceil(size.width * scale)))
+    let pixelHeight = max(1, Int(ceil(size.height * scale)))
+    let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+    guard
+      let context = CGContext(
+        data: nil,
+        width: pixelWidth,
+        height: pixelHeight,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: colorSpace,
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    else { return nil }
+
+    context.scaleBy(x: scale, y: scale)
+    context.textMatrix = .identity
+    context.setShouldAntialias(true)
+    context.setAllowsFontSmoothing(true)
+    let attributed = attributedString(
+      text: text,
+      language: language,
+      fontSize: fontSize,
+      fontWeight: fontWeight,
+      fontDesign: fontDesign,
+      vertical: true
+    )
+    let plan = verticalLayoutPlan(
+      attributed: attributed,
+      language: language,
+      fontSize: fontSize,
+      constrainedToHeight: size.height
+    )
+    guard !plan.columns.isEmpty, plan.requiredWidth <= size.width + 0.5 else { return nil }
+
+    let direction: CGFloat = progression == .rightToLeft ? -1 : 1
+    let firstCenter = size.width / 2 - direction * CGFloat(plan.columns.count - 1) * plan.columnAdvance / 2
+    let pathWidth = max(plan.glyphExtent, ceil(fontSize * 3.25))
+    for (index, range) in plan.columns.enumerated() {
+      let centerX = firstCenter + direction * CGFloat(index) * plan.columnAdvance
+      let frame = makeFrame(
+        attributed: attributed,
+        range: CFRange(location: range.location, length: range.length),
+        rect: CGRect(
+          x: centerX - pathWidth / 2,
+          y: 0,
+          width: pathWidth,
+          height: size.height
+        ),
+        progression: progression
+      )
+      let visible = CTFrameGetVisibleStringRange(frame)
+      guard visible.location == range.location, visible.length >= range.length else { return nil }
+      CTFrameDraw(frame, context)
+    }
+    return context.makeImage()
+  }
+
+  static func verticalLayoutPlan(
+    text: String,
+    language: Locale.Language,
+    fontSize: CGFloat,
+    fontWeight: OverlayFontWeight = .semibold,
+    fontDesign: OverlayFontDesign = .standard,
+    constrainedToHeight height: CGFloat
+  ) -> VerticalLayoutPlan {
+    verticalLayoutPlan(
+      attributed: attributedString(
+        text: text,
+        language: language,
+        fontSize: fontSize,
+        fontWeight: fontWeight,
+        fontDesign: fontDesign,
+        vertical: true
+      ),
+      language: language,
+      fontSize: fontSize,
+      constrainedToHeight: height
+    )
+  }
+
+  static func horizontalInVerticalRanges(in text: String) -> [NSRange] {
+    guard
+      let expression = try? NSRegularExpression(
+        pattern: "(?<![A-Za-z0-9])[A-Za-z0-9]{1,4}(?![A-Za-z0-9])"
+      )
+    else { return [] }
+    let range = NSRange(text.startIndex ..< text.endIndex, in: text)
+    return expression.matches(in: text, range: range).map(\.range)
+  }
+
+  // MARK: Private
+
+  private static func attributedString(
+    text: String,
+    language: Locale.Language,
+    fontSize: CGFloat,
+    fontWeight: OverlayFontWeight,
+    fontDesign: OverlayFontDesign,
+    vertical: Bool
+  ) -> NSMutableAttributedString {
+    let attributes: [NSAttributedString.Key: Any] = [
+      NSAttributedString.Key(kCTFontAttributeName as String): localizedSystemFont(
+        size: fontSize,
+        language: language,
+        weight: fontWeight,
+        design: fontDesign
+      ),
+      NSAttributedString.Key(kCTForegroundColorAttributeName as String): CGColor(
+        red: 1,
+        green: 1,
+        blue: 1,
+        alpha: 1
+      ),
+      NSAttributedString.Key(kCTLanguageAttributeName as String): language.maximalIdentifier,
+    ]
+    let attributed = NSMutableAttributedString(string: text, attributes: attributes)
+    guard vertical else { return attributed }
+
+    let wholeRange = NSRange(location: 0, length: attributed.length)
+    attributed.addAttribute(
+      NSAttributedString.Key(kCTVerticalFormsAttributeName as String),
+      value: true,
+      range: wholeRange
+    )
+    attributed.addAttribute(
+      NSAttributedString.Key(kCTParagraphStyleAttributeName as String),
+      value: wordWrappingParagraphStyle(),
+      range: wholeRange
+    )
+    for range in horizontalInVerticalRanges(in: text) {
+      attributed.addAttribute(
+        NSAttributedString.Key(kCTHorizontalInVerticalFormsAttributeName as String),
+        value: NSNumber(value: range.length),
+        range: range
+      )
+    }
+    return attributed
+  }
+
+  private static func verticalLayoutPlan(
+    attributed: NSAttributedString,
+    language: Locale.Language,
+    fontSize: CGFloat,
+    constrainedToHeight height: CGFloat
+  ) -> VerticalLayoutPlan {
+    guard attributed.length > 0, height > 0 else {
+      return VerticalLayoutPlan(columns: [], glyphExtent: 0, columnAdvance: 0, requiredWidth: 0)
+    }
+    let typesetter = CTTypesetterCreateWithAttributedString(attributed)
+    let text = attributed.string as NSString
+    var columns = [NSRange]()
+    var offset = 0
+    while offset < attributed.length {
+      var length = CTTypesetterSuggestLineBreak(typesetter, offset, height)
+      length = adjustedToWordBoundary(
+        proposedLength: length,
+        offset: offset,
+        text: attributed.string,
+        language: language
+      )
+      if length <= 0 {
+        length = CTTypesetterSuggestClusterBreak(typesetter, offset, height)
+      }
+      if length <= 0 {
+        length = text.rangeOfComposedCharacterSequence(at: offset).length
+      }
+      length = min(max(1, length), attributed.length - offset)
+      columns.append(NSRange(location: offset, length: length))
+      offset += length
+    }
+
+    let glyphExtent = ceil(fontSize * 1.2)
+    let columnAdvance = glyphExtent + ceil(max(1, fontSize * 0.1))
+    let requiredWidth = glyphExtent + CGFloat(max(0, columns.count - 1)) * columnAdvance
+    return VerticalLayoutPlan(
+      columns: columns,
+      glyphExtent: glyphExtent,
+      columnAdvance: columnAdvance,
+      requiredWidth: requiredWidth
+    )
+  }
+
+  private static func wordWrappingParagraphStyle() -> CTParagraphStyle {
+    var lineBreakMode = CTLineBreakMode.byWordWrapping
+    return withUnsafePointer(to: &lineBreakMode) { pointer in
+      var setting = CTParagraphStyleSetting(
+        spec: .lineBreakMode,
+        valueSize: MemoryLayout<CTLineBreakMode>.size,
+        value: UnsafeRawPointer(pointer)
+      )
+      return CTParagraphStyleCreate(&setting, 1)
+    }
+  }
+
+  private static func adjustedToWordBoundary(
+    proposedLength: Int,
+    offset: Int,
+    text: String,
+    language: Locale.Language
+  ) -> Int {
+    guard proposedLength > 0, !usesCharacterWrapping(language) else { return proposedLength }
+    let proposedEnd = offset + proposedLength
+    for token in horizontalTokenRanges(in: text, language: language) {
+      let tokenEnd = token.location + token.length
+      guard proposedEnd > token.location, proposedEnd < tokenEnd else { continue }
+      let adjusted = token.location - offset
+      return adjusted > 0 ? adjusted : proposedLength
+    }
+    return proposedLength
+  }
+
+  private static func localizedSystemFont(
+    size: CGFloat,
+    language _: Locale.Language,
+    weight: OverlayFontWeight,
+    design: OverlayFontDesign
+  ) -> CTFont {
+    switch design {
+    case .standard:
+      NSFont.systemFont(ofSize: max(1, size), weight: weight.nsFontWeight) as CTFont
+    case .monospaced:
+      NSFont.monospacedSystemFont(ofSize: max(1, size), weight: weight.nsFontWeight) as CTFont
+    }
+  }
+
+  private static func usesCharacterWrapping(_ language: Locale.Language) -> Bool {
+    switch language.script?.identifier {
+    case "Hans",
+         "Hant",
+         "Jpan": true
+    default: false
+    }
+  }
+
+  private static func horizontalTokens(
+    in text: String,
+    language: Locale.Language
+  ) -> [String] {
+    horizontalTokenRanges(in: text, language: language).compactMap { range in
+      Range(range, in: text).map { String(text[$0]) }
+    }
+  }
+
+  private static func horizontalTokenRanges(
+    in text: String,
+    language: Locale.Language
+  ) -> [NSRange] {
+    let tokenizer = NLTokenizer(unit: .word)
+    tokenizer.string = text
+    if let code = language.languageCode?.identifier {
+      tokenizer.setLanguage(NLLanguage(rawValue: code))
+    }
+    return tokenizer.tokens(for: text.startIndex ..< text.endIndex).map { NSRange($0, in: text) }
+  }
+
+  private static func makeFrame(
+    attributed: NSAttributedString,
+    size: CGSize,
+    progression: OverlayColumnProgression?
+  ) -> CTFrame {
+    makeFrame(
+      attributed: attributed,
+      range: CFRange(location: 0, length: attributed.length),
+      rect: CGRect(origin: .zero, size: size),
+      progression: progression
+    )
+  }
+
+  private static func makeFrame(
+    attributed: NSAttributedString,
+    range: CFRange,
+    rect: CGRect,
+    progression: OverlayColumnProgression?
+  ) -> CTFrame {
+    let framesetter = CTFramesetterCreateWithAttributedString(attributed)
+    let path = CGPath(rect: rect, transform: nil)
+    let attributes: CFDictionary? = progression.map { progression in
+      let value: UInt32 =
+        switch progression {
+        case .rightToLeft: CTFrameProgression.rightToLeft.rawValue
+        case .leftToRight: CTFrameProgression.leftToRight.rawValue
+        }
+      return [
+        kCTFrameProgressionAttributeName as String: NSNumber(value: value)
+      ] as CFDictionary
+    }
+    return CTFramesetterCreateFrame(
+      framesetter,
+      range,
+      path,
+      attributes
+    )
+  }
+}
+
+extension OverlayFontWeight {
+  fileprivate var nsFontWeight: NSFont.Weight {
+    switch self {
+    case .regular: .regular
+    case .medium: .medium
+    case .semibold: .semibold
+    case .bold: .bold
+    }
+  }
+}

--- a/Sources/Overlay/OverlayLayoutEngine.swift
+++ b/Sources/Overlay/OverlayLayoutEngine.swift
@@ -100,6 +100,7 @@ enum OverlayLayoutEngine {
   static func replacementFrame(
     for patch: OverlaySourcePatch,
     sourceLayout: OverlaySourceLayout,
+    sourceSurface: OverlaySourceSurface? = nil,
     in canvasSize: CGSize,
     displayScale: CGFloat
   ) -> CGRect {
@@ -124,9 +125,24 @@ enum OverlayLayoutEngine {
       // a 1–3 px halo; single-line labels still need at most one pixel for
       // faint antialiasing. Detected controls are clipped to their original
       // rounded surface later, so this cannot repaint outside their border.
-      verticalBleed = rows > 1
-        ? max(1, min(3, source.height * 0.08))
-        : min(1, source.height * 0.04)
+      if rows == 1, let sourceSurface, sourceSurface.confidence >= 0.35 {
+        let normalizedSurface = (sourceSurface.clippingBox ?? sourceSurface.box).standardized
+        let surface = sourceFrame(for: normalizedSurface, canvas: canvas, safeBounds: canvas)
+        let isCompact = surface.contains(CGPoint(x: source.midX, y: source.midY))
+          && surface.width <= source.width * 2.2
+          && surface.height <= source.height * 3
+        if isCompact {
+          let topGap = max(0, source.minY - surface.minY)
+          let bottomGap = max(0, surface.maxY - source.maxY)
+          verticalBleed = min(14, max(1, max(topGap, bottomGap)))
+        } else {
+          verticalBleed = min(1, source.height * 0.04)
+        }
+      } else {
+        verticalBleed = rows > 1
+          ? max(1, min(3, source.height * 0.08))
+          : min(1, source.height * 0.04)
+      }
 
     case .vertical:
       // Vertical OCR boxes often sit against speech-bubble edges. Keep their

--- a/Sources/Overlay/OverlayLayoutEngine.swift
+++ b/Sources/Overlay/OverlayLayoutEngine.swift
@@ -1,0 +1,549 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import Foundation
+
+// MARK: - OverlayTextAlignment
+
+enum OverlayTextAlignment: Equatable, Sendable {
+  case leading
+  case center
+  case trailing
+}
+
+// MARK: - OverlayPlacement
+
+struct OverlayPlacement: Equatable, Identifiable, Sendable {
+  let line: OverlayLine
+  let flow: OverlayTextFlow
+  /// The exact OCR source region whose pixels are being replaced.
+  let sourceFrame: CGRect
+  /// The original visual container used for translated text.
+  let frame: CGRect
+  /// Hard boundary that replacement text must never cross.
+  let placementBounds: CGRect
+  let fontSize: CGFloat
+  let lineLimit: Int?
+  let alignment: OverlayTextAlignment
+
+  var id: UUID {
+    line.id
+  }
+}
+
+// MARK: - OverlayLayoutEngine
+
+/// Keeps every translation inside its original visual container. Horizontal
+/// source text uses its OCR frame; a horizontal translation replacing vertical
+/// source text may use the detected speech bubble or panel. If the translated
+/// string needs more room, Core Text reduces its font instead of moving or
+/// expanding into neighboring content.
+enum OverlayLayoutEngine {
+
+  // MARK: Internal
+
+  static func placements(
+    for lines: [OverlayLine],
+    in canvasSize: CGSize,
+    prefersHorizontalTextLayout: Bool = false
+  ) -> [OverlayPlacement] {
+    guard canvasSize.width > 0, canvasSize.height > 0 else { return [] }
+    let canvas = CGRect(origin: .zero, size: canvasSize)
+    let safeBounds = canvasSize.width > 8 && canvasSize.height > 8
+      ? canvas.insetBy(dx: 4, dy: 4)
+      : canvas
+
+    return lines.compactMap { line in
+      // Pending, same-language, unavailable, and deliberately preserved metadata
+      // stay as untouched source pixels.
+      guard line.translatedText != nil else { return nil }
+      let sourceFrame = sourceFrame(
+        for: line.source.box,
+        canvas: canvas,
+        safeBounds: safeBounds
+      )
+      let flow = line.textFlow(prefersHorizontalTextLayout: prefersHorizontalTextLayout)
+      let alignment = resolvedAlignment(
+        for: line,
+        flow: flow,
+        sourceFrame: sourceFrame,
+        canvas: canvas,
+        safeBounds: safeBounds,
+        among: lines
+      )
+      let frame = originalContainerFrame(
+        for: line,
+        flow: flow,
+        alignment: alignment,
+        sourceFrame: sourceFrame,
+        canvas: canvas,
+        safeBounds: safeBounds
+      )
+      return makePlacement(
+        line: line,
+        flow: flow,
+        sourceFrame: sourceFrame,
+        frame: frame,
+        alignment: alignment,
+        preferredFontSize: preferredFontSize(
+          for: line,
+          sourceFrame: sourceFrame,
+          canvasSize: canvasSize
+        )
+      )
+    }
+  }
+
+  static func replacementFrame(
+    for patch: OverlaySourcePatch,
+    sourceLayout: OverlaySourceLayout,
+    in canvasSize: CGSize,
+    displayScale: CGFloat
+  ) -> CGRect {
+    guard canvasSize.width > 0, canvasSize.height > 0 else { return .zero }
+    let canvas = CGRect(origin: .zero, size: canvasSize)
+    let box = patch.box.standardized
+    let source = CGRect(
+      x: box.minX * canvasSize.width,
+      y: box.minY * canvasSize.height,
+      width: max(1, box.width * canvasSize.width),
+      height: max(1, box.height * canvasSize.height)
+    )
+    // Vision boxes hug the strongest part of antialiased glyphs and can omit a
+    // few faint edge pixels, especially around large Japanese headings. Scale
+    // the restoration bleed with glyph height while keeping it tightly bounded.
+    let horizontalBleed: CGFloat
+    let verticalBleed: CGFloat
+    switch sourceLayout {
+    case .horizontal(let rows):
+      horizontalBleed = max(2.5, min(14, source.height * 0.22))
+      // Vision patches hug the strongest source ink. Multiline body copy needs
+      // a 1–3 px halo; single-line labels still need at most one pixel for
+      // faint antialiasing. Detected controls are clipped to their original
+      // rounded surface later, so this cannot repaint outside their border.
+      verticalBleed = rows > 1
+        ? max(1, min(3, source.height * 0.08))
+        : min(1, source.height * 0.04)
+
+    case .vertical:
+      // Vertical OCR boxes often sit against speech-bubble edges. Keep their
+      // old narrow bleed instead of applying the wide horizontal-title rule.
+      horizontalBleed = 2.5
+      verticalBleed = 2
+    }
+    var expanded = source.insetBy(dx: -horizontalBleed, dy: -verticalBleed)
+
+    expanded = expanded.intersection(canvas)
+    guard !expanded.isNull, !expanded.isEmpty else { return .zero }
+    let scale = max(1, displayScale)
+    let minimumX = floor(expanded.minX * scale) / scale
+    let minimumY = floor(expanded.minY * scale) / scale
+    let maximumX = ceil(expanded.maxX * scale) / scale
+    let maximumY = ceil(expanded.maxY * scale) / scale
+    return CGRect(
+      x: minimumX,
+      y: minimumY,
+      width: maximumX - minimumX,
+      height: maximumY - minimumY
+    )
+  }
+
+  static func sourceSurfaceFrame(
+    for surface: OverlaySourceSurface,
+    in canvasSize: CGSize
+  ) -> CGRect {
+    guard canvasSize.width > 0, canvasSize.height > 0 else { return .zero }
+    let canvas = CGRect(origin: .zero, size: canvasSize)
+    let safe = surface.box.standardized
+    let full = (surface.clippingBox ?? surface.box).standardized
+    let interpolation: CGFloat = 0.95
+    let clipping = CGRect(
+      x: safe.minX + (full.minX - safe.minX) * interpolation,
+      y: safe.minY + (full.minY - safe.minY) * interpolation,
+      width: safe.width + (full.width - safe.width) * interpolation,
+      height: safe.height + (full.height - safe.height) * interpolation
+    )
+    return sourceFrame(for: clipping, canvas: canvas, safeBounds: canvas)
+  }
+
+  // MARK: Private
+
+  private static let minimumFontSize: CGFloat = 4
+
+  private static func originalContainerFrame(
+    for line: OverlayLine,
+    flow: OverlayTextFlow,
+    alignment: OverlayTextAlignment,
+    sourceFrame: CGRect,
+    canvas: CGRect,
+    safeBounds: CGRect
+  ) -> CGRect {
+    guard let surface = line.source.surface, surface.confidence >= 0.35 else {
+      return sourceFrame
+    }
+
+    let surfaceFrame = self.sourceFrame(
+      for: surface.box,
+      canvas: canvas,
+      safeBounds: safeBounds
+    )
+    guard surfaceFrame.contains(CGPoint(x: sourceFrame.midX, y: sourceFrame.midY)) else {
+      return sourceFrame
+    }
+    switch (line.source.layout, flow) {
+    case (.vertical, .horizontal):
+      return surfaceFrame
+
+    case (.horizontal(let rows), .horizontal) where rows == 1:
+      // Pills and buttons are compact text containers rather than whole cards.
+      // Use their detected interior so longer translations retain source scale,
+      // but preserve the source text's leading/trailing anchor. Starting at the
+      // surface edge shifts short badge labels into their original padding.
+      guard isCompactSurface(surfaceFrame, around: sourceFrame) else { return sourceFrame }
+      return compactFrame(
+        inside: surfaceFrame,
+        anchoredTo: sourceFrame,
+        alignment: alignment
+      )
+
+    default:
+      return sourceFrame
+    }
+  }
+
+  private static func makePlacement(
+    line: OverlayLine,
+    flow: OverlayTextFlow,
+    sourceFrame: CGRect,
+    frame: CGRect,
+    alignment: OverlayTextAlignment,
+    preferredFontSize: CGFloat
+  ) -> OverlayPlacement {
+    let fittedPreferred: CGFloat =
+      switch flow {
+      case .horizontal:
+        CoreTextTypesetter.horizontalWordFittedFontSize(
+          text: line.displayedText,
+          language: line.displayedLanguage,
+          constrainedToWidth: frame.width,
+          preferred: preferredFontSize,
+          minimum: minimumFontSize,
+          fontWeight: line.source.appearance.fontWeight,
+          fontDesign: line.source.appearance.fontDesign
+        )
+
+      case .vertical:
+        preferredFontSize
+      }
+    let fontSize = CoreTextTypesetter.fittedFontSize(
+      text: line.displayedText,
+      language: line.displayedLanguage,
+      flow: flow,
+      fontWeight: line.source.appearance.fontWeight,
+      fontDesign: line.source.appearance.fontDesign,
+      constrainedTo: frame.size,
+      preferred: fittedPreferred,
+      minimum: minimumFontSize
+    )
+
+    let lineLimit: Int? =
+      switch flow {
+      case .vertical:
+        nil
+
+      case .horizontal:
+        max(
+          1,
+          CoreTextTypesetter.horizontalLineCount(
+            text: line.displayedText,
+            language: line.displayedLanguage,
+            fontSize: fontSize,
+            fontWeight: line.source.appearance.fontWeight,
+            fontDesign: line.source.appearance.fontDesign,
+            in: frame.size
+          )
+        )
+      }
+    return OverlayPlacement(
+      line: line,
+      flow: flow,
+      sourceFrame: sourceFrame,
+      frame: frame,
+      placementBounds: frame,
+      fontSize: fontSize,
+      lineLimit: lineLimit,
+      alignment: alignment
+    )
+  }
+
+  private static func preferredFontSize(
+    for line: OverlayLine,
+    sourceFrame: CGRect,
+    canvasSize: CGSize
+  ) -> CGFloat {
+    let raw: CGFloat =
+      switch line.source.layout {
+      case .horizontal(let rows):
+        preferredHorizontalFontSize(
+          for: line,
+          rows: rows,
+          sourceFrame: sourceFrame,
+          canvasSize: canvasSize
+        )
+
+      case .vertical(let characterScale, _):
+        characterScale > 0
+          ? characterScale * canvasSize.width * 0.92
+          : min(sourceFrame.width * 0.72, sourceFrame.height * 0.2)
+      }
+    // The source frame remains the hard fitting boundary, so a fixed 72 pt cap
+    // only makes large hero text artificially small. Keep a canvas-relative
+    // sanity bound and let Core Text choose the largest size that really fits.
+    let canvasRelativeMaximum = max(72, min(canvasSize.width, canvasSize.height) * 0.22)
+    return max(8, min(canvasRelativeMaximum, raw))
+  }
+
+  private static func compactFrame(
+    inside surfaceFrame: CGRect,
+    anchoredTo sourceFrame: CGRect,
+    alignment: OverlayTextAlignment
+  ) -> CGRect {
+    let surface = surfaceFrame.standardized
+    let source = sourceFrame.standardized
+    let contentInset = min(surface.height * 0.22, surface.width * 0.12)
+    switch alignment {
+    case .leading:
+      let minimumX = min(
+        max(source.minX, surface.minX + contentInset),
+        surface.maxX - 1
+      )
+      return CGRect(
+        x: minimumX,
+        y: surface.minY,
+        width: surface.maxX - minimumX,
+        height: surface.height
+      )
+
+    case .trailing:
+      let maximumX = max(
+        min(source.maxX, surface.maxX - contentInset),
+        surface.minX + 1
+      )
+      return CGRect(
+        x: surface.minX,
+        y: surface.minY,
+        width: maximumX - surface.minX,
+        height: surface.height
+      )
+
+    case .center:
+      return surface
+    }
+  }
+
+  private static func resolvedAlignment(
+    for line: OverlayLine,
+    flow: OverlayTextFlow,
+    sourceFrame: CGRect,
+    canvas: CGRect,
+    safeBounds: CGRect,
+    among lines: [OverlayLine]
+  ) -> OverlayTextAlignment {
+    switch flow {
+    case .vertical:
+      return .center
+
+    case .horizontal(let direction):
+      guard case .horizontal(let rows) = line.source.layout else { return .center }
+      let fallback = line.source.alignment
+        ?? (direction == .rightToLeft ? .trailing : .leading)
+
+      if let surface = line.source.surface, surface.confidence >= 0.35 {
+        let surfaceFrame = self.sourceFrame(
+          for: surface.box,
+          canvas: canvas,
+          safeBounds: safeBounds
+        )
+        if surfaceFrame.contains(CGPoint(x: sourceFrame.midX, y: sourceFrame.midY)) {
+          // Geometry is strong evidence for compact controls because their
+          // surface is the actual text container. A card is different: OCR
+          // bounds hug the rendered glyphs, so a leading paragraph can look
+          // accidentally centered inside the much larger card. Preserve
+          // Vision's paragraph alignment for those non-compact surfaces.
+          guard rows == 1, isCompactSurface(surfaceFrame, around: sourceFrame) else {
+            return fallback
+          }
+          if let local = geometricAlignment(of: sourceFrame, inside: surfaceFrame) {
+            return local
+          }
+        }
+      }
+      return pageAlignment(
+        of: line,
+        sourceFrame: sourceFrame,
+        canvas: canvas,
+        safeBounds: safeBounds,
+        among: lines
+      ) ?? fallback
+    }
+  }
+
+  private static func geometricAlignment(
+    of sourceFrame: CGRect,
+    inside containerFrame: CGRect
+  ) -> OverlayTextAlignment? {
+    let source = sourceFrame.standardized
+    let container = containerFrame.standardized
+    guard container.width > 0, container.contains(CGPoint(x: source.midX, y: source.midY)) else {
+      return nil
+    }
+
+    let leadingMargin = max(0, source.minX - container.minX)
+    let trailingMargin = max(0, container.maxX - source.maxX)
+    if abs(source.midX - container.midX) <= max(2, container.width * 0.06) {
+      return .center
+    }
+
+    let edgeTolerance = max(2, min(source.height * 0.8, container.width * 0.12))
+    if leadingMargin <= edgeTolerance, trailingMargin > leadingMargin + edgeTolerance {
+      return .leading
+    }
+    if trailingMargin <= edgeTolerance, leadingMargin > trailingMargin + edgeTolerance {
+      return .trailing
+    }
+    return nil
+  }
+
+  private static func isCompactSurface(
+    _ surfaceFrame: CGRect,
+    around sourceFrame: CGRect
+  ) -> Bool {
+    surfaceFrame.width <= sourceFrame.width * 2.2
+      && surfaceFrame.height <= sourceFrame.height * 3
+  }
+
+  private static func pageAlignment(
+    of line: OverlayLine,
+    sourceFrame: CGRect,
+    canvas: CGRect,
+    safeBounds: CGRect,
+    among lines: [OverlayLine]
+  ) -> OverlayTextAlignment? {
+    let centeredAxis = abs(sourceFrame.midX - canvas.midX) <= max(
+      sourceFrame.height,
+      canvas.width * 0.035
+    )
+    let sourceBox = line.source.box.standardized
+    let hasNearbyWideCenteredSibling = lines.contains { candidate in
+      guard
+        candidate.id != line.id,
+        candidate.source.surface == nil,
+        case .horizontal = candidate.source.layout
+      else { return false }
+      let candidateBox = candidate.source.box.standardized
+      let verticalGap = max(
+        0,
+        max(sourceBox.minY, candidateBox.minY) - min(sourceBox.maxY, candidateBox.maxY)
+      )
+      return candidateBox.width >= 0.28
+        && abs(candidateBox.midX - 0.5) <= 0.035
+        && abs(candidateBox.midX - sourceBox.midX) <= 0.035
+        && verticalGap <= max(0.06, min(sourceBox.height * 3, 0.12))
+    }
+    if
+      centeredAxis,
+      sourceFrame.width >= canvas.width * 0.28 || hasNearbyWideCenteredSibling
+    {
+      return .center
+    }
+
+    let edgeTolerance = max(4, canvas.width * 0.025)
+    if sourceFrame.minX <= safeBounds.minX + edgeTolerance {
+      return .leading
+    }
+    if sourceFrame.maxX >= safeBounds.maxX - edgeTolerance {
+      return .trailing
+    }
+    return nil
+  }
+
+  private static func preferredHorizontalFontSize(
+    for line: OverlayLine,
+    rows: Int,
+    sourceFrame: CGRect,
+    canvasSize: CGSize
+  ) -> CGFloat {
+    let boxScale = line.source.horizontalGlyphScale > 0
+      ? line.source.horizontalGlyphScale
+      : sourceFrame.height / CGFloat(max(1, rows)) / canvasSize.height
+    // Weight changes stroke thickness, not point size.
+    let boxBasedSize = boxScale * canvasSize.height * 0.94
+    // Vision line boxes can include icons, controls, or Japanese ruby. Whenever
+    // pixel ink shows that inflation clearly, cap the estimate for every source
+    // scale rather than only large controls.
+    guard line.source.horizontalInkScale > 0 else { return boxBasedSize }
+    let inflationRatio = boxScale / line.source.horizontalInkScale
+    guard inflationRatio >= 1.7 else { return boxBasedSize }
+
+    if
+      line.source.language.languageCode?.identifier == "ja",
+      case .horizontal(let rows) = line.source.layout,
+      rows > 1,
+      inflationRatio >= 2.4
+    {
+      // Japanese school material often includes furigana inside every Vision
+      // row box. Pixel ink sees only the thin strokes while the box includes
+      // both ruby and base glyphs, so the generic icon cap makes body text tiny.
+      // The base glyph occupies roughly the lower half of that Apple-provided
+      // row geometry; Core Text still performs the final fit inside the frame.
+      let rubyAwareSize = boxScale * canvasSize.height * 0.54
+      let inkBasedSize = line.source.horizontalInkScale * canvasSize.height * 1.3
+      return min(boxBasedSize, max(inkBasedSize, rubyAwareSize))
+    }
+    if rows > 1 {
+      if boxBasedSize <= 32 {
+        // Small table/list copy can use a line-height-like Vision box while
+        // low-contrast ink captures only its darkest center. Blend those two
+        // bounds instead of trusting either extreme.
+        let inkBasedSize = line.source.horizontalInkScale * canvasSize.height * 2.4
+        return min(boxBasedSize, max(boxBasedSize * 0.76, inkBasedSize))
+      }
+      // A multiline paragraph supplies independent row geometry, so its
+      // per-row Vision box is a better point-size estimate than the darkest
+      // antialiased ink pixels. The ink cap is for single-line controls whose
+      // box may include an icon; applying it to body copy made 32pt source text
+      // render around 24pt despite ample room in the original frame.
+      return boxBasedSize
+    }
+    // On small, low-contrast single-line copy, thresholded foreground ink can
+    // cover only the darkest core of each antialiased glyph. Reserve the ink
+    // cap for genuinely inflated observations such as an icon and label
+    // reported inside one large control row.
+    guard boxBasedSize > 32 else { return boxBasedSize }
+    return min(boxBasedSize, line.source.horizontalInkScale * canvasSize.height * 1.3)
+  }
+
+  private static func sourceFrame(
+    for normalizedBox: CGRect,
+    canvas: CGRect,
+    safeBounds: CGRect
+  ) -> CGRect {
+    let box = normalizedBox.standardized
+    let raw = CGRect(
+      x: box.minX * canvas.width,
+      y: box.minY * canvas.height,
+      width: max(1, box.width * canvas.width),
+      height: max(1, box.height * canvas.height)
+    )
+    return containedFrame(raw, in: safeBounds)
+  }
+
+  private static func containedFrame(_ frame: CGRect, in bounds: CGRect) -> CGRect {
+    let width = min(max(1, frame.width), max(1, bounds.width))
+    let height = min(max(1, frame.height), max(1, bounds.height))
+    let x = min(max(frame.minX, bounds.minX), bounds.maxX - width)
+    let y = min(max(frame.minY, bounds.minY), bounds.maxY - height)
+    return CGRect(x: x, y: y, width: width, height: height)
+  }
+}

--- a/Sources/Overlay/OverlayLayoutEngine.swift
+++ b/Sources/Overlay/OverlayLayoutEngine.swift
@@ -24,6 +24,7 @@ struct OverlayPlacement: Equatable, Identifiable, Sendable {
   /// Hard boundary that replacement text must never cross.
   let placementBounds: CGRect
   let fontSize: CGFloat
+  let lineHeightMultiple: CGFloat
   let lineLimit: Int?
   let alignment: OverlayTextAlignment
 
@@ -90,7 +91,8 @@ enum OverlayLayoutEngine {
           for: line,
           sourceFrame: sourceFrame,
           canvasSize: canvasSize
-        )
+        ),
+        canvasHeight: canvasSize.height
       )
     }
   }
@@ -218,8 +220,15 @@ enum OverlayLayoutEngine {
     sourceFrame: CGRect,
     frame: CGRect,
     alignment: OverlayTextAlignment,
-    preferredFontSize: CGFloat
+    preferredFontSize: CGFloat,
+    canvasHeight: CGFloat
   ) -> OverlayPlacement {
+    let lineHeightMultiple = horizontalLineHeightMultiple(
+      for: line,
+      flow: flow,
+      preferredFontSize: preferredFontSize,
+      canvasHeight: canvasHeight
+    )
     let fittedPreferred: CGFloat =
       switch flow {
       case .horizontal:
@@ -244,7 +253,8 @@ enum OverlayLayoutEngine {
       fontDesign: line.source.appearance.fontDesign,
       constrainedTo: frame.size,
       preferred: fittedPreferred,
-      minimum: minimumFontSize
+      minimum: minimumFontSize,
+      lineHeightMultiple: lineHeightMultiple
     )
 
     let lineLimit: Int? =
@@ -261,7 +271,8 @@ enum OverlayLayoutEngine {
             fontSize: fontSize,
             fontWeight: line.source.appearance.fontWeight,
             fontDesign: line.source.appearance.fontDesign,
-            in: frame.size
+            in: frame.size,
+            lineHeightMultiple: lineHeightMultiple
           )
         )
       }
@@ -272,9 +283,35 @@ enum OverlayLayoutEngine {
       frame: frame,
       placementBounds: frame,
       fontSize: fontSize,
+      lineHeightMultiple: lineHeightMultiple,
       lineLimit: lineLimit,
       alignment: alignment
     )
+  }
+
+  private static func horizontalLineHeightMultiple(
+    for line: OverlayLine,
+    flow: OverlayTextFlow,
+    preferredFontSize: CGFloat,
+    canvasHeight: CGFloat
+  ) -> CGFloat {
+    guard
+      case .horizontal = flow,
+      case .horizontal(let rows) = line.source.layout,
+      rows > 1,
+      line.source.horizontalLineAdvanceScale > 0,
+      canvasHeight > 0
+    else { return 1 }
+
+    let naturalLineHeight = CoreTextTypesetter.lineHeight(
+      fontSize: preferredFontSize,
+      language: line.displayedLanguage,
+      fontWeight: line.source.appearance.fontWeight,
+      fontDesign: line.source.appearance.fontDesign
+    )
+    guard naturalLineHeight > 0 else { return 1 }
+    let sourceLineAdvance = line.source.horizontalLineAdvanceScale * canvasHeight
+    return min(1.6, max(1, sourceLineAdvance / naturalLineHeight))
   }
 
   private static func preferredFontSize(

--- a/Sources/Overlay/OverlayLayoutEngine.swift
+++ b/Sources/Overlay/OverlayLayoutEngine.swift
@@ -358,6 +358,7 @@ enum OverlayLayoutEngine {
       guard case .horizontal(let rows) = line.source.layout else { return .center }
       let fallback = line.source.alignment
         ?? (direction == .rightToLeft ? .trailing : .leading)
+      let neighboring = neighboringBlockAlignment(for: line, among: lines)
 
       if let surface = line.source.surface, surface.confidence >= 0.35 {
         let surfaceFrame = self.sourceFrame(
@@ -372,21 +373,83 @@ enum OverlayLayoutEngine {
           // accidentally centered inside the much larger card. Preserve
           // Vision's paragraph alignment for those non-compact surfaces.
           guard rows == 1, isCompactSurface(surfaceFrame, around: sourceFrame) else {
-            return fallback
+            return neighboring ?? fallback
           }
           if let local = geometricAlignment(of: sourceFrame, inside: surfaceFrame) {
             return local
           }
         }
       }
-      return pageAlignment(
-        of: line,
+      return neighboring ?? pageAlignment(
         sourceFrame: sourceFrame,
-        canvas: canvas,
         safeBounds: safeBounds,
-        among: lines
+        canvasWidth: canvas.width
       ) ?? fallback
     }
+  }
+
+  private static func neighboringBlockAlignment(
+    for line: OverlayLine,
+    among lines: [OverlayLine]
+  ) -> OverlayTextAlignment? {
+    let source = line.source.box.standardized
+    let sourceRowScale = horizontalRowScale(of: line.source)
+    let evidence = lines.compactMap { candidate -> OverlayTextAlignment? in
+      guard
+        candidate.id != line.id,
+        case .horizontal = candidate.source.layout
+      else { return nil }
+      let other = candidate.source.box.standardized
+      guard source.width > 0, source.height > 0, other.width > 0, other.height > 0 else {
+        return nil
+      }
+
+      let intersection = source.intersection(other)
+      let verticalOverlap = intersection.isNull ? 0 : intersection.height
+      guard verticalOverlap / min(source.height, other.height) <= 0.25 else { return nil }
+
+      let verticalGap = max(
+        0,
+        max(source.minY, other.minY) - min(source.maxY, other.maxY)
+      )
+      let rowScale = max(sourceRowScale, horizontalRowScale(of: candidate.source))
+      let maximumGap = min(0.08, max(0.02, rowScale * 2.5))
+      guard verticalGap <= maximumGap else { return nil }
+
+      let horizontalOverlap = max(0, min(source.maxX, other.maxX) - max(source.minX, other.minX))
+      guard horizontalOverlap / min(source.width, other.width) >= 0.55 else { return nil }
+
+      let tolerance = max(0.003, min(0.018, rowScale * 0.55))
+      let scores: [(alignment: OverlayTextAlignment, distance: CGFloat)] = [
+        (.leading, abs(source.minX - other.minX)),
+        (.center, abs(source.midX - other.midX)),
+        (.trailing, abs(source.maxX - other.maxX)),
+      ].sorted { $0.distance < $1.distance }
+      guard
+        let best = scores.first,
+        best.distance <= tolerance,
+        scores.count < 2 || scores[1].distance - best.distance >= max(0.003, tolerance * 0.4)
+      else { return nil }
+      return best.alignment
+    }
+
+    guard !evidence.isEmpty else { return nil }
+    let ranked = [OverlayTextAlignment.leading, .center, .trailing]
+      .map { alignment in
+        (alignment: alignment, count: evidence.count { $0 == alignment })
+      }
+      .filter { $0.count > 0 }
+      .sorted { $0.count > $1.count }
+    guard
+      let best = ranked.first,
+      ranked.count < 2 || best.count > ranked[1].count
+    else { return nil }
+    return best.alignment
+  }
+
+  private static func horizontalRowScale(of source: OverlayLine.Source) -> CGFloat {
+    guard case .horizontal(let rows) = source.layout else { return 0 }
+    return max(source.horizontalGlyphScale, source.box.height / CGFloat(max(1, rows)))
   }
 
   private static func geometricAlignment(
@@ -424,41 +487,15 @@ enum OverlayLayoutEngine {
   }
 
   private static func pageAlignment(
-    of line: OverlayLine,
     sourceFrame: CGRect,
-    canvas: CGRect,
     safeBounds: CGRect,
-    among lines: [OverlayLine]
+    canvasWidth: CGFloat
   ) -> OverlayTextAlignment? {
-    let centeredAxis = abs(sourceFrame.midX - canvas.midX) <= max(
-      sourceFrame.height,
-      canvas.width * 0.035
-    )
-    let sourceBox = line.source.box.standardized
-    let hasNearbyWideCenteredSibling = lines.contains { candidate in
-      guard
-        candidate.id != line.id,
-        candidate.source.surface == nil,
-        case .horizontal = candidate.source.layout
-      else { return false }
-      let candidateBox = candidate.source.box.standardized
-      let verticalGap = max(
-        0,
-        max(sourceBox.minY, candidateBox.minY) - min(sourceBox.maxY, candidateBox.maxY)
-      )
-      return candidateBox.width >= 0.28
-        && abs(candidateBox.midX - 0.5) <= 0.035
-        && abs(candidateBox.midX - sourceBox.midX) <= 0.035
-        && verticalGap <= max(0.06, min(sourceBox.height * 3, 0.12))
-    }
-    if
-      centeredAxis,
-      sourceFrame.width >= canvas.width * 0.28 || hasNearbyWideCenteredSibling
-    {
-      return .center
-    }
-
-    let edgeTolerance = max(4, canvas.width * 0.025)
+    // A wide OCR box centered on the page is not evidence of centered text:
+    // full-width search results and article rows have the same geometry. Center
+    // alignment must come from Vision, a detected surface, or neighboring rows
+    // that share a clear midpoint. Page geometry is reliable only at its edges.
+    let edgeTolerance = max(4, canvasWidth * 0.025)
     if sourceFrame.minX <= safeBounds.minX + edgeTolerance {
       return .leading
     }

--- a/Sources/Overlay/OverlayLayoutEngine.swift
+++ b/Sources/Overlay/OverlayLayoutEngine.swift
@@ -395,7 +395,11 @@ enum OverlayLayoutEngine {
       guard case .horizontal(let rows) = line.source.layout else { return .center }
       let fallback = line.source.alignment
         ?? (direction == .rightToLeft ? .trailing : .leading)
-      let neighboring = neighboringBlockAlignment(for: line, among: lines)
+      let preservesLeadingAccessory = fallback == .leading
+        && hasLeadingAccessoryIndent(for: line, among: lines)
+      let neighboring = preservesLeadingAccessory
+        ? .leading
+        : neighboringBlockAlignment(for: line, among: lines)
 
       if let surface = line.source.surface, surface.confidence >= 0.35 {
         let surfaceFrame = self.sourceFrame(
@@ -482,6 +486,63 @@ enum OverlayLayoutEngine {
       ranked.count < 2 || best.count > ranked[1].count
     else { return nil }
     return best.alignment
+  }
+
+  private static func hasLeadingAccessoryIndent(
+    for line: OverlayLine,
+    among lines: [OverlayLine]
+  ) -> Bool {
+    guard
+      line.source.alignment == nil,
+      case .horizontal(let rows) = line.source.layout,
+      rows == 1
+    else { return false }
+    let source = line.source.box.standardized
+    guard source.width > 0, source.height > 0, source.width <= 0.25 else { return false }
+    let sourceRowScale = horizontalRowScale(of: line.source)
+    let nearby = lines.compactMap { candidate -> CGRect? in
+      guard
+        candidate.id != line.id,
+        case .horizontal = candidate.source.layout
+      else { return nil }
+      let other = candidate.source.box.standardized
+      guard other.width > 0, other.height > 0 else { return nil }
+
+      let intersection = source.intersection(other)
+      let verticalOverlap = intersection.isNull ? 0 : intersection.height
+      guard verticalOverlap / min(source.height, other.height) <= 0.25 else { return nil }
+      let verticalGap = max(
+        0,
+        max(source.minY, other.minY) - min(source.maxY, other.maxY)
+      )
+      let rowScale = max(sourceRowScale, horizontalRowScale(of: candidate.source))
+      let maximumGap = min(0.08, max(0.02, rowScale * 2.5))
+      guard verticalGap <= maximumGap else { return nil }
+
+      let horizontalOverlap = max(0, min(source.maxX, other.maxX) - max(source.minX, other.minX))
+      guard horizontalOverlap / min(source.width, other.width) >= 0.55 else { return nil }
+      return other
+    }
+    let above = nearby.filter { $0.midY < source.midY }
+    let below = nearby.filter { $0.midY > source.midY }
+
+    for upper in above {
+      for lower in below {
+        let rowScale = max(sourceRowScale, max(upper.height, lower.height))
+        let edgeTolerance = max(0.003, min(0.018, rowScale * 0.55))
+        guard abs(upper.minX - lower.minX) <= edgeTolerance else { continue }
+        let commonLeadingEdge = (upper.minX + lower.minX) / 2
+        let leadingIndent = source.minX - commonLeadingEdge
+        guard
+          leadingIndent >= max(0.006, sourceRowScale * 0.75),
+          leadingIndent <= min(0.08, sourceRowScale * 3),
+          source.width <= max(upper.width, lower.width) * 0.8,
+          max(upper.maxX, lower.maxX) - source.maxX >= max(0.01, sourceRowScale * 2)
+        else { continue }
+        return true
+      }
+    }
+    return false
   }
 
   private static func horizontalRowScale(of source: OverlayLine.Source) -> CGFloat {

--- a/Sources/Overlay/OverlaySourceAppearanceAnalyzer.swift
+++ b/Sources/Overlay/OverlaySourceAppearanceAnalyzer.swift
@@ -10,10 +10,10 @@ enum OverlaySourceAppearanceAnalyzer {
 
   // MARK: Internal
 
-  static func applyingAppearances(to result: OCRResult, from image: CGImage) -> OCRResult {
+  static func applyingAppearances(to result: OCRResult, from image: CGImage) async -> OCRResult {
     let styleRaster = PixelRaster(image: image, longestSide: 1_024)
     let surfaceRaster = PixelRaster(image: image, longestSide: 384)
-    let styled = OCRResult(lines: result.lines.map { line in
+    let styled = OCRResult(lines: await concurrentMap(result.lines) { line in
       var line = line
       let lineAppearance = styleRaster.map {
         appearance(around: line.boundingBoxNormalized, raster: $0)
@@ -217,7 +217,7 @@ enum OverlaySourceAppearanceAnalyzer {
       return line
     })
     let coalesced = styled.absorbingRubyAnnotations().coalescingParagraphFragments()
-    return OCRResult(lines: coalesced.lines.map { line in
+    return OCRResult(lines: await concurrentMap(coalesced.lines) { line in
       var line = line
       if line.wasCoalesced, !line.isVerticalBlock, let styleRaster {
         let sampledUnion = appearance(around: line.boundingBoxNormalized, raster: styleRaster)
@@ -258,12 +258,20 @@ enum OverlaySourceAppearanceAnalyzer {
             ? surface
             : nil
         }
-        let updatedSurface = inferredSurface(
-          containing: sourceBox,
-          appearance: line.appearance,
-          raster: surfaceRaster,
-          limitingTo: previousSurface?.clippingBox
-        )
+        // Initial analysis already found or rejected a surface for every
+        // unmerged line. Re-run the flood fill only when coalescing changed the
+        // source bounds, or when that change invalidated a previously found
+        // surface. The old unconditional pass doubled this cost on dense pages.
+        let needsSurfaceRefresh = line.wasCoalesced
+          || (line.surface != nil && previousSurface == nil)
+        let updatedSurface = needsSurfaceRefresh
+          ? inferredSurface(
+            containing: sourceBox,
+            appearance: line.appearance,
+            raster: surfaceRaster,
+            limitingTo: previousSurface?.clippingBox
+          )
+          : nil
         line.surface = previousSurface.flatMap {
           isCompactTextSurface($0, around: sourceBox) ? $0 : nil
         } ?? updatedSurface ?? previousSurface
@@ -347,7 +355,7 @@ enum OverlaySourceAppearanceAnalyzer {
     var weight: CGFloat = 1
   }
 
-  private struct PixelRaster {
+  private struct PixelRaster: Sendable {
 
     // MARK: Lifecycle
 
@@ -407,6 +415,26 @@ enum OverlaySourceAppearanceAnalyzer {
     ) -> Bool {
       guard let sample = self.color(at: index) else { return false }
       return sample.distance(to: color) <= tolerance
+    }
+  }
+
+  /// Appearance sampling is independent per OCR line. Structured child tasks
+  /// let the executor use available cores while the indexed merge keeps Vision's
+  /// stable source order intact for paragraph reconstruction.
+  private static func concurrentMap<Element: Sendable, Output: Sendable>(
+    _ elements: [Element],
+    transform: @escaping @Sendable (Element) -> Output
+  ) async -> [Output] {
+    guard elements.count > 1 else { return elements.map(transform) }
+    return await withTaskGroup(of: (Int, Output).self) { group in
+      for (index, element) in elements.enumerated() {
+        group.addTask { (index, transform(element)) }
+      }
+      var ordered = [Output?](repeating: nil, count: elements.count)
+      for await (index, output) in group {
+        ordered[index] = output
+      }
+      return ordered.compactMap { $0 }
     }
   }
 
@@ -646,6 +674,12 @@ enum OverlaySourceAppearanceAnalyzer {
       cursor += 1
       let x = index % raster.width
       let y = index / raster.width
+      // Components that reach the capture edge represent the page/background,
+      // not a local text surface. Return as soon as that outcome is known
+      // instead of traversing the full page.
+      if x == 0 || y == 0 || x == raster.width - 1 || y == raster.height - 1 {
+        return nil
+      }
       minimumX = min(minimumX, x)
       minimumY = min(minimumY, y)
       maximumX = max(maximumX, x)
@@ -681,11 +715,6 @@ enum OverlaySourceAppearanceAnalyzer {
       }
     }
 
-    let touchesImageEdge = minimumX == 0
-      || minimumY == 0
-      || maximumX == raster.width - 1
-      || maximumY == raster.height - 1
-    guard !touchesImageEdge else { return nil }
     let component = CGRect(
       x: minimumX,
       y: minimumY,
@@ -979,7 +1008,11 @@ enum OverlaySourceAppearanceAnalyzer {
     excluding excluded: CGRect?,
     raster: PixelRaster
   ) -> DominantSample? {
-    var buckets = [Int: Bucket]()
+    // Samples are quantized to four bits per RGB channel below, so every key
+    // is in a fixed 16³ space. Direct indexing avoids allocating and hashing a
+    // fresh Dictionary for every line, word, and restoration patch.
+    var buckets = [Bucket](repeating: Bucket(), count: 4_096)
+    var occupiedKeys = [Int]()
     var total = 0
     for y in Int(bounds.minY) ..< Int(bounds.maxY) {
       for x in Int(bounds.minX) ..< Int(bounds.maxX) {
@@ -990,18 +1023,23 @@ enum OverlaySourceAppearanceAnalyzer {
         let green = Int((color.green * 255).rounded())
         let blue = Int((color.blue * 255).rounded())
         let key = (red >> 4) << 8 | (green >> 4) << 4 | (blue >> 4)
-        var bucket = buckets[key, default: Bucket()]
-        bucket.count += 1
-        bucket.red += red
-        bucket.green += green
-        bucket.blue += blue
-        buckets[key] = bucket
+        if buckets[key].count == 0 {
+          occupiedKeys.append(key)
+        }
+        buckets[key].count += 1
+        buckets[key].red += red
+        buckets[key].green += green
+        buckets[key].blue += blue
         total += 1
       }
     }
-    guard total > 0, let dominant = buckets.values.max(by: { $0.count < $1.count }) else {
+    guard
+      total > 0,
+      let dominantKey = occupiedKeys.max(by: { buckets[$0].count < buckets[$1].count })
+    else {
       return nil
     }
+    let dominant = buckets[dominantKey]
     let divisor = CGFloat(dominant.count * 255)
     return DominantSample(
       color: OverlayColor(

--- a/Sources/Overlay/OverlaySourceAppearanceAnalyzer.swift
+++ b/Sources/Overlay/OverlaySourceAppearanceAnalyzer.swift
@@ -132,15 +132,85 @@ enum OverlaySourceAppearanceAnalyzer {
           line.replacementPatches.append(rubyPatch)
         }
       }
-      if !line.isVerticalBlock, line.appearance.inkHeightScale > 0 {
-        line.horizontalInkScale = line.appearance.inkHeightScale
-      }
       line.surface = surfaceRaster.flatMap {
         inferredSurface(
           containing: line.boundingBoxNormalized,
           appearance: line.appearance,
           raster: $0
         )
+      }
+      let hasDistinctCompactFill = !line.isVerticalBlock
+        && line.rowCount == 1
+        && line.appearance.background.distance(to: surroundingBackground) >= 0.18
+      if line.surface == nil, hasDistinctCompactFill, let styleRaster {
+        // The low-resolution flood fill is normally enough for cards and
+        // balloons. Densely lettered pills can leave only a one-pixel corridor
+        // at that scale, though, so retry just those compact high-contrast
+        // candidates with the style raster already held in memory.
+        line.surface = inferredSurface(
+          containing: line.boundingBoxNormalized,
+          appearance: line.appearance,
+          raster: styleRaster
+        )
+      }
+      if
+        hasDistinctCompactFill,
+        let surface = line.surface,
+        isCompactTextSurface(surface, around: line.boundingBoxNormalized)
+      {
+        line.surface = applyingCompactTextInsets(to: surface)
+      }
+      if
+        hasDistinctCompactFill,
+        let surface = line.surface,
+        let styleRaster,
+        isCompactTextSurface(surface, around: line.boundingBoxNormalized),
+        let refined = compactSurfaceAppearance(
+          for: line.boundingBoxNormalized,
+          inside: surface,
+          original: line.appearance,
+          surroundingBackground: surroundingBackground,
+          raster: styleRaster
+        )
+      {
+        let original = line.appearance
+        line.appearance = refined
+        line.styleRuns = line.styleRuns.map { run in
+          var run = run
+          guard run.appearance.background.distance(to: original.background) <= 0.08 else {
+            return run
+          }
+          run.appearance.background = refined.background
+          if
+            run.appearance.foregroundConfidence < 0.08
+            || run.appearance.foreground.distance(to: original.foreground) <= 0.12
+          {
+            run.appearance.foreground = refined.foreground
+            run.appearance.foregroundConfidence = refined.foregroundConfidence
+            run.appearance.inkCoverage = refined.inkCoverage
+            run.appearance.inkHeightScale = refined.inkHeightScale
+            run.appearance.fontWeight = refined.fontWeight
+            run.appearance.isUnderlined = refined.isUnderlined
+          }
+          return run
+        }
+        line.replacementPatches = line.replacementPatches.map { patch in
+          var patch = patch
+          guard patch.appearance.background.distance(to: original.background) <= 0.08 else {
+            return patch
+          }
+          patch.appearance.background = refined.background
+          patch.appearance.foreground = refined.foreground
+          patch.appearance.foregroundConfidence = refined.foregroundConfidence
+          patch.appearance.inkCoverage = refined.inkCoverage
+          patch.appearance.inkHeightScale = refined.inkHeightScale
+          patch.appearance.fontWeight = refined.fontWeight
+          patch.appearance.isUnderlined = refined.isUnderlined
+          return patch
+        }
+      }
+      if !line.isVerticalBlock, line.appearance.inkHeightScale > 0 {
+        line.horizontalInkScale = line.appearance.inkHeightScale
       }
       return line
     })
@@ -186,12 +256,15 @@ enum OverlaySourceAppearanceAnalyzer {
             ? surface
             : nil
         }
-        line.surface = inferredSurface(
+        let updatedSurface = inferredSurface(
           containing: sourceBox,
           appearance: line.appearance,
           raster: surfaceRaster,
           limitingTo: previousSurface?.clippingBox
-        ) ?? previousSurface
+        )
+        line.surface = previousSurface.flatMap {
+          isCompactTextSurface($0, around: sourceBox) ? $0 : nil
+        } ?? updatedSurface ?? previousSurface
       }
       if let styleRaster {
         let sourceLength = (line.text as NSString).length
@@ -993,6 +1066,66 @@ enum OverlaySourceAppearanceAnalyzer {
       dy: -max(4, source.height)
     ).integral.intersection(CGRect(x: 0, y: 0, width: raster.width, height: raster.height))
     return dominantSample(in: bounds, excluding: source, raster: raster)?.color
+  }
+
+  private static func compactSurfaceAppearance(
+    for source: CGRect,
+    inside surface: OverlaySourceSurface,
+    original: OverlaySourceAppearance,
+    surroundingBackground: OverlayColor,
+    raster: PixelRaster
+  ) -> OverlaySourceAppearance? {
+    let sampleBox = source.standardized.intersection(surface.box.standardized)
+    guard !sampleBox.isNull, !sampleBox.isEmpty else { return nil }
+    var refined = appearance(around: sampleBox, raster: raster)
+    guard refined.background.distance(to: original.background) <= 0.08 else { return nil }
+
+    // A tight OCR box can protrude by a pixel beyond a rounded chip. The
+    // parent's high-contrast color then wins the "farthest pixel" vote and is
+    // mistaken for both glyph ink and font height. Sampling within the detected
+    // interior removes that border contamination while retaining actual ink.
+    let originalMatchesParent = original.foreground.distance(to: surroundingBackground) <= 0.12
+    let hasBetterInkEvidence = refined.foregroundConfidence
+      >= max(0.04, original.foregroundConfidence * 1.2)
+    guard originalMatchesParent || hasBetterInkEvidence else { return nil }
+    refined.fontDesign = original.fontDesign
+    return refined
+  }
+
+  private static func isCompactTextSurface(
+    _ surface: OverlaySourceSurface,
+    around normalizedSource: CGRect
+  ) -> Bool {
+    let surface = (surface.clippingBox ?? surface.box).standardized
+    let source = normalizedSource.standardized
+    guard !surface.isEmpty, !source.isEmpty else { return false }
+    let intersection = surface.intersection(source)
+    guard !intersection.isNull, !intersection.isEmpty else { return false }
+    let sourceArea = max(0.000_001, source.width * source.height)
+    let surfaceArea = surface.width * surface.height
+    let coveredSource = intersection.width * intersection.height / sourceArea
+    return coveredSource >= 0.75
+      && surfaceArea / sourceArea <= 8
+      && surface.width <= source.width * 2.2
+      && surface.height <= source.height * 3
+  }
+
+  private static func applyingCompactTextInsets(
+    to surface: OverlaySourceSurface
+  ) -> OverlaySourceSurface {
+    guard let clippingBox = surface.clippingBox?.standardized else { return surface }
+    guard clippingBox.width / max(0.000_001, clippingBox.height) >= 2.2 else { return surface }
+    let verticalInset = clippingBox.height * 0.15
+    let insetBox = CGRect(
+      x: surface.box.minX,
+      y: clippingBox.minY + verticalInset,
+      width: surface.box.width,
+      height: clippingBox.height - verticalInset * 2
+    )
+    guard !insetBox.isEmpty else { return surface }
+    var surface = surface
+    surface.box = insetBox
+    return surface
   }
 
   private static func isCompactInlineSurface(_ surface: CGRect, around source: CGRect) -> Bool {

--- a/Sources/Overlay/OverlaySourceAppearanceAnalyzer.swift
+++ b/Sources/Overlay/OverlaySourceAppearanceAnalyzer.swift
@@ -150,7 +150,9 @@ enum OverlaySourceAppearanceAnalyzer {
         line.surface = inferredSurface(
           containing: line.boundingBoxNormalized,
           appearance: line.appearance,
-          raster: styleRaster
+          raster: styleRaster,
+          minimumConfidence: 0.30,
+          acceptedConfidenceFloor: 0.35
         )
       }
       if
@@ -569,7 +571,9 @@ enum OverlaySourceAppearanceAnalyzer {
     containing normalizedSource: CGRect,
     appearance: OverlaySourceAppearance,
     raster: PixelRaster,
-    limitingTo normalizedLimit: CGRect? = nil
+    limitingTo normalizedLimit: CGRect? = nil,
+    minimumConfidence: CGFloat = 0.35,
+    acceptedConfidenceFloor: CGFloat? = nil
   ) -> OverlaySourceSurface? {
     let unit = CGRect(x: 0, y: 0, width: 1, height: 1)
     let normalizedSource = normalizedSource.standardized.intersection(unit)
@@ -709,7 +713,7 @@ enum OverlaySourceAppearanceAnalyzer {
         * min(1, fillRatio / 0.65)
         * min(1, 0.65 + (expansion - 1) * 0.2)
     )
-    guard confidence >= 0.35 else { return nil }
+    guard confidence >= minimumConfidence else { return nil }
     let cornerRadiusFraction = inferredCornerRadiusFraction(
       minimumY: minimumY,
       maximumY: maximumY,
@@ -723,7 +727,11 @@ enum OverlaySourceAppearanceAnalyzer {
         width: safe.width / CGFloat(raster.width),
         height: safe.height / CGFloat(raster.height)
       ),
-      confidence: confidence,
+      // A high-resolution retry is made only for a compact fill already known
+      // to contrast with its surroundings. Promote that accepted geometry to
+      // the renderer's ordinary confidence floor instead of detecting it and
+      // then discarding it one stage later.
+      confidence: max(confidence, acceptedConfidenceFloor ?? confidence),
       clippingBox: CGRect(
         x: component.minX / CGFloat(raster.width),
         y: component.minY / CGFloat(raster.height),

--- a/Sources/Overlay/OverlaySourceAppearanceAnalyzer.swift
+++ b/Sources/Overlay/OverlaySourceAppearanceAnalyzer.swift
@@ -1,0 +1,1242 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import Foundation
+
+// MARK: - OverlaySourceAppearanceAnalyzer
+
+enum OverlaySourceAppearanceAnalyzer {
+
+  // MARK: Internal
+
+  static func applyingAppearances(to result: OCRResult, from image: CGImage) -> OCRResult {
+    let styleRaster = PixelRaster(image: image, longestSide: 1_024)
+    let surfaceRaster = PixelRaster(image: image, longestSide: 384)
+    let styled = OCRResult(lines: result.lines.map { line in
+      var line = line
+      let lineAppearance = styleRaster.map {
+        appearance(around: line.boundingBoxNormalized, raster: $0)
+      } ?? .fallback
+      let surroundingBackground = styleRaster.flatMap {
+        sampledSurroundingBackground(around: line.boundingBoxNormalized, raster: $0)
+      } ?? lineAppearance.background
+      line.styleRuns = line.styleRuns.map { run in
+        var run = run
+        if let styleRaster {
+          run.appearance = appearance(around: run.box, raster: styleRaster)
+          run.appearance.fontDesign = fontDesign(
+            for: text(in: run.range, source: line.text),
+            appearance: run.appearance,
+            surroundingBackground: surroundingBackground
+          )
+        }
+        return run
+      }
+      let sourceLength = (line.text as NSString).length
+      let distinctStyleRuns = line.styleRuns.filter { run in
+        let isPartialStyle = run.range.location > 0 || NSMaxRange(run.range) < sourceLength
+        return isPartialStyle
+          && run.appearance.background.distance(to: surroundingBackground) >= 0.025
+      }
+      // Vision tokenizes punctuation separately, so a standalone pill such as
+      // `On-device` arrives as three partial runs even though the compact
+      // surface belongs to the whole line. Only erase a styled surface when
+      // the distinct runs leave other visible source text outside them.
+      let inlineStyleRuns = coversVisibleSource(distinctStyleRuns, in: line.text)
+        ? []
+        : distinctStyleRuns
+      let patches = line.replacementPatches.isEmpty
+        ? [OverlaySourcePatch(box: line.boundingBoxNormalized)]
+        : line.replacementPatches
+      line.replacementPatches = patches.map { patch in
+        var patch = patch
+        if let styleRun = line.styleRuns.first(where: { sameBox($0.box, patch.box) }) {
+          patch.appearance = styleRun.appearance
+          if inlineStyleRuns.contains(where: { sameBox($0.box, styleRun.box) }) {
+            // Inline code and badges carry their own source background. Erase
+            // that old compact surface back to the parent container; the
+            // mapped target style redraws the chip at the translated token's
+            // new position. Keeping the source surface produced empty pills.
+            patch.appearance.background = surroundingBackground
+            patch.erasesDistinctSurface = true
+          }
+        } else if let styleRaster {
+          patch.appearance = appearance(around: patch.box, raster: styleRaster)
+        }
+        return patch
+      }
+      if let styleRaster, !inlineStyleRuns.isEmpty {
+        line.replacementPatches.append(contentsOf: inlineSurfaceErasers(
+          for: inlineStyleRuns,
+          parentBackground: surroundingBackground,
+          raster: styleRaster
+        ))
+      }
+      let appearanceSamples: [WeightedAppearance]
+      if line.styleRuns.isEmpty {
+        appearanceSamples = line.replacementPatches.map {
+          WeightedAppearance(appearance: $0.appearance)
+        }
+      } else {
+        let textLength = (line.text as NSString).length
+        let coveredLength = min(
+          textLength,
+          line.styleRuns.reduce(0) { $0 + max(0, $1.range.length) }
+        )
+        var samples = line.styleRuns.map {
+          WeightedAppearance(
+            appearance: $0.appearance,
+            weight: CGFloat(max(1, $0.range.length))
+          )
+        }
+        if coveredLength < textLength {
+          samples.append(WeightedAppearance(
+            appearance: lineAppearance,
+            weight: CGFloat(textLength - coveredLength)
+          ))
+        }
+        appearanceSamples = samples
+      }
+      line.appearance = combinedAppearance(appearanceSamples, fallback: lineAppearance)
+      if
+        !line.replacementPatches.contains(where: \.erasesDistinctSurface),
+        shouldConsolidatePatches(
+          line.replacementPatches,
+          into: lineAppearance,
+          isVertical: line.isVerticalBlock
+        )
+      {
+        // A flat line is cleaner as one restoration surface: punctuation and
+        // anti-aliased word edges cannot leak through. Keep word patches only
+        // when they reveal multiple backgrounds, such as text inside a button
+        // whose surrounding ring crosses the control border.
+        line.replacementPatches = [
+          OverlaySourcePatch(box: line.boundingBoxNormalized, appearance: lineAppearance)
+        ]
+      }
+      if
+        !line.isVerticalBlock,
+        let styleRaster,
+        Self.isChromatic(line.appearance.foreground),
+        Self.isLightNeutral(line.appearance.background)
+      {
+        var restorationAppearance = lineAppearance
+        restorationAppearance.background = surroundingBackground
+        let patch = OverlaySourcePatch(
+          box: line.boundingBoxNormalized,
+          appearance: restorationAppearance
+        )
+        line.replacementPatches = [patch]
+        if let rubyPatch = nearbyChromaticRubyPatch(above: patch, raster: styleRaster) {
+          line.replacementPatches.append(rubyPatch)
+        }
+      }
+      if !line.isVerticalBlock, line.appearance.inkHeightScale > 0 {
+        line.horizontalInkScale = line.appearance.inkHeightScale
+      }
+      line.surface = surfaceRaster.flatMap {
+        inferredSurface(
+          containing: line.boundingBoxNormalized,
+          appearance: line.appearance,
+          raster: $0
+        )
+      }
+      return line
+    })
+    let coalesced = styled.absorbingRubyAnnotations().coalescingParagraphFragments()
+    return OCRResult(lines: coalesced.lines.map { line in
+      var line = line
+      if line.wasCoalesced, !line.isVerticalBlock, let styleRaster {
+        let sampledUnion = appearance(around: line.boundingBoxNormalized, raster: styleRaster)
+        let surroundingBackground = sampledSurroundingBackground(
+          around: line.boundingBoxNormalized,
+          raster: styleRaster
+        ) ?? sampledUnion.background
+        let parentCandidates = line.styleRuns.compactMap { run -> WeightedAppearance? in
+          guard run.appearance.background.distance(to: surroundingBackground) <= 0.06 else {
+            return nil
+          }
+          return WeightedAppearance(
+            appearance: run.appearance,
+            weight: CGFloat(max(1, run.range.length))
+          )
+        }
+        let neutralCandidates = parentCandidates.filter {
+          !$0.appearance.isUnderlined && !isChromatic($0.appearance.foreground)
+        }
+        let parentSamples = neutralCandidates.isEmpty ? parentCandidates : neutralCandidates
+        var unionAppearance = combinedAppearance(parentSamples, fallback: sampledUnion)
+        unionAppearance.background = surroundingBackground
+        unionAppearance.fontDesign = fontDesign(
+          for: line.text,
+          appearance: unionAppearance,
+          surroundingBackground: surroundingBackground
+        )
+        line.appearance = unionAppearance
+      }
+      if let surfaceRaster {
+        let sourceBox = line.boundingBoxNormalized.standardized
+        let previousSurface = line.surface.flatMap { surface -> OverlaySourceSurface? in
+          let bounds = (surface.clippingBox ?? surface.box).standardized
+          let intersection = bounds.intersection(sourceBox)
+          guard !intersection.isNull, !intersection.isEmpty else { return nil }
+          let sourceArea = max(0.000_001, sourceBox.width * sourceBox.height)
+          return intersection.width * intersection.height / sourceArea >= 0.94
+            ? surface
+            : nil
+        }
+        line.surface = inferredSurface(
+          containing: sourceBox,
+          appearance: line.appearance,
+          raster: surfaceRaster,
+          limitingTo: previousSurface?.clippingBox
+        ) ?? previousSurface
+      }
+      if let styleRaster {
+        let sourceLength = (line.text as NSString).length
+        let inlineStyleRuns = line.styleRuns.filter { run in
+          let isPartialStyle = run.range.location > 0 || NSMaxRange(run.range) < sourceLength
+          return isPartialStyle
+            && run.appearance.background.distance(to: line.appearance.background) >= 0.025
+        }
+        if !inlineStyleRuns.isEmpty, !coversVisibleSource(inlineStyleRuns, in: line.text) {
+          line.replacementPatches = line.replacementPatches.map { patch in
+            var patch = patch
+            guard inlineStyleRuns.contains(where: { sameBox($0.box, patch.box) }) else {
+              return patch
+            }
+            patch.appearance.background = line.appearance.background
+            patch.erasesDistinctSurface = true
+            return patch
+          }
+          let erasers = inlineSurfaceErasers(
+            for: inlineStyleRuns,
+            parentBackground: line.appearance.background,
+            raster: styleRaster
+          ).filter { candidate in
+            !line.replacementPatches.contains { existing in
+              existing.erasesDistinctSurface && coversSameSurface(existing.box, candidate.box)
+            }
+          }
+          line.replacementPatches.append(contentsOf: erasers)
+        }
+      }
+      if line.isVerticalBlock, line.surface != nil {
+        line.replacementPatches = line.replacementPatches.map { patch in
+          var patch = patch
+          patch.appearance.background = line.appearance.background
+          return patch
+        }
+      }
+      if
+        line.isVerticalBlock,
+        line.verticalCharScale > 0,
+        let styleRaster,
+        let surface = line.surface
+      {
+        line.replacementPatches = line.replacementPatches.map {
+          extendingVerticalPatch(
+            $0,
+            characterScale: line.verticalCharScale,
+            inside: surface.box,
+            raster: styleRaster
+          )
+        }
+      }
+      return line
+    })
+  }
+
+  // MARK: Private
+
+  private struct Bucket {
+    var count = 0
+    var red = 0
+    var green = 0
+    var blue = 0
+  }
+
+  private struct DominantSample {
+    var color: OverlayColor
+    var count: Int
+    var total: Int
+
+    var confidence: CGFloat {
+      CGFloat(count) / CGFloat(max(1, total))
+    }
+  }
+
+  private struct WeightedAppearance {
+    var appearance: OverlaySourceAppearance
+    var weight: CGFloat = 1
+  }
+
+  private struct PixelRaster {
+
+    // MARK: Lifecycle
+
+    init?(image: CGImage, longestSide targetLongestSide: Int) {
+      let sourceLongestSide = max(image.width, image.height)
+      guard sourceLongestSide > 0, targetLongestSide > 0 else { return nil }
+      let scale = min(1, CGFloat(targetLongestSide) / CGFloat(sourceLongestSide))
+      let width = max(1, Int((CGFloat(image.width) * scale).rounded()))
+      let height = max(1, Int((CGFloat(image.height) * scale).rounded()))
+      let bytesPerRow = width * 4
+      var pixels = [UInt8](repeating: 0, count: height * bytesPerRow)
+      let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+      let rendered = pixels.withUnsafeMutableBytes { bytes -> Bool in
+        guard
+          let address = bytes.baseAddress,
+          let context = CGContext(
+            data: address,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+          )
+        else { return false }
+        context.interpolationQuality = .medium
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return true
+      }
+      guard rendered else { return nil }
+      self.width = width
+      self.height = height
+      self.pixels = pixels
+    }
+
+    // MARK: Internal
+
+    let width: Int
+    let height: Int
+    let pixels: [UInt8]
+
+    func color(at index: Int) -> OverlayColor? {
+      let offset = index * 4
+      guard offset >= 0, offset + 3 < pixels.count, pixels[offset + 3] > 127 else { return nil }
+      return OverlayColor(
+        red: CGFloat(pixels[offset]) / 255,
+        green: CGFloat(pixels[offset + 1]) / 255,
+        blue: CGFloat(pixels[offset + 2]) / 255,
+        alpha: 1
+      )
+    }
+
+    func matchesBackground(
+      at index: Int,
+      color: OverlayColor,
+      tolerance: CGFloat
+    ) -> Bool {
+      guard let sample = self.color(at: index) else { return false }
+      return sample.distance(to: color) <= tolerance
+    }
+  }
+
+  private static func extendingVerticalPatch(
+    _ patch: OverlaySourcePatch,
+    characterScale: CGFloat,
+    inside normalizedSurface: CGRect,
+    raster: PixelRaster
+  ) -> OverlaySourcePatch {
+    let source = pixelRect(for: patch.box, raster: raster).integral
+    let surface = pixelRect(for: normalizedSurface, raster: raster).integral
+    guard
+      !source.isNull,
+      !source.isEmpty,
+      !surface.isNull,
+      !surface.isEmpty
+    else { return patch }
+
+    let characterExtent = max(4, Int(ceil(characterScale * CGFloat(raster.width))))
+    let inset = max(1, Int(source.width * 0.12))
+    let minimumX = max(Int(surface.minX), Int(source.minX) + inset)
+    let maximumX = min(Int(surface.maxX), Int(source.maxX) - inset)
+    guard maximumX > minimumX else { return patch }
+
+    let foregroundDistance = patch.appearance.background.distance(to: patch.appearance.foreground)
+    let inkThreshold = max(0.18, foregroundDistance * 0.35)
+    let minimumInkPerRow = max(2, Int(ceil(CGFloat(maximumX - minimumX) * 0.12)))
+    let minimumRunLength = max(4, Int(ceil(CGFloat(characterExtent) * 0.22)))
+
+    func qualifyingRuns(in range: Range<Int>) -> [Range<Int>] {
+      var runs = [Range<Int>]()
+      var runStart: Int?
+      for y in range {
+        let inkCount = (minimumX ..< maximumX).count { x in
+          guard let color = raster.color(at: y * raster.width + x) else { return false }
+          return color.distance(to: patch.appearance.background) >= inkThreshold
+        }
+        if inkCount >= minimumInkPerRow {
+          runStart = runStart ?? y
+        } else if let start = runStart {
+          if y - start >= minimumRunLength { runs.append(start ..< y) }
+          runStart = nil
+        }
+      }
+      if let start = runStart, range.upperBound - start >= minimumRunLength {
+        runs.append(start ..< range.upperBound)
+      }
+      return runs
+    }
+
+    let sourceMinimumY = max(Int(surface.minY), Int(source.minY))
+    let sourceMaximumY = min(Int(surface.maxY), Int(source.maxY))
+    let upperRange = max(Int(surface.minY), sourceMinimumY - characterExtent) ..< sourceMinimumY
+    let lowerRange = sourceMaximumY ..< min(Int(surface.maxY), sourceMaximumY + characterExtent)
+    let upperRun = qualifyingRuns(in: upperRange).last.flatMap { run in
+      let startsAtSurfaceEdge = upperRange.lowerBound == Int(surface.minY)
+        && run.lowerBound <= upperRange.lowerBound + 1
+      return startsAtSurfaceEdge ? nil : run
+    }
+    let lowerRun = qualifyingRuns(in: lowerRange).first.flatMap { run in
+      let endsAtSurfaceEdge = lowerRange.upperBound == Int(surface.maxY)
+        && run.upperBound >= lowerRange.upperBound - 1
+      return endsAtSurfaceEdge ? nil : run
+    }
+    guard upperRun != nil || lowerRun != nil else { return patch }
+
+    let minimumY = CGFloat(upperRun?.lowerBound ?? Int(source.minY))
+    let maximumY = CGFloat(lowerRun?.upperBound ?? Int(source.maxY))
+    var result = patch
+    result.box = CGRect(
+      x: patch.box.minX,
+      y: minimumY / CGFloat(raster.height),
+      width: patch.box.width,
+      height: (maximumY - minimumY) / CGFloat(raster.height)
+    )
+    return result
+  }
+
+  private static func nearbyChromaticRubyPatch(
+    above patch: OverlaySourcePatch,
+    raster: PixelRaster
+  ) -> OverlaySourcePatch? {
+    let source = pixelRect(for: patch.box, raster: raster).integral
+    guard !source.isNull, !source.isEmpty else { return nil }
+
+    let extensionHeight = max(3, min(24, Int(ceil(source.height * 0.45))))
+    var minimumY = max(0, Int(source.minY) - extensionHeight)
+    let sourceMinimumY = max(minimumY, Int(source.minY))
+    let minimumX = max(0, Int(source.minX))
+    let maximumX = min(raster.width, Int(source.maxX))
+    guard minimumY < sourceMinimumY, minimumX < maximumX else { return nil }
+
+    let background = patch.appearance.background
+    let borderThreshold = max(4, Int(CGFloat(maximumX - minimumX) * 0.45))
+    for y in minimumY ..< sourceMinimumY {
+      var currentRun = 0
+      var longestRun = 0
+      for x in minimumX ..< maximumX {
+        if
+          let color = raster.color(at: y * raster.width + x),
+          color.distance(to: background) >= 0.14
+        {
+          currentRun += 1
+          longestRun = max(longestRun, currentRun)
+        } else {
+          currentRun = 0
+        }
+      }
+      if longestRun >= borderThreshold {
+        minimumY = min(sourceMinimumY, y + 1)
+      }
+    }
+
+    let foreground = patch.appearance.foreground
+    let red = foreground.red - background.red
+    let green = foreground.green - background.green
+    let blue = foreground.blue - background.blue
+    let denominator = red * red + green * green + blue * blue
+    guard denominator > 0.01 else { return nil }
+
+    var inkMinimumX = Int.max
+    var inkMaximumX = Int.min
+    var inkMinimumY = Int.max
+    var inkMaximumY = Int.min
+    var inkCount = 0
+    for y in minimumY ..< sourceMinimumY {
+      for x in minimumX ..< maximumX {
+        guard let color = raster.color(at: y * raster.width + x) else { continue }
+        let sampleRed = color.red - background.red
+        let sampleGreen = color.green - background.green
+        let sampleBlue = color.blue - background.blue
+        let amount = (sampleRed * red + sampleGreen * green + sampleBlue * blue) / denominator
+        guard amount >= 0.12, amount <= 1.35 else { continue }
+        let expected = OverlayColor(
+          red: background.red + red * amount,
+          green: background.green + green * amount,
+          blue: background.blue + blue * amount,
+          alpha: 1
+        )
+        guard color.distance(to: expected) <= 0.08 else { continue }
+        inkMinimumX = min(inkMinimumX, x)
+        inkMaximumX = max(inkMaximumX, x)
+        inkMinimumY = min(inkMinimumY, y)
+        inkMaximumY = max(inkMaximumY, y)
+        inkCount += 1
+      }
+    }
+    guard inkCount >= 4, inkMaximumY - inkMinimumY + 1 >= 2 else { return nil }
+
+    return OverlaySourcePatch(
+      box: CGRect(
+        x: CGFloat(inkMinimumX) / CGFloat(raster.width),
+        y: CGFloat(inkMinimumY) / CGFloat(raster.height),
+        width: CGFloat(inkMaximumX - inkMinimumX + 1) / CGFloat(raster.width),
+        height: CGFloat(inkMaximumY - inkMinimumY + 1) / CGFloat(raster.height)
+      ),
+      appearance: patch.appearance
+    )
+  }
+
+  private static func inferredSurface(
+    containing normalizedSource: CGRect,
+    appearance: OverlaySourceAppearance,
+    raster: PixelRaster,
+    limitingTo normalizedLimit: CGRect? = nil
+  ) -> OverlaySourceSurface? {
+    let unit = CGRect(x: 0, y: 0, width: 1, height: 1)
+    let normalizedSource = normalizedSource.standardized.intersection(unit)
+    guard !normalizedSource.isNull, !normalizedSource.isEmpty else { return nil }
+    let rasterBounds = CGRect(x: 0, y: 0, width: raster.width, height: raster.height)
+    let allowedBounds = normalizedLimit.map { normalizedLimit in
+      CGRect(
+        x: normalizedLimit.minX * CGFloat(raster.width),
+        y: normalizedLimit.minY * CGFloat(raster.height),
+        width: normalizedLimit.width * CGFloat(raster.width),
+        height: normalizedLimit.height * CGFloat(raster.height)
+      ).integral.intersection(rasterBounds)
+    } ?? rasterBounds
+    let source = CGRect(
+      x: normalizedSource.minX * CGFloat(raster.width),
+      y: normalizedSource.minY * CGFloat(raster.height),
+      width: max(1, normalizedSource.width * CGFloat(raster.width)),
+      height: max(1, normalizedSource.height * CGFloat(raster.height))
+    ).integral.intersection(allowedBounds)
+    guard !source.isNull, !source.isEmpty else { return nil }
+
+    // Keep nearby dark surfaces distinct. A #1c1c1e card on a black page is
+    // only ~0.11 apart in sRGB; the old adaptive 0.22 ceiling crossed its
+    // border and flooded to the image edge, discarding the card surface.
+    let tolerance = min(0.09, max(0.05, 0.05 + (1 - appearance.confidence) * 0.12))
+    let search = source.insetBy(
+      dx: -max(2, source.width * 0.2),
+      dy: -max(2, source.height * 0.2)
+    ).integral.intersection(allowedBounds)
+    var seed: Int?
+    var seedScore = -CGFloat.infinity
+    let center = CGPoint(x: source.midX, y: source.midY)
+    for y in Int(search.minY) ..< Int(search.maxY) {
+      for x in Int(search.minX) ..< Int(search.maxX) {
+        let index = y * raster.width + x
+        guard raster.matchesBackground(at: index, color: appearance.background, tolerance: tolerance) else {
+          continue
+        }
+        var matchingNeighbors = 0
+        for neighborY in max(0, y - 1) ... min(raster.height - 1, y + 1) {
+          for neighborX in max(0, x - 1) ... min(raster.width - 1, x + 1) {
+            let neighbor = neighborY * raster.width + neighborX
+            if raster.matchesBackground(at: neighbor, color: appearance.background, tolerance: tolerance) {
+              matchingNeighbors += 1
+            }
+          }
+        }
+        let distance = hypot(CGFloat(x) - center.x, CGFloat(y) - center.y)
+        let score = CGFloat(matchingNeighbors) * 100 - distance
+        if score > seedScore {
+          seed = index
+          seedScore = score
+        }
+      }
+    }
+    guard let seed else { return nil }
+
+    var visited = [Bool](repeating: false, count: raster.width * raster.height)
+    var queue = [seed]
+    visited[seed] = true
+    var cursor = 0
+    var minimumX = raster.width
+    var minimumY = raster.height
+    var maximumX = 0
+    var maximumY = 0
+    var rowMinimumX = [Int](repeating: raster.width, count: raster.height)
+    var rowMaximumX = [Int](repeating: -1, count: raster.height)
+    while cursor < queue.count {
+      let index = queue[cursor]
+      cursor += 1
+      let x = index % raster.width
+      let y = index / raster.width
+      minimumX = min(minimumX, x)
+      minimumY = min(minimumY, y)
+      maximumX = max(maximumX, x)
+      maximumY = max(maximumY, y)
+      rowMinimumX[y] = min(rowMinimumX[y], x)
+      rowMaximumX[y] = max(rowMaximumX[y], x)
+      let neighbors = [
+        x > 0 ? index - 1 : -1,
+        x + 1 < raster.width ? index + 1 : -1,
+        y > 0 ? index - raster.width : -1,
+        y + 1 < raster.height ? index + raster.width : -1,
+      ]
+      for neighbor in neighbors where neighbor >= 0 && !visited[neighbor] {
+        visited[neighbor] = true
+        let neighborX = neighbor % raster.width
+        let neighborY = neighbor / raster.width
+        guard
+          allowedBounds.contains(CGPoint(
+            x: CGFloat(neighborX) + 0.5,
+            y: CGFloat(neighborY) + 0.5
+          ))
+        else { continue }
+        guard
+          raster.matchesBackground(
+            at: neighbor,
+            color: appearance.background,
+            tolerance: tolerance
+          )
+        else {
+          continue
+        }
+        queue.append(neighbor)
+      }
+    }
+
+    let touchesImageEdge = minimumX == 0
+      || minimumY == 0
+      || maximumX == raster.width - 1
+      || maximumY == raster.height - 1
+    guard !touchesImageEdge else { return nil }
+    let component = CGRect(
+      x: minimumX,
+      y: minimumY,
+      width: maximumX - minimumX + 1,
+      height: maximumY - minimumY + 1
+    )
+    // A page or screenshot enclosed by a border is a flat closed component too,
+    // but it is not a semantic text container. Treating it as one made the
+    // entire document look like a single speech bubble.
+    let componentWidthRatio = component.width / CGFloat(raster.width)
+    let componentHeightRatio = component.height / CGFloat(raster.height)
+    guard componentWidthRatio < 0.9 || componentHeightRatio < 0.9 else { return nil }
+    let fillRatio = CGFloat(queue.count) / max(1, component.width * component.height)
+    let expansion = component.width * component.height / max(1, source.width * source.height)
+    guard fillRatio >= 0.45, expansion >= 1.15 else { return nil }
+
+    let safe = component.insetBy(
+      dx: max(1, component.width * 0.07),
+      dy: max(1, component.height * 0.05)
+    )
+    guard safe.width > 1, safe.height > 1 else { return nil }
+    let confidence = min(
+      1,
+      appearance.confidence
+        * min(1, fillRatio / 0.65)
+        * min(1, 0.65 + (expansion - 1) * 0.2)
+    )
+    guard confidence >= 0.35 else { return nil }
+    let cornerRadiusFraction = inferredCornerRadiusFraction(
+      minimumY: minimumY,
+      maximumY: maximumY,
+      rowMinimumX: rowMinimumX,
+      rowMaximumX: rowMaximumX
+    )
+    return OverlaySourceSurface(
+      box: CGRect(
+        x: safe.minX / CGFloat(raster.width),
+        y: safe.minY / CGFloat(raster.height),
+        width: safe.width / CGFloat(raster.width),
+        height: safe.height / CGFloat(raster.height)
+      ),
+      confidence: confidence,
+      clippingBox: CGRect(
+        x: component.minX / CGFloat(raster.width),
+        y: component.minY / CGFloat(raster.height),
+        width: component.width / CGFloat(raster.width),
+        height: component.height / CGFloat(raster.height)
+      ),
+      cornerRadiusFraction: cornerRadiusFraction
+    )
+  }
+
+  private static func inferredCornerRadiusFraction(
+    minimumY: Int,
+    maximumY: Int,
+    rowMinimumX: [Int],
+    rowMaximumX: [Int]
+  ) -> CGFloat {
+    guard maximumY >= minimumY else { return 0 }
+    let rowWidths = (minimumY ... maximumY).map { y in
+      max(0, rowMaximumX[y] - rowMinimumX[y] + 1)
+    }
+    guard let maximumWidth = rowWidths.max(), maximumWidth > 0 else { return 0 }
+    let edgeBandSize = max(1, Int(ceil(CGFloat(rowWidths.count) * 0.08)))
+    let edgeWidths = Array(rowWidths.prefix(edgeBandSize))
+      + Array(rowWidths.suffix(edgeBandSize))
+    let edgeWidthRatio = CGFloat(edgeWidths.reduce(0, +))
+      / CGFloat(max(1, edgeWidths.count * maximumWidth))
+    return edgeWidthRatio < 0.78 ? 0.35 : 0
+  }
+
+  private static func appearance(
+    around normalizedBox: CGRect,
+    raster: PixelRaster
+  ) -> OverlaySourceAppearance {
+    let source = pixelRect(for: normalizedBox, raster: raster)
+    guard !source.isNull, !source.isEmpty else { return .fallback }
+    let rasterBounds = CGRect(x: 0, y: 0, width: raster.width, height: raster.height)
+    // Include the glyph box itself and only a narrow local ring. The dominant
+    // color inside a word box is still its background, while a width-relative
+    // ring escapes long inline-code pills and incorrectly samples the table or
+    // page beneath them.
+    let sampleBounds = source.insetBy(
+      dx: -max(2, min(source.width * 0.12, source.height * 0.5)),
+      dy: -max(2, source.height * 0.35)
+    ).integral.intersection(rasterBounds)
+
+    let interior = dominantSample(in: source, excluding: nil, raster: raster)
+    let exterior = dominantSample(in: sampleBounds, excluding: source, raster: raster)
+    let dominant: DominantSample
+    var hasHighContrastSurface = false
+    switch (interior, exterior) {
+    case (.some(let interior), .some(let exterior)):
+      // Text glyphs are usually much farther from their surface than adjacent
+      // UI surfaces are from one another. A moderately different, dominant
+      // interior color is therefore an inline-code/control fill; a high-contrast
+      // interior cluster is glyph ink unless it forms a continuous edge band,
+      // which identifies a high-contrast pill or button fill.
+      let interiorDistance = interior.color.distance(to: exterior.color)
+      let interiorFormsSurface = edgeMatchRatio(
+        color: interior.color,
+        in: source,
+        raster: raster
+      ) >= 0.55
+      hasHighContrastSurface = interiorDistance > 0.25 && interiorFormsSurface
+      dominant = interior.confidence >= 0.32
+        && (interiorDistance <= 0.25 || interiorFormsSurface)
+        ? interior
+        : exterior
+
+    case (.some(let interior), .none):
+      dominant = interior
+
+    case (.none, .some(let exterior)):
+      dominant = exterior
+
+    case (.none, .none):
+      return .fallback
+    }
+    let background = dominant.color
+    var maximumDistance: CGFloat = 0
+    var sourceSampleCount = 0
+    for y in Int(source.minY) ..< Int(source.maxY) {
+      for x in Int(source.minX) ..< Int(source.maxX) {
+        guard let color = raster.color(at: y * raster.width + x) else { continue }
+        maximumDistance = max(maximumDistance, color.distance(to: background))
+        sourceSampleCount += 1
+      }
+    }
+    let foregroundThreshold = max(0.08, maximumDistance * 0.94)
+    let inkThreshold = max(0.06, maximumDistance * 0.35)
+    var foregroundRed: CGFloat = 0
+    var foregroundGreen: CGFloat = 0
+    var foregroundBlue: CGFloat = 0
+    var foregroundSampleCount = 0
+    var foregroundMinimumY = Int.max
+    var foregroundMaximumY = Int.min
+    var inkSampleCount = 0
+    for y in Int(source.minY) ..< Int(source.maxY) {
+      for x in Int(source.minX) ..< Int(source.maxX) {
+        guard let color = raster.color(at: y * raster.width + x) else { continue }
+        let distance = color.distance(to: background)
+        if distance >= foregroundThreshold {
+          foregroundRed += color.red
+          foregroundGreen += color.green
+          foregroundBlue += color.blue
+          foregroundSampleCount += 1
+          foregroundMinimumY = min(foregroundMinimumY, y)
+          foregroundMaximumY = max(foregroundMaximumY, y)
+        }
+        if distance >= inkThreshold {
+          inkSampleCount += 1
+        }
+      }
+    }
+    let foreground: OverlayColor =
+      if foregroundSampleCount > 0 {
+        OverlayColor(
+          red: foregroundRed / CGFloat(foregroundSampleCount),
+          green: foregroundGreen / CGFloat(foregroundSampleCount),
+          blue: foregroundBlue / CGFloat(foregroundSampleCount),
+          alpha: 1
+        )
+      } else {
+        relativeLuminance(background) >= 0.179 ? .black : .white
+      }
+    let inkCoverage = CGFloat(inkSampleCount) / CGFloat(max(1, sourceSampleCount))
+    let inkHeightScale = foregroundSampleCount > 0
+      ? CGFloat(foregroundMaximumY - foregroundMinimumY + 1) / CGFloat(raster.height)
+      : 0
+    let foregroundConfidence = min(
+      1,
+      maximumDistance * min(1, CGFloat(foregroundSampleCount) / CGFloat(max(1, sourceSampleCount)) * 10)
+    )
+    let underlineThreshold = max(2, Int(source.width * 0.58))
+    let underlineStart = Int(source.minY + source.height * 0.68)
+    let underlineScan = CGRect(
+      x: source.minX,
+      y: CGFloat(underlineStart),
+      width: source.width,
+      height: source.maxY - CGFloat(underlineStart)
+        + (hasHighContrastSurface ? 0 : max(2, source.height * 0.15))
+    ).integral.intersection(rasterBounds)
+    let underlineInkThreshold = max(0.08, maximumDistance * 0.7)
+    var underlineRuns = [Int: Int]()
+    for y in Int(underlineScan.minY) ..< Int(underlineScan.maxY) {
+      var currentRun = 0
+      var longestRun = 0
+      for x in Int(underlineScan.minX) ..< Int(underlineScan.maxX) {
+        guard let color = raster.color(at: y * raster.width + x) else { continue }
+        if color.distance(to: background) >= underlineInkThreshold {
+          currentRun += 1
+          longestRun = max(longestRun, currentRun)
+        } else {
+          currentRun = 0
+        }
+      }
+      underlineRuns[y] = longestRun
+    }
+    let canContainUnderline = source.width >= max(8, source.height * 1.4)
+    let isUnderlined = canContainUnderline && underlineRuns.contains { y, longestRun in
+      y >= underlineStart && longestRun >= underlineThreshold
+    }
+    return OverlaySourceAppearance(
+      background: background,
+      foreground: foreground,
+      confidence: min(1, dominant.confidence),
+      foregroundConfidence: foregroundConfidence,
+      inkCoverage: inkCoverage,
+      inkHeightScale: inkHeightScale,
+      fontWeight: fontWeight(for: inkCoverage, source: source, raster: raster),
+      isUnderlined: isUnderlined
+    )
+  }
+
+  private static func combinedAppearance(
+    _ samples: [WeightedAppearance],
+    fallback: OverlaySourceAppearance
+  ) -> OverlaySourceAppearance {
+    let samples = samples.filter { $0.appearance.confidence > 0 && $0.weight > 0 }
+    guard !samples.isEmpty else { return fallback }
+    var clusters = [[WeightedAppearance]]()
+    for sample in samples {
+      if
+        let index = clusters.firstIndex(where: { cluster in
+          guard let representative = cluster.first?.appearance else { return false }
+          let appearance = sample.appearance
+          return representative.background.distance(to: appearance.background) <= 0.045
+            && representative.foreground.distance(to: appearance.foreground) <= 0.12
+            && representative.fontDesign == appearance.fontDesign
+            && abs(representative.fontWeight.rawValue - appearance.fontWeight.rawValue) <= 1
+        })
+      {
+        clusters[index].append(sample)
+      } else {
+        clusters.append([sample])
+      }
+    }
+    let dominant = clusters.max { lhs, rhs in
+      clusterWeight(lhs) < clusterWeight(rhs)
+    } ?? samples
+    let totalSemanticWeight = dominant.reduce(0) { $0 + $1.weight }
+    let backgroundWeight = dominant.reduce(0) {
+      $0 + $1.weight * max(0.01, $1.appearance.confidence)
+    }
+    let foregroundWeight = dominant.reduce(0) {
+      $0 + $1.weight * max(0.01, $1.appearance.foregroundConfidence)
+    }
+    let background = weightedColor(dominant, totalWeight: backgroundWeight) {
+      ($0.appearance.background, $0.weight * max(0.01, $0.appearance.confidence))
+    }
+    let foreground = weightedColor(dominant, totalWeight: foregroundWeight) {
+      ($0.appearance.foreground, $0.weight * max(0.01, $0.appearance.foregroundConfidence))
+    }
+    let coverage = dominant.reduce(0) {
+      $0 + $1.appearance.inkCoverage * $1.weight
+    } / max(1, totalSemanticWeight)
+    let inkHeight = weightedInkHeight(dominant)
+    return OverlaySourceAppearance(
+      background: background,
+      foreground: foreground,
+      confidence: min(1, dominant.reduce(0) {
+        $0 + $1.appearance.confidence * $1.weight
+      } / max(1, totalSemanticWeight)),
+      foregroundConfidence: min(
+        1,
+        dominant.reduce(0) {
+          $0 + $1.appearance.foregroundConfidence * $1.weight
+        } / max(1, totalSemanticWeight)
+      ),
+      inkCoverage: coverage,
+      inkHeightScale: inkHeight,
+      fontWeight: combinedFontWeight(dominant),
+      fontDesign: dominant.filter { $0.appearance.fontDesign == .monospaced }.reduce(0) {
+        $0 + $1.weight
+      } * 2 >= totalSemanticWeight
+        ? .monospaced
+        : .standard,
+      isUnderlined: dominant.filter { $0.appearance.isUnderlined }.reduce(0) {
+        $0 + $1.weight
+      } * 2 >= totalSemanticWeight
+    )
+  }
+
+  private static func dominantSample(
+    in bounds: CGRect,
+    excluding excluded: CGRect?,
+    raster: PixelRaster
+  ) -> DominantSample? {
+    var buckets = [Int: Bucket]()
+    var total = 0
+    for y in Int(bounds.minY) ..< Int(bounds.maxY) {
+      for x in Int(bounds.minX) ..< Int(bounds.maxX) {
+        let point = CGPoint(x: CGFloat(x) + 0.5, y: CGFloat(y) + 0.5)
+        if excluded?.contains(point) == true { continue }
+        guard let color = raster.color(at: y * raster.width + x) else { continue }
+        let red = Int((color.red * 255).rounded())
+        let green = Int((color.green * 255).rounded())
+        let blue = Int((color.blue * 255).rounded())
+        let key = (red >> 4) << 8 | (green >> 4) << 4 | (blue >> 4)
+        var bucket = buckets[key, default: Bucket()]
+        bucket.count += 1
+        bucket.red += red
+        bucket.green += green
+        bucket.blue += blue
+        buckets[key] = bucket
+        total += 1
+      }
+    }
+    guard total > 0, let dominant = buckets.values.max(by: { $0.count < $1.count }) else {
+      return nil
+    }
+    let divisor = CGFloat(dominant.count * 255)
+    return DominantSample(
+      color: OverlayColor(
+        red: CGFloat(dominant.red) / divisor,
+        green: CGFloat(dominant.green) / divisor,
+        blue: CGFloat(dominant.blue) / divisor,
+        alpha: 1
+      ),
+      count: dominant.count,
+      total: total
+    )
+  }
+
+  private static func edgeMatchRatio(
+    color: OverlayColor,
+    in bounds: CGRect,
+    raster: PixelRaster
+  ) -> CGFloat {
+    let band = max(1, min(3, Int(min(bounds.width, bounds.height) * 0.15)))
+    var matching = 0
+    var total = 0
+    for y in Int(bounds.minY) ..< Int(bounds.maxY) {
+      for x in Int(bounds.minX) ..< Int(bounds.maxX) {
+        let onEdge = x < Int(bounds.minX) + band
+          || x >= Int(bounds.maxX) - band
+          || y < Int(bounds.minY) + band
+          || y >= Int(bounds.maxY) - band
+        guard onEdge, let sample = raster.color(at: y * raster.width + x) else { continue }
+        total += 1
+        if sample.distance(to: color) <= 0.08 { matching += 1 }
+      }
+    }
+    return CGFloat(matching) / CGFloat(max(1, total))
+  }
+
+  private static func clusterWeight(_ samples: [WeightedAppearance]) -> CGFloat {
+    samples.reduce(0) {
+      $0 + $1.weight * (1 + $1.appearance.confidence + $1.appearance.foregroundConfidence)
+    }
+  }
+
+  private static func fontDesign(
+    for text: String,
+    appearance: OverlaySourceAppearance,
+    surroundingBackground: OverlayColor
+  ) -> OverlayFontDesign {
+    let strongCodePunctuation = CharacterSet(charactersIn: "*_`{}[]<>\\=")
+    if
+      text.count > 1 && text.hasPrefix(".")
+      || text.unicodeScalars.contains(where: strongCodePunctuation.contains)
+    {
+      return .monospaced
+    }
+    let sitsOnDistinctSurface = appearance.background.distance(to: surroundingBackground) >= 0.025
+    guard sitsOnDistinctSurface else { return .standard }
+    let codePunctuation = CharacterSet(charactersIn: "/:")
+    return text.unicodeScalars.contains(where: codePunctuation.contains)
+      ? .monospaced
+      : .standard
+  }
+
+  private static func sampledSurroundingBackground(
+    around normalizedBox: CGRect,
+    raster: PixelRaster
+  ) -> OverlayColor? {
+    let source = pixelRect(for: normalizedBox, raster: raster)
+    guard !source.isNull, !source.isEmpty else { return nil }
+    let bounds = source.insetBy(
+      dx: -max(4, source.height * 1.2),
+      dy: -max(4, source.height)
+    ).integral.intersection(CGRect(x: 0, y: 0, width: raster.width, height: raster.height))
+    return dominantSample(in: bounds, excluding: source, raster: raster)?.color
+  }
+
+  private static func isCompactInlineSurface(_ surface: CGRect, around source: CGRect) -> Bool {
+    let surface = surface.standardized
+    let source = source.standardized
+    guard !surface.isEmpty, !source.isEmpty, surface.contains(source) else { return false }
+    let areaRatio = surface.width * surface.height / max(0.000_001, source.width * source.height)
+    return areaRatio <= 8
+      && surface.width <= source.width * 2.2
+      && surface.height <= source.height * 3
+  }
+
+  private static func coversVisibleSource(
+    _ runs: [OverlaySourceStyleRun],
+    in text: String
+  ) -> Bool {
+    guard !runs.isEmpty else { return false }
+    var visible = IndexSet()
+    for lowerBound in text.indices {
+      let character = text[lowerBound]
+      guard !character.unicodeScalars.allSatisfy(\.properties.isWhitespace) else { continue }
+      let upperBound = text.index(after: lowerBound)
+      let range = NSRange(lowerBound ..< upperBound, in: text)
+      visible.insert(integersIn: range.location ..< NSMaxRange(range))
+    }
+    guard !visible.isEmpty else { return false }
+
+    let sourceLength = (text as NSString).length
+    var covered = IndexSet()
+    for run in runs {
+      let lowerBound = max(0, min(sourceLength, run.range.location))
+      let upperBound = max(lowerBound, min(sourceLength, NSMaxRange(run.range)))
+      covered.insert(integersIn: lowerBound ..< upperBound)
+    }
+    return visible.subtracting(covered).isEmpty
+  }
+
+  private static func inlineSurfaceErasers(
+    for runs: [OverlaySourceStyleRun],
+    parentBackground: OverlayColor,
+    raster: PixelRaster
+  ) -> [OverlaySourcePatch] {
+    let runs = runs.reduce(into: [OverlaySourceStyleRun]()) { result, run in
+      guard !result.contains(where: { sameBox($0.box, run.box) }) else { return }
+      result.append(run)
+    }
+    var visited = Array(repeating: false, count: runs.count)
+    var erasers = [OverlaySourcePatch]()
+    for start in runs.indices where !visited[start] {
+      visited[start] = true
+      var queue = [start]
+      var group = [runs[start]]
+      while let index = queue.popLast() {
+        for candidate in runs.indices where !visited[candidate] {
+          guard sharesInlineSurface(runs[index], runs[candidate], raster: raster) else { continue }
+          visited[candidate] = true
+          queue.append(candidate)
+          group.append(runs[candidate])
+        }
+      }
+      let source = group.dropFirst().reduce(group[0].box) { $0.union($1.box) }
+      let representative = group.max {
+        $0.appearance.confidence < $1.appearance.confidence
+      } ?? group[0]
+      let detected = inferredSurface(
+        containing: source,
+        appearance: representative.appearance,
+        raster: raster
+      )?.clippingBox
+      let box: CGRect
+      if let detected, isCompactInlineSurface(detected, around: source) {
+        box = detected
+      } else {
+        let pixels = pixelRect(for: source, raster: raster)
+        let padded = pixels.insetBy(
+          dx: -max(1, pixels.height * 0.45),
+          dy: -max(1, pixels.height * 0.5)
+        ).intersection(CGRect(x: 0, y: 0, width: raster.width, height: raster.height))
+        box = CGRect(
+          x: padded.minX / CGFloat(raster.width),
+          y: padded.minY / CGFloat(raster.height),
+          width: padded.width / CGFloat(raster.width),
+          height: padded.height / CGFloat(raster.height)
+        )
+      }
+      var appearance = representative.appearance
+      appearance.background = parentBackground
+      erasers.append(OverlaySourcePatch(
+        box: box,
+        appearance: appearance,
+        erasesDistinctSurface: true
+      ))
+    }
+    return erasers
+  }
+
+  private static func sharesInlineSurface(
+    _ lhs: OverlaySourceStyleRun,
+    _ rhs: OverlaySourceStyleRun,
+    raster: PixelRaster
+  ) -> Bool {
+    guard lhs.appearance.background.distance(to: rhs.appearance.background) <= 0.04 else {
+      return false
+    }
+    let lhs = pixelRect(for: lhs.box, raster: raster)
+    let rhs = pixelRect(for: rhs.box, raster: raster)
+    let verticalOverlap = max(0, min(lhs.maxY, rhs.maxY) - max(lhs.minY, rhs.minY))
+    guard verticalOverlap / max(1, min(lhs.height, rhs.height)) >= 0.45 else { return false }
+    let horizontalGap = max(0, max(lhs.minX, rhs.minX) - min(lhs.maxX, rhs.maxX))
+    return horizontalGap <= max(lhs.height, rhs.height) * 0.8
+  }
+
+  private static func text(in range: NSRange, source: String) -> String {
+    guard let range = Range(range, in: source) else { return "" }
+    return String(source[range])
+  }
+
+  private static func sameBox(_ lhs: CGRect, _ rhs: CGRect) -> Bool {
+    abs(lhs.minX - rhs.minX) < 0.000_1
+      && abs(lhs.minY - rhs.minY) < 0.000_1
+      && abs(lhs.maxX - rhs.maxX) < 0.000_1
+      && abs(lhs.maxY - rhs.maxY) < 0.000_1
+  }
+
+  private static func coversSameSurface(_ lhs: CGRect, _ rhs: CGRect) -> Bool {
+    let lhs = lhs.standardized
+    let rhs = rhs.standardized
+    let intersection = lhs.intersection(rhs)
+    guard !intersection.isNull, !intersection.isEmpty else { return false }
+    let intersectionArea = intersection.width * intersection.height
+    let minimumArea = min(lhs.width * lhs.height, rhs.width * rhs.height)
+    return intersectionArea / max(0.000_001, minimumArea) >= 0.8
+  }
+
+  private static func shouldConsolidatePatches(
+    _ patches: [OverlaySourcePatch],
+    into lineAppearance: OverlaySourceAppearance,
+    isVertical: Bool
+  ) -> Bool {
+    guard
+      !isVertical,
+      patches.count > 1,
+      lineAppearance.confidence >= 0.3
+    else { return false }
+    return patches.allSatisfy {
+      $0.appearance.background.distance(to: lineAppearance.background) <= 0.045
+    }
+  }
+
+  private static func pixelRect(for normalizedBox: CGRect, raster: PixelRaster) -> CGRect {
+    let box = normalizedBox.standardized.intersection(CGRect(x: 0, y: 0, width: 1, height: 1))
+    guard !box.isNull, !box.isEmpty else { return .null }
+    return CGRect(
+      x: box.minX * CGFloat(raster.width),
+      y: box.minY * CGFloat(raster.height),
+      width: max(1, box.width * CGFloat(raster.width)),
+      height: max(1, box.height * CGFloat(raster.height))
+    ).integral.intersection(CGRect(x: 0, y: 0, width: raster.width, height: raster.height))
+  }
+
+  private static func weightedColor(
+    _ appearances: [WeightedAppearance],
+    totalWeight: CGFloat,
+    component: (WeightedAppearance) -> (OverlayColor, CGFloat)
+  ) -> OverlayColor {
+    appearances.reduce(OverlayColor(red: 0, green: 0, blue: 0, alpha: 1)) { result, appearance in
+      let (color, weight) = component(appearance)
+      return OverlayColor(
+        red: result.red + color.red * weight / totalWeight,
+        green: result.green + color.green * weight / totalWeight,
+        blue: result.blue + color.blue * weight / totalWeight,
+        alpha: 1
+      )
+    }
+  }
+
+  private static func fontWeight(
+    for inkCoverage: CGFloat,
+    source: CGRect,
+    raster: PixelRaster
+  ) -> OverlayFontWeight {
+    if source.width >= source.height * 2, source.height / CGFloat(raster.height) >= 0.06, inkCoverage >= 0.2 {
+      return .bold
+    }
+    return switch inkCoverage {
+    case ..<0.23: .regular
+    case ..<0.27: .medium
+    case ..<0.33: .semibold
+    default: .bold
+    }
+  }
+
+  private static func combinedFontWeight(
+    _ samples: [WeightedAppearance]
+  ) -> OverlayFontWeight {
+    let sorted = samples.sorted {
+      $0.appearance.fontWeight.rawValue < $1.appearance.fontWeight.rawValue
+    }
+    let midpoint = sorted.reduce(0) { $0 + $1.weight } / 2
+    var cumulative: CGFloat = 0
+    for sample in sorted {
+      cumulative += sample.weight
+      if cumulative >= midpoint { return sample.appearance.fontWeight }
+    }
+    return sorted.last?.appearance.fontWeight ?? .semibold
+  }
+
+  private static func weightedInkHeight(_ samples: [WeightedAppearance]) -> CGFloat {
+    let sorted = samples.filter { $0.appearance.inkHeightScale > 0 }.sorted {
+      $0.appearance.inkHeightScale < $1.appearance.inkHeightScale
+    }
+    guard !sorted.isEmpty else { return 0 }
+    let midpoint = sorted.reduce(0) { $0 + $1.weight } / 2
+    var cumulative: CGFloat = 0
+    for sample in sorted {
+      cumulative += sample.weight
+      if cumulative >= midpoint { return sample.appearance.inkHeightScale }
+    }
+    return sorted.last?.appearance.inkHeightScale ?? 0
+  }
+
+  private static func relativeLuminance(_ color: OverlayColor) -> CGFloat {
+    func linearized(_ component: CGFloat) -> CGFloat {
+      component <= 0.04045
+        ? component / 12.92
+        : pow((component + 0.055) / 1.055, 2.4)
+    }
+    return 0.2126 * linearized(color.red)
+      + 0.7152 * linearized(color.green)
+      + 0.0722 * linearized(color.blue)
+  }
+
+  private static func isChromatic(_ color: OverlayColor) -> Bool {
+    max(color.red, color.green, color.blue) - min(color.red, color.green, color.blue) >= 0.15
+  }
+
+  private static func isLightNeutral(_ color: OverlayColor) -> Bool {
+    min(color.red, color.green, color.blue) >= 0.8
+      && max(color.red, color.green, color.blue) - min(color.red, color.green, color.blue) <= 0.08
+  }
+}
+
+extension OverlayColor {
+  fileprivate func distance(to other: OverlayColor) -> CGFloat {
+    max(abs(red - other.red), abs(green - other.green), abs(blue - other.blue))
+  }
+}

--- a/Sources/Overlay/OverlayView.swift
+++ b/Sources/Overlay/OverlayView.swift
@@ -3,6 +3,12 @@
 
 import SwiftUI
 
+// MARK: - OverlayChromeMetrics
+
+enum OverlayChromeMetrics {
+  static let moveHandleSize = CGSize(width: 56, height: 40)
+}
+
 // MARK: - OverlayView
 
 struct OverlayView: View {
@@ -38,14 +44,19 @@ struct OverlayView: View {
           )
       }
       .overlay(alignment: .topLeading) {
-        // Drag handle: the only way to move the overlay. The window-background
-        // drag is gated to this corner by the controller; the view itself takes
-        // no hits, so the drag falls through to the window.
+        // Drag handle: the only way to move the overlay. Use SwiftUI's native
+        // window gesture so dragging remains reliable inside NSHostingView.
         MoveHandle()
           .opacity(showMoveHandle ? 1 : 0)
           .animation(.easeOut(duration: 0.15), value: showMoveHandle)
           .padding(8)
-          .allowsHitTesting(false)
+          .frame(
+            width: OverlayChromeMetrics.moveHandleSize.width,
+            height: OverlayChromeMetrics.moveHandleSize.height,
+            alignment: .topLeading
+          )
+          .contentShape(.rect)
+          .gesture(WindowDragGesture())
       }
       .overlay(alignment: .topTrailing) {
         HStack(spacing: 6) {
@@ -149,9 +160,7 @@ private struct LiveHandle: View {
 
 // MARK: - MoveHandle
 
-/// Purely visual grab affordance shown at the top-left while the cursor is over
-/// the overlay. The actual move is the window-background drag the controller
-/// enables in this corner, so the handle takes no hits itself.
+/// Grab affordance shown at the top-left while the cursor is over the overlay.
 private struct MoveHandle: View {
   var body: some View {
     Image(systemName: "arrow.up.and.down.and.arrow.left.and.right")
@@ -159,6 +168,9 @@ private struct MoveHandle: View {
       .foregroundStyle(.secondary)
       .frame(width: 24, height: 18)
       .glassEffect(.regular, in: Capsule())
+      .help("Drag to move overlay")
+      .accessibilityLabel("Move overlay")
+      .accessibilityHint("Drag to reposition the translation overlay")
   }
 }
 

--- a/Sources/Overlay/OverlayView.swift
+++ b/Sources/Overlay/OverlayView.swift
@@ -28,13 +28,15 @@ struct OverlayView: View {
   var body: some View {
     bodyContent
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-      .overlay(
+      .overlay {
+        // Keep the overlay boundary visible in both modes. Source-replacement
+        // patches inside the boundary remain borderless.
         RoundedRectangle(cornerRadius: 22, style: .continuous)
           .strokeBorder(
             frameOnly ? AnyShapeStyle(.tint) : AnyShapeStyle(.white.opacity(0.35)),
             lineWidth: frameOnly ? 2.5 : 1.5
           )
-      )
+      }
       .overlay(alignment: .topLeading) {
         // Drag handle: the only way to move the overlay. The window-background
         // drag is gated to this corner by the controller; the view itself takes

--- a/Sources/Overlay/OverlayWindowController.swift
+++ b/Sources/Overlay/OverlayWindowController.swift
@@ -12,11 +12,6 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
 
   // MARK: Internal
 
-  var windowID: CGWindowID? {
-    guard let window else { return nil }
-    return CGWindowID(window.windowNumber)
-  }
-
   /// Registers the sink for controls drawn on the overlay (live toggle, close).
   func setEventHandler(_ handler: @escaping @Sendable (OverlayUserAction) -> Void) {
     eventHandler = handler
@@ -58,7 +53,8 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
   /// the pasteboard — driven by the overlay's hidden ⌘C affordance.
   func copyTranslation() {
     let text = model.lines
-      .compactMap { $0.translated ?? ($0.sourceText.isEmpty ? nil : $0.sourceText) }
+      .map(\.displayedText)
+      .filter { !$0.isEmpty }
       .joined(separator: "\n")
     guard !text.isEmpty else { return }
     NSPasteboard.general.clearContents()
@@ -115,8 +111,8 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
     if model.isTranslating != state.isTranslating { model.isTranslating = state.isTranslating }
     if model.isLive != state.isLive { model.isLive = state.isLive }
     if model.liveMode != state.liveMode { model.liveMode = state.liveMode }
-    if model.backgroundImageData != state.backgroundImageData {
-      model.backgroundImageData = state.backgroundImageData
+    if model.sourceImageData != state.sourceImageData {
+      model.sourceImageData = state.sourceImageData
     }
     if model.imageSize != state.imageSize { model.imageSize = state.imageSize }
     if model.translationUnavailable != state.translationUnavailable {
@@ -189,6 +185,7 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
     panel.isMovable = true
     panel.isOpaque = false
     panel.backgroundColor = .clear
+    panel.hasShadow = false
     panel.level = .floating
     panel.isFloatingPanel = true
     panel.becomesKeyOnlyIfNeeded = true
@@ -206,12 +203,11 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
     let hosting = NSHostingView(rootView: rootView)
     hosting.frame = panel.contentLayoutRect
     hosting.autoresizingMask = [.width, .height]
-    // Match the SwiftUI glass shape so the borderless panel chrome stops
-    // showing a thin grey edge around the overlay.
+    // Keep the hosting surface genuinely transparent. Clipping this layer to a
+    // rounded rectangle exposed a compositing edge in in-place mode.
     hosting.wantsLayer = true
-    hosting.layer?.cornerRadius = 22
-    hosting.layer?.cornerCurve = .continuous
-    hosting.layer?.masksToBounds = true
+    hosting.layer?.backgroundColor = NSColor.clear.cgColor
+    hosting.layer?.masksToBounds = false
     panel.contentView = hosting
     window = panel
   }
@@ -381,7 +377,7 @@ final class OverlayWindowModel {
   var isLive = false
   var isTranslating = false
   var liveMode = OverlayLiveMode.inPlace
-  var backgroundImageData: Data?
+  var sourceImageData: Data?
   var imageSize = CGSize.zero
   var translationUnavailable = false
   var isPreparingRecognition = false
@@ -396,8 +392,6 @@ final class OverlayWindowModel {
 // MARK: - OverlayRootView
 
 private struct OverlayRootView: View {
-
-  // MARK: Internal
 
   let model: OverlayWindowModel
 
@@ -441,8 +435,9 @@ private struct OverlayRootView: View {
 
 // MARK: - LiveResultView
 
-/// The detached translation window shown in Window live mode: the blurred
-/// screenshot with glass translation chips, updating live.
+/// The detached translation window shown in Window live mode: the captured
+/// backdrop with in-place source restoration and replacement text,
+/// updating live.
 private struct LiveResultView: View {
 
   // MARK: Internal
@@ -470,11 +465,11 @@ private struct LiveResultView: View {
 
   @ViewBuilder
   private var content: some View {
-    if let data = model.backgroundImageData, let image = NSImage(data: data) {
+    if let data = model.sourceImageData, let image = NSImage(data: data) {
       ZStack {
         Image(nsImage: image)
           .resizable()
-        TranslationOverlayLayer(lines: model.lines, glass: true)
+        TranslationOverlayLayer(lines: model.lines)
       }
       .aspectRatio(aspectRatio, contentMode: .fit)
       .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))

--- a/Sources/Overlay/OverlayWindowController.swift
+++ b/Sources/Overlay/OverlayWindowController.swift
@@ -89,7 +89,7 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
   private let resizeMargin: CGFloat = 14
   /// Top-left grab handle — the only region that moves the window. Its hit zone
   /// stays live even while the handle is faded out (so you can always grab it).
-  private let moveHandleSize = CGSize(width: 56, height: 40)
+  private let moveHandleSize = OverlayChromeMetrics.moveHandleSize
   /// Top-right cluster (LIVE toggle + close) — clickable, but never moves the
   /// window.
   private let controlsZoneSize = CGSize(width: 170, height: 52)
@@ -103,7 +103,7 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
   private var eventHandler: (@Sendable (OverlayUserAction) -> Void)?
 
   /// Writes only what changed. `@Observable` notifies on every assignment, equal
-  /// value or not, so blindly re-assigning `lines` or the backdrop `Data` on each
+  /// value or not, so blindly re-assigning `lines` or the backdrop on each
   /// render invalidated the whole overlay view tree at the live capture rate.
   private func assign(_ state: OverlayRenderState) {
     if model.lines != state.lines { model.lines = state.lines }
@@ -111,8 +111,8 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
     if model.isTranslating != state.isTranslating { model.isTranslating = state.isTranslating }
     if model.isLive != state.isLive { model.isLive = state.isLive }
     if model.liveMode != state.liveMode { model.liveMode = state.liveMode }
-    if model.sourceImageData != state.sourceImageData {
-      model.sourceImageData = state.sourceImageData
+    if model.backdrop != state.backdrop {
+      model.backdrop = state.backdrop
     }
     if model.imageSize != state.imageSize { model.imageSize = state.imageSize }
     if model.translationUnavailable != state.translationUnavailable {
@@ -179,7 +179,7 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
       backing: .buffered,
       defer: false
     )
-    // Movement is gated to the move-handle zone in updatePassThroughForCursor;
+    // Movement belongs to the SwiftUI WindowDragGesture on the move handle;
     // never move on a plain background drag.
     panel.isMovableByWindowBackground = false
     panel.isMovable = true
@@ -213,8 +213,8 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
   }
 
   /// The overlay always lets mouse interaction reach the apps below — except in
-  /// a thin margin around the edges (resize) and the top-right handle cluster
-  /// (live toggle / close / drag-to-move). We can't express that with a static
+  /// a thin margin around the edges, the top-left move handle, and the top-right
+  /// control cluster. We can't express that with a static
   /// `ignoresMouseEvents` (it's all-or-nothing per window), so we track the
   /// cursor and flip the window's mouse handling based on where it sits.
   private func applyPassThrough() {
@@ -264,13 +264,9 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
     )
     if moveZone.contains(mouse) {
       window.alphaValue = 1
-      window.isMovableByWindowBackground = true
       window.ignoresMouseEvents = false
       return
     }
-
-    // Everywhere else, a background drag must not move the window.
-    window.isMovableByWindowBackground = false
 
     // Top-right controls (LIVE toggle, close): clickable, but don't move.
     let controlsZone = CGRect(
@@ -377,7 +373,7 @@ final class OverlayWindowModel {
   var isLive = false
   var isTranslating = false
   var liveMode = OverlayLiveMode.inPlace
-  var sourceImageData: Data?
+  var backdrop: OverlayBackdrop?
   var imageSize = CGSize.zero
   var translationUnavailable = false
   var isPreparingRecognition = false
@@ -465,10 +461,10 @@ private struct LiveResultView: View {
 
   @ViewBuilder
   private var content: some View {
-    if let data = model.sourceImageData, let image = NSImage(data: data) {
+    if let backdrop = model.backdrop {
       ZStack {
-        Image(nsImage: image)
-          .resizable()
+        LiveBackdropImage(backdrop: backdrop)
+          .equatable()
         TranslationOverlayLayer(lines: model.lines)
       }
       .aspectRatio(aspectRatio, contentMode: .fit)
@@ -481,5 +477,18 @@ private struct LiveResultView: View {
   private var aspectRatio: CGFloat {
     guard model.imageSize.height > 0 else { return 1 }
     return model.imageSize.width / model.imageSize.height
+  }
+}
+
+// MARK: - LiveBackdropImage
+
+/// Keeps line-by-line translation responses from rebuilding the unchanged
+/// capture layer. Only a genuinely new capture invalidates this subtree.
+private struct LiveBackdropImage: Equatable, View {
+  let backdrop: OverlayBackdrop
+
+  var body: some View {
+    Image(decorative: backdrop.image, scale: 1)
+      .resizable()
   }
 }

--- a/Sources/Overlay/TranslationOverlayLayer.swift
+++ b/Sources/Overlay/TranslationOverlayLayer.swift
@@ -1,199 +1,354 @@
 // SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import Accessibility
 import SwiftUI
 
 // MARK: - TranslationOverlayLayer
 
-/// Draws each translated line at its source bounding box, sized to that box's
-/// height. Shared by the live overlay (Liquid Glass chips) and the
-/// region-capture result. The result uses `glass: false` because ImageRenderer
-/// can't rasterize Liquid Glass, so a solid chip keeps the saved/copied image
-/// matching what's on screen.
+/// Draws locale-aware translated text over its OCR source region. Geometry is
+/// resolved as one scene so every translation stays inside its original visual
+/// container. Vision's word/line regions are restored before replacement text
+/// is drawn, preserving nearby borders and artwork.
 struct TranslationOverlayLayer: View {
+
+  // MARK: Lifecycle
+
+  init(
+    lines: [OverlayLine],
+    prefersHorizontalTextLayout preferenceOverride: Bool? = nil
+  ) {
+    self.lines = lines
+    followsSystemHorizontalTextPreference = preferenceOverride == nil
+    _prefersHorizontalTextLayout = State(
+      initialValue: preferenceOverride ?? AccessibilitySettings.prefersHorizontalTextLayout
+    )
+  }
 
   // MARK: Internal
 
   let lines: [OverlayLine]
-  var glass = true
 
   var body: some View {
     GeometryReader { proxy in
-      chips(in: proxy.size)
+      OverlayCanvas(
+        lines: lines,
+        size: proxy.size,
+        prefersHorizontalTextLayout: prefersHorizontalTextLayout
+      )
+    }
+    .onReceive(
+      NotificationCenter.default.publisher(
+        for: AccessibilitySettings.prefersHorizontalTextLayoutDidChangeNotification
+      )
+    ) { _ in
+      guard followsSystemHorizontalTextPreference else { return }
+      prefersHorizontalTextLayout = AccessibilitySettings.prefersHorizontalTextLayout
     }
   }
 
   // MARK: Private
 
-  private func chips(in size: CGSize) -> some View {
-    ForEach(lines) { line in
-      let box = line.box
-      let width = max(1, box.width * size.width)
-      let height = max(1, box.height * size.height)
+  @State private var prefersHorizontalTextLayout: Bool
 
-      Group {
-        if line.isVerticalBlock, line.verticalLayout {
-          // The chip hugs the vertical text (so the glass matches it) and is
-          // pinned to the box's top-right, where vertical CJK starts reading.
-          // A column's width is the source character size, so render near that
-          // scale to keep the page's font hierarchy.
-          verticalBlockChip(for: line, width: width, height: height, sourceFont: line.verticalCharScale * size.width)
-            .frame(width: width, height: height, alignment: .topTrailing)
-        } else if line.isVerticalBlock {
-          // Vertical CJK source but a horizontally-written target, so the
-          // translation is wrapped horizontally and centred on the source box
-          // instead of being stacked one character per row.
-          horizontalBlockChip(for: line, width: width, height: height)
-            .frame(width: width, height: height, alignment: .center)
-        } else {
-          let rows = max(1, line.rowCount)
-          let fontSize = max(8, min(96, height / CGFloat(rows) * 0.85))
-          lineChip(for: line, fontSize: fontSize, rows: rows)
-            .frame(width: width + 12, height: height + 4, alignment: .leading)
-        }
-      }
-      .position(
-        x: box.midX * size.width,
-        y: box.midY * size.height
-      )
-    }
-  }
+  private let followsSystemHorizontalTextPreference: Bool
 
-  private func lineChip(for line: OverlayLine, fontSize: CGFloat, rows: Int) -> some View {
-    background(
-      for: line,
-      cornerRadius: 8,
-      label: Text(line.translated ?? line.sourceText)
-        .font(.system(size: fontSize, weight: .semibold))
-        .multilineTextAlignment(.leading)
-        .lineLimit(rows)
-        .truncationMode(.tail)
-        .minimumScaleFactor(0.4)
-        .padding(.horizontal, 6)
-        .padding(.vertical, 2)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-    )
-  }
-
-  /// A stitched block of vertical CJK columns rendered into a vertically-written
-  /// target: lay the translation out the same way the source reads — characters
-  /// top-to-bottom, columns right-to-left — so it sits over the original like an
-  /// in-place replacement. Sized so the text roughly fills the box.
-  @ViewBuilder
-  private func verticalBlockChip(for line: OverlayLine, width: CGFloat, height: CGFloat, sourceFont: CGFloat) -> some View {
-    let text = line.translated ?? line.sourceText
-    // Largest font that still fits the box, then prefer the source font scale so
-    // the hierarchy is kept — capped to the fit so a long translation can't spill.
-    let fit = (width * height / CGFloat(max(text.count, 1))).squareRoot() * 0.9
-    let fontSize = max(8, min(fit, sourceFont > 0 ? sourceFont : fit))
-    background(
-      for: line,
-      cornerRadius: 12,
-      // The chip sizes to the text (columns wrap at the box height), so the
-      // glass background matches the translation instead of the full box.
-      label: VerticalText(text: text, fontSize: fontSize, availableHeight: max(1, height - 12))
-        .padding(6)
-    )
-  }
-
-  /// A stitched block of vertical CJK columns rendered into a horizontally-written
-  /// target. The column layout can't be reused: a Latin translation forced through
-  /// it lands one character per row, which is unreadable. Wrap it horizontally over
-  /// the source box instead.
-  @ViewBuilder
-  private func horizontalBlockChip(for line: OverlayLine, width: CGFloat, height: CGFloat) -> some View {
-    let text = line.translated ?? line.sourceText
-    // Vertical CJK boxes are tall and narrow. Horizontal text needs more width, so
-    // let the chip widen past the source box (staying centred on it) before the
-    // font has to shrink — capped by the box height so it can't swallow the page.
-    let chipWidth = max(width, min(width * 2.2, height))
-    // Largest font that still fills the chip, capped so a short line can't balloon.
-    let fit = (chipWidth * height / CGFloat(max(text.count, 1))).squareRoot() * 1.3
-    let fontSize = max(8, min(fit, 96))
-    background(
-      for: line,
-      cornerRadius: 12,
-      label: Text(text)
-        .font(.system(size: fontSize, weight: .semibold))
-        .multilineTextAlignment(.center)
-        .minimumScaleFactor(0.35)
-        .padding(6)
-        .frame(width: chipWidth, alignment: .center)
-    )
-  }
-
-  @ViewBuilder
-  private func background(for line: OverlayLine, cornerRadius: CGFloat, label: some View) -> some View {
-    if glass {
-      label
-        .foregroundStyle(line.translated == nil ? .secondary : .primary)
-        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-    } else {
-      label
-        .foregroundStyle(.white)
-        .background(.black.opacity(0.62), in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-    }
-  }
 }
 
-// MARK: - VerticalText
+// MARK: - OverlayCanvas
 
-/// Lays out a string as vertical CJK writing: each character upright, stacked
-/// top-to-bottom, columns advancing right-to-left.
-private struct VerticalText: View {
-  let text: String
-  let fontSize: CGFloat
-  /// Height to wrap columns at — the chip then sizes itself to the content.
-  let availableHeight: CGFloat
+private struct OverlayCanvas: View {
+
+  // MARK: Internal
+
+  let lines: [OverlayLine]
+  let size: CGSize
+  let prefersHorizontalTextLayout: Bool
 
   var body: some View {
-    VerticalColumns(charExtent: fontSize * 1.18, availableHeight: availableHeight) {
-      ForEach(Array(text.enumerated()), id: \.offset) { _, character in
-        Text(String(character))
-          .font(.system(size: fontSize, weight: .semibold))
+    let placements = OverlayLayoutEngine.placements(
+      for: lines,
+      in: size,
+      prefersHorizontalTextLayout: prefersHorizontalTextLayout
+    )
+    ZStack(alignment: .topLeading) {
+      ForEach(placements) { placement in
+        ForEach(placement.line.source.replacementPatches.indices, id: \.self) { index in
+          let patch = placement.line.source.replacementPatches[index]
+          let frame = OverlayLayoutEngine.replacementFrame(
+            for: patch,
+            sourceLayout: placement.line.source.layout,
+            in: size,
+            displayScale: displayScale
+          )
+          let sourceSurface = placement.line.source.surface.flatMap { surface in
+            surface.confidence >= 0.35 ? surface : nil
+          }
+          SourceReplacementSurface(
+            appearance: patch.appearance,
+            patchFrame: frame,
+            clippingFrame: sourceSurface.map {
+              OverlayLayoutEngine.sourceSurfaceFrame(for: $0, in: size)
+            },
+            cornerRadiusFraction: sourceSurface?.cornerRadiusFraction ?? 0
+          )
+          .equatable()
+        }
       }
+      ForEach(placements) { placement in
+        ReplacementText(placement: placement)
+          .equatable()
+          .frame(width: placement.frame.width, height: placement.frame.height)
+          .clipped()
+          .position(x: placement.frame.midX, y: placement.frame.midY)
+      }
+    }
+    .frame(width: size.width, height: size.height, alignment: .topLeading)
+    .clipped()
+  }
+
+  // MARK: Private
+
+  @Environment(\.displayScale) private var displayScale
+
+}
+
+// MARK: - SourceReplacementSurface
+
+private struct SourceReplacementSurface: View, Equatable {
+
+  let appearance: OverlaySourceAppearance
+  let patchFrame: CGRect
+  let clippingFrame: CGRect?
+  let cornerRadiusFraction: CGFloat
+
+  var body: some View {
+    if let clippingFrame, !clippingFrame.isEmpty {
+      ZStack(alignment: .topLeading) {
+        Rectangle()
+          .fill(Color(appearance.background))
+          .frame(width: patchFrame.width, height: patchFrame.height)
+          .offset(
+            x: patchFrame.minX - clippingFrame.minX,
+            y: patchFrame.minY - clippingFrame.minY
+          )
+      }
+      .frame(
+        width: clippingFrame.width,
+        height: clippingFrame.height,
+        alignment: .topLeading
+      )
+      .clipShape(.rect(
+        cornerRadius: min(clippingFrame.width, clippingFrame.height) * cornerRadiusFraction,
+        style: .continuous
+      ))
+      .position(x: clippingFrame.midX, y: clippingFrame.midY)
+    } else {
+      Rectangle()
+        .fill(Color(appearance.background))
+        .frame(width: patchFrame.width, height: patchFrame.height)
+        .position(x: patchFrame.midX, y: patchFrame.midY)
     }
   }
 }
 
-// MARK: - VerticalColumns
+// MARK: - ReplacementText
 
-/// Places each subview (one character) top-to-bottom; when a column fills
-/// `availableHeight` it wraps to a new column on the left. Reports the size it
-/// actually uses so the surrounding chip hugs the text.
-private struct VerticalColumns: Layout {
-  var charExtent: CGFloat
-  var availableHeight: CGFloat
+private struct ReplacementText: View, Equatable {
 
-  func sizeThatFits(proposal _: ProposedViewSize, subviews: Subviews, cache _: inout ()) -> CGSize {
-    guard !subviews.isEmpty else { return .zero }
-    let columnWidth = subviews.map { $0.sizeThatFits(.unspecified).width }.max() ?? charExtent
-    let perColumn = max(1, Int(availableHeight / charExtent))
-    let columns = Int(ceil(Double(subviews.count) / Double(perColumn)))
-    let rows = min(subviews.count, perColumn)
-    return CGSize(width: CGFloat(columns) * columnWidth, height: CGFloat(rows) * charExtent)
+  let placement: OverlayPlacement
+
+  var body: some View {
+    switch placement.flow {
+    case .horizontal(let direction):
+      HorizontalOverlayText(
+        text: placement.line.displayedText,
+        language: placement.line.displayedLanguage,
+        fontSize: placement.fontSize,
+        appearance: placement.line.source.appearance,
+        styleRuns: placement.line.displayedStyleRuns,
+        lineLimit: placement.lineLimit,
+        direction: direction,
+        alignment: placement.alignment,
+        sourceLayout: placement.line.source.layout
+      )
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel(Text(verbatim: placement.line.displayedText))
+
+    case .vertical(let progression):
+      VerticalOverlayText(
+        text: placement.line.displayedText,
+        language: placement.line.displayedLanguage,
+        fontSize: placement.fontSize,
+        fontWeight: placement.line.source.appearance.fontWeight,
+        fontDesign: placement.line.source.appearance.fontDesign,
+        progression: progression
+      )
+      .foregroundStyle(Color(placement.line.source.appearance.foreground))
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel(Text(verbatim: placement.line.displayedText))
+    }
+  }
+}
+
+// MARK: - HorizontalOverlayText
+
+private struct HorizontalOverlayText: View, Equatable {
+
+  // MARK: Internal
+
+  let text: String
+  let language: Locale.Language
+  let fontSize: CGFloat
+  let appearance: OverlaySourceAppearance
+  let styleRuns: [OverlayTextStyleRun]
+  let lineLimit: Int?
+  let direction: OverlayInlineDirection
+  let alignment: OverlayTextAlignment
+  let sourceLayout: OverlaySourceLayout
+
+  var body: some View {
+    Text(styledText)
+      .font(.system(
+        size: fontSize,
+        weight: appearance.fontWeight.swiftUIWeight,
+        design: appearance.fontDesign.swiftUIFontDesign
+      ))
+      .foregroundStyle(Color(appearance.foreground))
+      .multilineTextAlignment(textAlignment)
+      .lineLimit(lineLimit)
+      .truncationMode(.tail)
+      .minimumScaleFactor(0.78)
+      .allowsTightening(true)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: frameAlignment)
+      .environment(\.locale, Locale(identifier: language.maximalIdentifier))
+      .environment(\.layoutDirection, direction == .rightToLeft ? .rightToLeft : .leftToRight)
   }
 
-  func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
-    guard !subviews.isEmpty else { return }
-    let columnWidth = subviews.map { $0.sizeThatFits(.unspecified).width }.max() ?? charExtent
-    let perColumn = max(1, Int(availableHeight / charExtent))
-    var x = bounds.maxX - columnWidth
-    var y = bounds.minY
-    var placed = 0
-    for subview in subviews {
-      subview.place(
-        at: CGPoint(x: x, y: y),
-        anchor: .topLeading,
-        proposal: ProposedViewSize(width: columnWidth, height: charExtent)
+  // MARK: Private
+
+  private var styledText: AttributedString {
+    var attributed = AttributedString(text)
+    for run in styleRuns {
+      guard
+        let stringRange = Range(run.range, in: text),
+        let lowerBound = AttributedString.Index(stringRange.lowerBound, within: attributed),
+        let upperBound = AttributedString.Index(stringRange.upperBound, within: attributed)
+      else { continue }
+      let range = lowerBound ..< upperBound
+      attributed[range].font = .system(
+        size: fontSize,
+        weight: run.appearance.fontWeight.swiftUIWeight,
+        design: run.appearance.fontDesign.swiftUIFontDesign
       )
-      placed += 1
-      y += charExtent
-      if placed >= perColumn {
-        placed = 0
-        y = bounds.minY
-        x -= columnWidth
+      attributed[range].foregroundColor = Color(run.appearance.foreground)
+      if run.appearance.background.distance(to: appearance.background) >= 0.025 {
+        attributed[range].backgroundColor = Color(run.appearance.background)
+      }
+      if run.appearance.isUnderlined {
+        attributed[range].underlineStyle = .single
       }
     }
+    return attributed
+  }
+
+  private var textAlignment: TextAlignment {
+    switch alignment {
+    case .leading: .leading
+    case .center: .center
+    case .trailing: .trailing
+    }
+  }
+
+  private var frameAlignment: Alignment {
+    switch (sourceLayout, alignment) {
+    // Vision includes ascenders, furigana, and line-leading in its source box.
+    // Centering on that original box keeps a shorter translation on the same
+    // visual baseline instead of pinning it against the top border.
+    case (.horizontal, .leading): .leading
+    case (.horizontal, .center): .center
+    case (.horizontal, .trailing): .trailing
+    case (.vertical, .leading): .leading
+    case (.vertical, .center): .center
+    case (.vertical, .trailing): .trailing
+    }
+  }
+}
+
+// MARK: - VerticalOverlayText
+
+private struct VerticalOverlayText: View {
+
+  // MARK: Internal
+
+  let text: String
+  let language: Locale.Language
+  let fontSize: CGFloat
+  let fontWeight: OverlayFontWeight
+  let fontDesign: OverlayFontDesign
+  let progression: OverlayColumnProgression
+
+  var body: some View {
+    GeometryReader { proxy in
+      if
+        let image = CoreTextTypesetter.verticalGlyphImage(
+          text: text,
+          language: language,
+          fontSize: fontSize,
+          fontWeight: fontWeight,
+          fontDesign: fontDesign,
+          size: proxy.size,
+          scale: displayScale,
+          progression: progression
+        )
+      {
+        Image(decorative: image, scale: displayScale)
+          .renderingMode(.template)
+          .resizable()
+          .frame(width: proxy.size.width, height: proxy.size.height)
+      }
+    }
+    .environment(\.locale, Locale(identifier: language.maximalIdentifier))
+  }
+
+  // MARK: Private
+
+  @Environment(\.displayScale) private var displayScale
+}
+
+extension Color {
+  fileprivate init(_ color: OverlayColor) {
+    self.init(
+      red: Double(color.red),
+      green: Double(color.green),
+      blue: Double(color.blue),
+      opacity: Double(color.alpha)
+    )
+  }
+}
+
+extension OverlayFontWeight {
+  fileprivate var swiftUIWeight: Font.Weight {
+    switch self {
+    case .regular: .regular
+    case .medium: .medium
+    case .semibold: .semibold
+    case .bold: .bold
+    }
+  }
+}
+
+extension OverlayFontDesign {
+  fileprivate var swiftUIFontDesign: Font.Design {
+    switch self {
+    case .standard: .default
+    case .monospaced: .monospaced
+    }
+  }
+}
+
+extension OverlayColor {
+  fileprivate func distance(to other: OverlayColor) -> CGFloat {
+    max(abs(red - other.red), abs(green - other.green), abs(blue - other.blue))
   }
 }

--- a/Sources/Overlay/TranslationOverlayLayer.swift
+++ b/Sources/Overlay/TranslationOverlayLayer.swift
@@ -75,15 +75,16 @@ private struct OverlayCanvas: View {
       ForEach(placements) { placement in
         ForEach(placement.line.source.replacementPatches.indices, id: \.self) { index in
           let patch = placement.line.source.replacementPatches[index]
-          let frame = OverlayLayoutEngine.replacementFrame(
-            for: patch,
-            sourceLayout: placement.line.source.layout,
-            in: size,
-            displayScale: displayScale
-          )
           let sourceSurface = placement.line.source.surface.flatMap { surface in
             surface.confidence >= 0.35 ? surface : nil
           }
+          let frame = OverlayLayoutEngine.replacementFrame(
+            for: patch,
+            sourceLayout: placement.line.source.layout,
+            sourceSurface: sourceSurface,
+            in: size,
+            displayScale: displayScale
+          )
           SourceReplacementSurface(
             appearance: patch.appearance,
             patchFrame: frame,

--- a/Sources/Overlay/TranslationOverlayLayer.swift
+++ b/Sources/Overlay/TranslationOverlayLayer.swift
@@ -165,6 +165,7 @@ private struct ReplacementText: View, Equatable {
         text: placement.line.displayedText,
         language: placement.line.displayedLanguage,
         fontSize: placement.fontSize,
+        lineHeightMultiple: placement.lineHeightMultiple,
         appearance: placement.line.source.appearance,
         styleRuns: placement.line.displayedStyleRuns,
         lineLimit: placement.lineLimit,
@@ -200,6 +201,7 @@ private struct HorizontalOverlayText: View, Equatable {
   let text: String
   let language: Locale.Language
   let fontSize: CGFloat
+  let lineHeightMultiple: CGFloat
   let appearance: OverlaySourceAppearance
   let styleRuns: [OverlayTextStyleRun]
   let lineLimit: Int?
@@ -216,6 +218,13 @@ private struct HorizontalOverlayText: View, Equatable {
       ))
       .foregroundStyle(Color(appearance.foreground))
       .multilineTextAlignment(textAlignment)
+      .lineSpacing(CoreTextTypesetter.lineSpacing(
+        fontSize: fontSize,
+        language: language,
+        fontWeight: appearance.fontWeight,
+        fontDesign: appearance.fontDesign,
+        lineHeightMultiple: lineHeightMultiple
+      ))
       .lineLimit(lineLimit)
       .truncationMode(.tail)
       .minimumScaleFactor(0.78)

--- a/Sources/SwiftyCrowApp.swift
+++ b/Sources/SwiftyCrowApp.swift
@@ -167,7 +167,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       isTranslating: store.capture.isTranslating || store.capture.isCapturing,
       isLive: store.capture.isLive,
       liveMode: store.settings.overlay.liveMode,
-      sourceImageData: store.capture.sourceImageData,
+      backdrop: store.capture.backdrop,
       imageSize: store.capture.imageSize,
       placementID: store.capture.overlayPlacementID,
       translationUnavailable: store.capture.translationUnavailable,

--- a/Sources/SwiftyCrowApp.swift
+++ b/Sources/SwiftyCrowApp.swift
@@ -74,6 +74,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   // MARK: Internal
 
   func applicationDidFinishLaunching(_: Notification) {
+    guard !ProcessInfo.processInfo.isRunningUnitTests else { return }
+
     // Start Sparkle's background check schedule by reading the dependency.
     _ = updater
 
@@ -105,7 +107,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
   /// Receives the App-owned store once and wires up app-lifetime work.
   func bind(_ store: StoreOf<AppFeature>) {
-    guard self.store == nil else { return }
+    guard self.store == nil, !ProcessInfo.processInfo.isRunningUnitTests else { return }
     self.store = store
 
     // Run the keyboard-shortcut listener for the entire app lifetime.
@@ -165,7 +167,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       isTranslating: store.capture.isTranslating || store.capture.isCapturing,
       isLive: store.capture.isLive,
       liveMode: store.settings.overlay.liveMode,
-      backgroundImageData: store.capture.backgroundImageData,
+      sourceImageData: store.capture.sourceImageData,
       imageSize: store.capture.imageSize,
       placementID: store.capture.overlayPlacementID,
       translationUnavailable: store.capture.translationUnavailable,
@@ -175,8 +177,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
   private func syncOverlay(_ state: OverlayRenderState) async {
     await overlay.render(state)
-    let excluded = await overlay.windowID().map { [$0] } ?? []
-    store?.send(.capture(.setExcludedWindowIDs(excluded)))
+  }
+}
+
+extension ProcessInfo {
+  fileprivate var isRunningUnitTests: Bool {
+    environment["XCTestConfigurationFilePath"] != nil
+      || environment["XCTestBundlePath"] != nil
   }
 }
 
@@ -186,8 +193,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 /// bridge that turns an `.openSettingsWindow` notification into a scene-level
 /// `openWindow` (see `Notification.Name.openSettingsWindow`).
 private struct MenuBarLabel: View {
-  @Environment(\.openWindow) private var openWindow
-
   var body: some View {
     Image(systemName: "character.bubble.fill")
       .accessibilityLabel("SwiftyCrow")
@@ -196,6 +201,9 @@ private struct MenuBarLabel: View {
         NSApp.activate(ignoringOtherApps: true)
       }
   }
+
+  @Environment(\.openWindow) private var openWindow
+
 }
 
 // MARK: - OpenSettingsCommandButton
@@ -203,8 +211,6 @@ private struct MenuBarLabel: View {
 /// Backs the ⌘, / "Settings…" app-menu item. A dedicated view so it can read
 /// the `openWindow` environment action from inside `.commands`.
 private struct OpenSettingsCommandButton: View {
-  @Environment(\.openWindow) private var openWindow
-
   var body: some View {
     Button("Settings…") {
       openWindow(id: settingsWindowID)
@@ -212,6 +218,9 @@ private struct OpenSettingsCommandButton: View {
     }
     .keyboardShortcut(",", modifiers: .command)
   }
+
+  @Environment(\.openWindow) private var openWindow
+
 }
 
 // MARK: - Regular-while-open

--- a/Tests/CaptureFeatureTests.swift
+++ b/Tests/CaptureFeatureTests.swift
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import ComposableArchitecture
+import Foundation
+import Testing
+@testable import SwiftyCrow
+
+@Suite("Capture translation lifecycle")
+@MainActor
+struct CaptureFeatureTests {
+
+  // MARK: Internal
+
+  @Test
+  func lateResponseFromCancelledGenerationIsIgnored() async {
+    let store = TestStore(initialState: makeState()) {
+      CaptureFeature()
+    }
+
+    await store.send(
+      CaptureFeature.Action.translationResponse(
+        generation: 1,
+        lineID: pendingLine.id,
+        key: cacheKey,
+        translation: TranslatedText(text: "Stale translation")
+      )
+    )
+  }
+
+  @Test
+  func currentResponseResolvesPendingLineAndCachesOnlyNonemptyText() async {
+    let store = TestStore(initialState: makeState()) {
+      CaptureFeature()
+    }
+
+    await store.send(
+      CaptureFeature.Action.translationResponse(
+        generation: 2,
+        lineID: pendingLine.id,
+        key: cacheKey,
+        translation: TranslatedText(text: "  Current translation  ")
+      )
+    ) {
+      $0.translationCache[cacheKey] = TranslatedText(text: "Current translation")
+      $0.overlayLines[0].showTranslation(
+        "Current translation",
+        language: Locale.Language(identifier: "en-US")
+      )
+      $0.isTranslating = false
+    }
+  }
+
+  @Test
+  func emptyResponseBecomesVisibleErrorWithoutPoisoningCache() async {
+    let store = TestStore(initialState: makeState()) {
+      CaptureFeature()
+    }
+
+    await store.send(
+      CaptureFeature.Action.translationResponse(
+        generation: 2,
+        lineID: pendingLine.id,
+        key: cacheKey,
+        translation: TranslatedText(text: " \n ")
+      )
+    ) {
+      $0.overlayLines[0].showUnavailable()
+      $0.isTranslating = false
+      $0.lastError = "Translation returned empty text."
+    }
+  }
+
+  @Test
+  func omittedResultBecomesExplicitFallback() async {
+    let store = TestStore(initialState: makeState()) {
+      CaptureFeature()
+    }
+
+    await store.send(
+      CaptureFeature.Action.translationUnavailable(
+        generation: 2,
+        lineIDs: [pendingLine.id],
+        message: nil
+      )
+    ) {
+      $0.overlayLines[0].showUnavailable()
+      $0.isTranslating = false
+      $0.lastError = "Translation did not return every requested line."
+    }
+  }
+
+  @Test
+  func unchangedLiveOCRKeepsInFlightTranslationAndRefreshesSourceStyle() async {
+    var state = makeState()
+    state.$settings.withLock {
+      $0.languages.source = Language(code: "ja")
+      $0.languages.target = Language(code: "en-US")
+    }
+    state.translationRequestContext = CaptureFeature.TranslationRequestContext(
+      strategy: .lowLatency,
+      target: "en-US"
+    )
+    let appearance = OverlaySourceAppearance(
+      background: OverlayColor(red: 0.1, green: 0.2, blue: 0.3, alpha: 1),
+      foreground: OverlayColor(red: 0.8, green: 0.7, blue: 0.6, alpha: 1),
+      confidence: 0.9,
+      foregroundConfidence: 0.8,
+      inkCoverage: 0.25,
+      fontWeight: .medium
+    )
+    let refreshed = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.41, y: 0.21, width: 0.08, height: 0.3),
+      text: pendingLine.source.text,
+      isVerticalBlock: true,
+      verticalCharScale: 0.04,
+      appearance: appearance
+    )
+    let capture = CaptureFeature.LiveCapture(
+      imageData: nil,
+      imageSize: CGSize(width: 900, height: 600),
+      result: OCRResult(lines: [refreshed])
+    )
+    let expectedSource = OverlayLine.Source(
+      recognized: refreshed,
+      language: Locale.Language(identifier: "ja")
+    ).stabilized(relativeTo: state.overlayLines[0].source, imageSize: capture.imageSize)
+    let store = TestStore(initialState: state) {
+      CaptureFeature()
+    }
+    store.dependencies.languageDetection = LanguageDetectionClient(
+      detect: { _, _ in nil }
+    )
+
+    await store.send(.captureResponse(.success(capture))) {
+      $0.imageSize = capture.imageSize
+      $0.overlayLines[0].source = expectedSource
+    }
+
+    #expect(store.state.translationGeneration == 2)
+    #expect(store.state.overlayLines[0].isPending)
+    #expect(store.state.overlayLines[0].source.box != refreshed.boundingBoxNormalized)
+    #expect(abs(store.state.overlayLines[0].source.box.minX - 0.4035) < 0.000_001)
+  }
+
+  @Test
+  func sourceStabilizationAcceptsRealMovementImmediately() {
+    let previous = pendingLine.source
+    let moved = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.55, y: 0.35, width: 0.08, height: 0.3),
+      text: previous.text,
+      isVerticalBlock: true,
+      verticalCharScale: 0.04
+    )
+    let current = OverlayLine.Source(recognized: moved, language: previous.language)
+
+    let stabilized = current.stabilized(
+      relativeTo: previous,
+      imageSize: CGSize(width: 900, height: 600)
+    )
+
+    #expect(stabilized.box == moved.boundingBoxNormalized)
+  }
+
+  // MARK: Private
+
+  private var cacheKey: CaptureFeature.TranslationCacheKey {
+    CaptureFeature.TranslationCacheKey(
+      source: "ja-Jpan-JP",
+      strategy: .lowLatency,
+      target: "en-US",
+      text: "今日は大切な話があります"
+    )
+  }
+
+  private var pendingLine: OverlayLine {
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.4, y: 0.2, width: 0.08, height: 0.3),
+      text: "今日は大切な話があります",
+      isVerticalBlock: true,
+      verticalCharScale: 0.04
+    )
+    return OverlayLine(
+      id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "ja")
+      ),
+      initialContent: .pending
+    )
+  }
+
+  private func makeState() -> CaptureFeature.State {
+    var state = CaptureFeature.State()
+    state.translationGeneration = 2
+    state.isTranslating = true
+    state.overlayLines = [pendingLine]
+    return state
+  }
+}

--- a/Tests/CaptureFeatureTests.swift
+++ b/Tests/CaptureFeatureTests.swift
@@ -117,7 +117,7 @@ struct CaptureFeatureTests {
       appearance: appearance
     )
     let capture = CaptureFeature.LiveCapture(
-      imageData: nil,
+      backdrop: nil,
       imageSize: CGSize(width: 900, height: 600),
       result: OCRResult(lines: [refreshed])
     )
@@ -160,6 +160,28 @@ struct CaptureFeatureTests {
     )
 
     #expect(stabilized.box == moved.boundingBoxNormalized)
+  }
+
+  @Test
+  func liveCadenceSubtractsWorkAlreadySpentInTheTick() {
+    #expect(
+      LiveCaptureCadence.remainingDelay(
+        interval: .milliseconds(800),
+        elapsed: .milliseconds(275)
+      ) == .milliseconds(525)
+    )
+    #expect(
+      LiveCaptureCadence.remainingDelay(
+        interval: .milliseconds(800),
+        elapsed: .milliseconds(800)
+      ) == nil
+    )
+    #expect(
+      LiveCaptureCadence.remainingDelay(
+        interval: .milliseconds(800),
+        elapsed: .seconds(2)
+      ) == nil
+    )
   }
 
   // MARK: Private

--- a/Tests/CoreTextTypesetterTests.swift
+++ b/Tests/CoreTextTypesetterTests.swift
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import SwiftyCrow
+
+@Suite("Core Text typesetting")
+struct CoreTextTypesetterTests {
+
+  // MARK: Internal
+
+  struct VerticalCase: Sendable, CustomTestStringConvertible {
+    let language: String
+    let text: String
+
+    var testDescription: String {
+      language
+    }
+  }
+
+  @Test
+  func koreanVerticalColumnsKeepWordsTogetherAndStayCompact() throws {
+    let text = "괜찮다면 지금 시작해요."
+    let fontSize: CGFloat = 22.75
+    let plan = CoreTextTypesetter.verticalLayoutPlan(
+      text: text,
+      language: Locale.Language(identifier: "ko"),
+      fontSize: fontSize,
+      constrainedToHeight: 154
+    )
+    let columns = try substrings(plan.columns, in: text)
+
+    #expect(columns == ["괜찮다면 지금 ", "시작해요."])
+    #expect(plan.columnGap <= fontSize * 0.15)
+    #expect(plan.requiredWidth < fontSize * 3)
+  }
+
+  @Test
+  func koreanEmergencyBreakMovesWholeWordToNextColumn() throws {
+    let text = "갑자기 찾아와서 미안해요."
+    let plan = CoreTextTypesetter.verticalLayoutPlan(
+      text: text,
+      language: Locale.Language(identifier: "ko"),
+      fontSize: 29.44,
+      constrainedToHeight: 342.8
+    )
+    let columns = try substrings(plan.columns, in: text)
+
+    #expect(columns == ["갑자기 찾아와서 ", "미안해요."])
+    #expect(CoreTextTypesetter.verticalColumnsPreserveWords(
+      text: text,
+      language: Locale.Language(identifier: "ko"),
+      fontSize: 29.44,
+      constrainedToHeight: 342.8
+    ))
+  }
+
+  @Test(arguments: [
+    VerticalCase(language: "ja", text: "2026年8月27日です。OKなら今すぐ始めよう。"),
+    VerticalCase(language: "ko", text: "오늘 중요한 이야기가 있어요. 괜찮다면 지금 시작해요."),
+    VerticalCase(language: "zh-Hans", text: "今天有重要的事情告诉你。如果可以的话，我们现在开始吧。"),
+  ])
+  func verticalPlansConsumeEveryComposedCharacter(_ testCase: VerticalCase) throws {
+    let plan = CoreTextTypesetter.verticalLayoutPlan(
+      text: testCase.text,
+      language: Locale.Language(identifier: testCase.language),
+      fontSize: 24,
+      constrainedToHeight: 180
+    )
+    let columns = try substrings(plan.columns, in: testCase.text)
+
+    #expect(!columns.isEmpty)
+    #expect(columns.joined() == testCase.text)
+    #expect(plan.columns.reduce(0) { $0 + $1.length } == (testCase.text as NSString).length)
+  }
+
+  @Test
+  func englishFontFitsTheLongestWordBeforeWrapping() {
+    let language = Locale.Language(identifier: "en-US")
+    let availableWidth: CGFloat = 62
+    let fontSize = CoreTextTypesetter.horizontalWordFittedFontSize(
+      text: "I have something important to tell you.",
+      language: language,
+      constrainedToWidth: availableWidth,
+      preferred: 28,
+      minimum: 6
+    )
+    let longestWord = CoreTextTypesetter.suggestedHorizontalSize(
+      text: "something",
+      language: language,
+      fontSize: fontSize,
+      constrainedToWidth: 1_000
+    )
+
+    #expect(fontSize < 28)
+    #expect(longestWord.width <= availableWidth + 1)
+    #expect(CoreTextTypesetter.horizontalWordsFit(
+      text: "I have something important to tell you.",
+      language: language,
+      fontSize: fontSize,
+      constrainedToWidth: availableWidth
+    ))
+  }
+
+  // MARK: Private
+
+  private func substrings(_ ranges: [NSRange], in text: String) throws -> [String] {
+    try ranges.map { range in
+      String(text[try #require(Range(range, in: text))])
+    }
+  }
+}

--- a/Tests/CoreTextTypesetterTests.swift
+++ b/Tests/CoreTextTypesetterTests.swift
@@ -104,6 +104,40 @@ struct CoreTextTypesetterTests {
     ))
   }
 
+  @Test
+  func horizontalLineHeightMultipleParticipatesInFitting() {
+    let text = "첫 번째 줄과 두 번째 줄의 간격을 원본과 동일하게 유지합니다."
+    let language = Locale.Language(identifier: "ko-KR")
+    let size = CGSize(width: 180, height: 72)
+    let defaultSize = CoreTextTypesetter.fittedFontSize(
+      text: text,
+      language: language,
+      flow: .horizontal(.leftToRight),
+      constrainedTo: size,
+      preferred: 24,
+      minimum: 6
+    )
+    let spacedSize = CoreTextTypesetter.fittedFontSize(
+      text: text,
+      language: language,
+      flow: .horizontal(.leftToRight),
+      constrainedTo: size,
+      preferred: 24,
+      minimum: 6,
+      lineHeightMultiple: 1.35
+    )
+
+    #expect(spacedSize <= defaultSize)
+    #expect(CoreTextTypesetter.fits(
+      text: text,
+      language: language,
+      flow: .horizontal(.leftToRight),
+      fontSize: spacedSize,
+      in: size,
+      lineHeightMultiple: 1.35
+    ))
+  }
+
   // MARK: Private
 
   private func substrings(_ ranges: [NSRange], in text: String) throws -> [String] {

--- a/Tests/JapaneseRubyOCRCorrectorTests.swift
+++ b/Tests/JapaneseRubyOCRCorrectorTests.swift
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Foundation
+import Testing
+@testable import SwiftyCrow
+
+@Suite("Japanese ruby OCR correction")
+struct JapaneseRubyOCRCorrectorTests {
+
+  @Test
+  func acceptsConfidentBaseGlyphCorrection() {
+    let corrected = JapaneseRubyOCRCorrector.preferredCorrection(
+      original: "腸や驚をとるための「やり」と",
+      candidate: "動物や魚をとるための「やり」と",
+      confidence: 1
+    )
+
+    #expect(corrected == "動物や魚をとるための「やり」と")
+  }
+
+  @Test
+  func rejectsCandidateThatOnlyDropsAValidGlyph() {
+    let corrected = JapaneseRubyOCRCorrector.preferredCorrection(
+      original: "ナイフ型石器",
+      candidate: "ナイフ石器",
+      confidence: 0.5
+    )
+
+    #expect(corrected == nil)
+  }
+
+  @Test
+  func acceptsCompactHanCorrectionDespiteSevereInitialOCRDamage() {
+    let corrected = JapaneseRubyOCRCorrector.preferredCorrection(
+      original: "貓岩-",
+      candidate: "細石器",
+      confidence: 0.3
+    )
+
+    #expect(corrected == "細石器")
+  }
+
+  @Test
+  func rejectsLowConfidenceCroppedHeading() {
+    let corrected = JapaneseRubyOCRCorrector.preferredCorrection(
+      original: "おの型石器",
+      candidate: "おの坐白各",
+      confidence: 0.3
+    )
+
+    #expect(corrected == nil)
+  }
+
+  @Test
+  func rejectsKanaOnlyFuriganaMutation() {
+    let corrected = JapaneseRubyOCRCorrector.preferredCorrection(
+      original: "さいせっ",
+      candidate: "さいせつ",
+      confidence: 0.5
+    )
+
+    #expect(corrected == nil)
+  }
+
+  @Test
+  func preservesReliableOriginalKanaWhileCorrectingKanji() {
+    let corrected = JapaneseRubyOCRCorrector.preferredCorrection(
+      original: "手でにぎったり、柔",
+      candidate: "手でにぎうたり、木",
+      confidence: 0.5
+    )
+
+    #expect(corrected == "手でにぎったり、木")
+  }
+
+  @Test
+  func remapsUnchangedPunctuationStyleAfterTextCorrection() {
+    let original = "脂岩器時花の道真＝折製若器）"
+    let corrected = "旧石器時代の道具＝打製石器）"
+    let closingRange = (original as NSString).range(of: "）")
+    let run = OverlaySourceStyleRun(
+      range: closingRange,
+      box: .zero,
+      appearance: .fallback
+    )
+
+    let remapped = JapaneseRubyOCRCorrector.remappedStyleRuns(
+      [run],
+      from: original,
+      to: corrected
+    )
+
+    #expect(remapped.count == 1)
+    #expect((corrected as NSString).substring(with: remapped[0].range) == "）")
+  }
+}

--- a/Tests/OCRResultTests.swift
+++ b/Tests/OCRResultTests.swift
@@ -1,0 +1,1168 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import SwiftyCrow
+
+@Suite("OCR paragraph coalescing")
+struct OCRResultTests {
+
+  // MARK: Internal
+
+  struct SeparationCase: Sendable, CustomTestStringConvertible {
+    let name: String
+    let lhs: OCRResult.Line
+    let rhs: OCRResult.Line
+
+    var testDescription: String {
+      name
+    }
+  }
+
+  struct BodyAppearanceCase: Sendable, CustomTestStringConvertible {
+    let name: String
+    let firstForeground: CGFloat
+    let secondForeground: CGFloat
+    let firstForegroundConfidence: CGFloat
+    let secondForegroundConfidence: CGFloat
+    let firstWeight: OverlayFontWeight
+
+    var testDescription: String {
+      name
+    }
+  }
+
+  @Test
+  func joinsObservedSplitBubbleRightToLeft() throws {
+    let right = verticalLine(
+      x: 0.453125,
+      y: 0.38125,
+      width: 0.03125,
+      height: 0.11458,
+      text: "それは本当で"
+    )
+    let left = verticalLine(
+      x: 0.421875,
+      y: 0.38125,
+      width: 0.028125,
+      height: 0.03958,
+      text: "すか"
+    )
+
+    let result = OCRResult(lines: [right, left]).coalescingParagraphFragments()
+    let merged = try #require(result.lines.first)
+    #expect(result.lines.count == 1)
+    #expect(merged.text == "それは本当ですか")
+    #expect(merged.boundingBoxNormalized == right.boundingBoxNormalized.union(left.boundingBoxNormalized))
+    #expect(merged.isVerticalBlock)
+  }
+
+  @Test
+  func joinsThreeColumnComponentTransitively() {
+    let lines = [
+      verticalLine(x: 0.40, y: 0.2, width: 0.03, height: 0.2, text: "右"),
+      verticalLine(x: 0.368, y: 0.2, width: 0.03, height: 0.2, text: "中"),
+      verticalLine(x: 0.336, y: 0.2, width: 0.03, height: 0.2, text: "左"),
+    ]
+    let result = OCRResult(lines: lines).coalescingParagraphFragments()
+    #expect(result.lines.count == 1)
+    #expect(result.lines.first?.text == "右中左")
+  }
+
+  @Test
+  func joinsWideSpacedVerticalColumnsInsideOneDetectedSurface() throws {
+    let surface = OverlaySourceSurface(
+      box: CGRect(x: 0.30, y: 0.10, width: 0.20, height: 0.30),
+      confidence: 0.7
+    )
+    var right = verticalLine(x: 0.44, y: 0.12, width: 0.02, height: 0.20, text: "昨日の夜")
+    right.recognitionGroupID = 3
+    right.surface = surface
+    var middle = verticalLine(x: 0.408, y: 0.12, width: 0.02, height: 0.20, text: "時計が止まり")
+    middle.recognitionGroupID = 3
+    middle.surface = surface
+    var left = verticalLine(x: 0.376, y: 0.12, width: 0.02, height: 0.07, text: "ました")
+    left.recognitionGroupID = 3
+    left.surface = surface
+
+    let merged = try #require(
+      OCRResult(lines: [right, middle, left]).coalescingParagraphFragments().lines.first
+    )
+
+    #expect(merged.text == "昨日の夜時計が止まりました")
+  }
+
+  @Test
+  func prefersCompactSurfaceContainingMergedText() throws {
+    let compact = OverlaySourceSurface(
+      box: CGRect(x: 0.38, y: 0.10, width: 0.12, height: 0.30),
+      confidence: 0.6,
+      clippingBox: CGRect(x: 0.36, y: 0.08, width: 0.16, height: 0.34)
+    )
+    let oversized = OverlaySourceSurface(
+      box: CGRect(x: 0.02, y: 0.02, width: 0.94, height: 0.50),
+      confidence: 0.99,
+      clippingBox: CGRect(x: 0.01, y: 0.01, width: 0.98, height: 0.54)
+    )
+    var right = verticalLine(x: 0.44, y: 0.12, width: 0.02, height: 0.20, text: "右")
+    right.recognitionGroupID = 7
+    right.surface = oversized
+    var left = verticalLine(x: 0.408, y: 0.12, width: 0.02, height: 0.20, text: "左")
+    left.recognitionGroupID = 7
+    left.surface = compact
+
+    let merged = try #require(
+      OCRResult(lines: [right, left]).coalescingParagraphFragments().lines.first
+    )
+
+    #expect(merged.surface == compact)
+  }
+
+  @Test
+  func ordersSplitHorizontalFragmentsInVisualReadingOrder() throws {
+    let lines = [
+      OCRResult.Line(
+        boundingBoxNormalized: CGRect(x: 0.05, y: 0.80, width: 0.18, height: 0.020),
+        text: "first",
+        recognitionGroupID: 9
+      ),
+      OCRResult.Line(
+        boundingBoxNormalized: CGRect(x: 0.15, y: 0.816, width: 0.08, height: 0.017),
+        text: "right",
+        recognitionGroupID: 9
+      ),
+      OCRResult.Line(
+        boundingBoxNormalized: CGRect(x: 0.06, y: 0.819, width: 0.09, height: 0.017),
+        text: "left",
+        recognitionGroupID: 9
+      ),
+      OCRResult.Line(
+        boundingBoxNormalized: CGRect(x: 0.08, y: 0.833, width: 0.13, height: 0.017),
+        text: "last",
+        recognitionGroupID: 9
+      ),
+    ]
+
+    let merged = try #require(OCRResult(lines: lines).coalescingParagraphFragments().lines.first)
+
+    #expect(merged.text == "first left right last")
+  }
+
+  @Test
+  func joinsAdjacentMixedStyleFragmentsOnOneVisualRow() throws {
+    let normalAppearance = OverlaySourceAppearance(
+      background: OverlayColor(red: 0.08, green: 0.09, blue: 0.10, alpha: 1),
+      foreground: OverlayColor(red: 0.92, green: 0.93, blue: 0.95, alpha: 1),
+      confidence: 0.7,
+      foregroundConfidence: 0.1,
+      fontWeight: .regular
+    )
+    let codeAppearance = OverlaySourceAppearance(
+      background: OverlayColor(red: 0.20, green: 0.21, blue: 0.23, alpha: 1),
+      foreground: OverlayColor(red: 0.95, green: 0.95, blue: 0.96, alpha: 1),
+      confidence: 0.8,
+      foregroundConfidence: 0.2,
+      fontWeight: .regular,
+      fontDesign: .monospaced
+    )
+    let left = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.10, y: 0.30, width: 0.22, height: 0.03),
+      text: "Open report",
+      rowCount: 1,
+      recognitionGroupID: 1,
+      appearance: normalAppearance
+    )
+    let codeText = "build 2.10.0"
+    let code = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.325, y: 0.299, width: 0.11, height: 0.032),
+      text: codeText,
+      rowCount: 1,
+      recognitionGroupID: 2,
+      appearance: codeAppearance,
+      styleRuns: [
+        OverlaySourceStyleRun(
+          range: NSRange(location: 0, length: (codeText as NSString).length),
+          box: CGRect(x: 0.325, y: 0.299, width: 0.11, height: 0.032),
+          appearance: codeAppearance
+        )
+      ],
+      surface: OverlaySourceSurface(
+        box: CGRect(x: 0.32, y: 0.295, width: 0.12, height: 0.04),
+        confidence: 0.8
+      )
+    )
+    let tail = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.432, y: 0.301, width: 0.09, height: 0.029),
+      text: ", and keep",
+      rowCount: 1,
+      recognitionGroupID: 3,
+      appearance: normalAppearance
+    )
+
+    let result = OCRResult(lines: [left, code, tail]).coalescingParagraphFragments()
+    let merged = try #require(result.lines.first)
+
+    #expect(result.lines.count == 1)
+    #expect(merged.text == "Open report build 2.10.0, and keep")
+    #expect(merged.rowCount == 1)
+    #expect(merged.wasCoalesced)
+    #expect(merged.appearance == normalAppearance)
+    let styled = try #require(merged.styleRuns.first)
+    #expect((merged.text as NSString).substring(with: styled.range) == codeText)
+  }
+
+  @Test
+  func keepsPaddedSegmentLabelsSeparate() {
+    let selected = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.10, y: 0.30, width: 0.09, height: 0.03),
+      text: "Balanced"
+    )
+    let neighboring = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.22, y: 0.30, width: 0.08, height: 0.03),
+      text: "Fast mode"
+    )
+
+    let result = OCRResult(lines: [selected, neighboring]).coalescingParagraphFragments()
+
+    #expect(result.lines == [selected, neighboring])
+  }
+
+  @Test
+  func keepsAdjacentMultilineCardBodiesSeparate() {
+    let left = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.10, y: 0.40, width: 0.30, height: 0.15),
+      text: "The left card contains several wrapped rows of supporting text.",
+      rowCount: 4
+    )
+    let right = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.42, y: 0.40, width: 0.30, height: 0.15),
+      text: "The right card is a separate visual container with its own body.",
+      rowCount: 4
+    )
+
+    let result = OCRResult(lines: [left, right]).coalescingParagraphFragments()
+
+    #expect(result.lines == [left, right])
+  }
+
+  @Test
+  func preservesTightReplacementPatchesWhenParagraphsMerge() throws {
+    var right = verticalLine(x: 0.40, y: 0.2, width: 0.03, height: 0.2, text: "右")
+    right.replacementPatches = [OverlaySourcePatch(box: right.boundingBoxNormalized)]
+    var left = verticalLine(x: 0.368, y: 0.2, width: 0.03, height: 0.2, text: "左")
+    left.replacementPatches = [OverlaySourcePatch(box: left.boundingBoxNormalized)]
+
+    let merged = try #require(OCRResult(lines: [right, left]).coalescingParagraphFragments().lines.first)
+
+    #expect(merged.replacementPatches.map(\.box) == [right.boundingBoxNormalized, left.boundingBoxNormalized])
+  }
+
+  @Test
+  func absorbsShortCJKContinuationMisclassifiedAsHorizontal() throws {
+    let vertical = verticalLine(
+      x: 0.15,
+      y: 0.0479,
+      width: 0.0344,
+      height: 0.2083,
+      text: "今日はいい天気です"
+    )
+    let continuation = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1156, y: 0.0479, width: 0.0281, height: 0.0208),
+      text: "ね"
+    )
+
+    let result = OCRResult(lines: [vertical, continuation]).coalescingParagraphFragments()
+    let merged = try #require(result.lines.first)
+    #expect(result.lines.count == 1)
+    #expect(merged.text == "今日はいい天気ですね")
+    #expect(merged.isVerticalBlock)
+    #expect(merged.verticalCharScale == vertical.verticalCharScale)
+  }
+
+  @Test
+  func absorbsOverlappingTerminalGlyphInsideSameVerticalSurface() throws {
+    let surface = OverlaySourceSurface(
+      box: CGRect(x: 0.07, y: 0.04, width: 0.14, height: 0.23),
+      confidence: 0.8
+    )
+    var vertical = verticalLine(
+      x: 0.109,
+      y: 0.05,
+      width: 0.019,
+      height: 0.15,
+      text: "この町で起きている不思議な出来事を説明してもらいます"
+    )
+    vertical.surface = surface
+    var terminal = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.081, y: 0.094, width: 0.019, height: 0.015),
+      text: "か"
+    )
+    terminal.surface = surface
+
+    let merged = try #require(
+      OCRResult(lines: [vertical, terminal]).coalescingParagraphFragments().lines.first
+    )
+
+    #expect(merged.text.hasSuffix("か"))
+    #expect(merged.isVerticalBlock)
+  }
+
+  @Test
+  func joinsWrappedHorizontalRowsFromOneTextBlock() throws {
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.0903, y: 0.4444, width: 0.3288, height: 0.0266),
+      text: "今日はいい天気ですね。"
+    )
+    let second = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.0906, y: 0.4688, width: 0.3406, height: 0.0479),
+      text: "次の週末もここで会いましょう。",
+      rowCount: 2
+    )
+
+    let result = OCRResult(lines: [first, second]).coalescingParagraphFragments()
+    let merged = try #require(result.lines.first)
+    #expect(result.lines.count == 1)
+    #expect(merged.text == "今日はいい天気ですね。 次の週末もここで会いましょう。")
+    #expect(merged.rowCount == 3)
+    #expect(!merged.isVerticalBlock)
+  }
+
+  @Test
+  func keepsLargeHeadingAndSmallSubtitleSeparate() {
+    let heading = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.2, y: 0.1, width: 0.6, height: 0.09),
+      text: "Lives in your menu bar."
+    )
+    let subtitle = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1, y: 0.2, width: 0.8, height: 0.04),
+      text: "No Dock icon, no clutter."
+    )
+
+    let result = OCRResult(lines: [heading, subtitle]).coalescingParagraphFragments()
+
+    #expect(result.lines == [heading, subtitle])
+  }
+
+  @Test
+  func joinsObservedWebBodyRowsWithTightCSSLineHeight() throws {
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.0756, y: 0.7125, width: 0.2253, height: 0.0271),
+      text: "Open the popover or fire any action"
+    )
+    let second = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.0740, y: 0.7499, width: 0.2298, height: 0.0332),
+      text: "from a global shortcut, even with no"
+    )
+    let third = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.0726, y: 0.7891, width: 0.0948, height: 0.0248),
+      text: "window open."
+    )
+
+    let result = OCRResult(lines: [first, second, third]).coalescingParagraphFragments()
+    let merged = try #require(result.lines.first)
+
+    #expect(result.lines.count == 1)
+    #expect(merged.rowCount == 3)
+    #expect(merged.text == "Open the popover or fire any action from a global shortcut, even with no window open.")
+  }
+
+  @Test
+  func visionTranscriptNewlineSeparatesCardHeadingFromWrappedBody() {
+    let groups = OCRParagraphLineGrouping.segmentIndices(
+      paragraphTranscript: "Smart, or fully manual\nChoose Conservative, Balanced, or Fast and let Amado filter spikes.",
+      lineTranscripts: [
+        "Smart, or fully manual",
+        "Choose Conservative, Balanced, or",
+        "Fast and let Amado filter spikes.",
+      ]
+    )
+
+    #expect(groups == [0, 1, 1])
+  }
+
+  @Test
+  func infersHardBreakWhenACompletedRowLeavesRoomForTheNextToken() throws {
+    let appearance = OverlaySourceAppearance(
+      background: OverlayColor(red: 1, green: 0.94, blue: 0.84, alpha: 1),
+      foreground: OverlayColor(red: 0.65, green: 0.40, blue: 0.02, alpha: 1),
+      confidence: 0.7,
+      foregroundConfidence: 0.15,
+      fontWeight: .regular
+    )
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.626, y: 0.302, width: 0.170, height: 0.024),
+      text: "Two checks are pending.",
+      horizontalGlyphScale: 0.023,
+      recognitionGroupID: 10,
+      appearance: appearance,
+      alignment: .leading
+    )
+    let secondText = "The orange surface and its rounded corners"
+    let second = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.629, y: 0.335, width: 0.271, height: 0.026),
+      text: secondText,
+      horizontalGlyphScale: 0.023,
+      recognitionGroupID: 10,
+      appearance: appearance,
+      styleRuns: [
+        OverlaySourceStyleRun(
+          range: NSRange(location: 0, length: 3),
+          box: CGRect(x: 0.629, y: 0.335, width: 0.021, height: 0.024)
+        )
+      ],
+      alignment: .leading
+    )
+    let third = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.626, y: 0.372, width: 0.227, height: 0.026),
+      text: "must remain visible after translation.",
+      horizontalGlyphScale: 0.023,
+      recognitionGroupID: 10,
+      appearance: appearance,
+      alignment: .leading
+    )
+
+    let merged = try #require(
+      OCRResult(lines: [first, second, third]).coalescingParagraphFragments().lines.first
+    )
+
+    #expect(merged.text == "Two checks are pending.\n\(secondText) must remain visible after translation.")
+    #expect(merged.rowCount == 3)
+  }
+
+  @Test
+  func ordinaryWrappedRowsRemainOneContinuousSentence() throws {
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.10, y: 0.30, width: 0.39, height: 0.03),
+      text: "The first sentence ends here.",
+      recognitionGroupID: 3,
+      alignment: .leading
+    )
+    let second = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.10, y: 0.34, width: 0.40, height: 0.03),
+      text: "The next sentence uses the remaining row.",
+      recognitionGroupID: 3,
+      alignment: .leading
+    )
+
+    let merged = try #require(OCRResult(lines: [first, second]).coalescingParagraphFragments().lines.first)
+
+    #expect(merged.text == "The first sentence ends here. The next sentence uses the remaining row.")
+  }
+
+  @Test
+  func visionParagraphMembershipJoinsLooseWrappedRowsWithoutAbsorbingHeading() {
+    let heading = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.03, y: 0.20, width: 0.20, height: 0.05),
+      text: "Bypass list",
+      recognitionGroupID: 1
+    )
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.03, y: 0.30, width: 0.80, height: 0.04),
+      text: "Exempt roles, teams, agents, apps, and users from this ruleset by adding them to the",
+      recognitionGroupID: 2
+    )
+    let second = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.03, y: 0.38, width: 0.12, height: 0.04),
+      text: "bypass list.",
+      recognitionGroupID: 2
+    )
+
+    let result = OCRResult(lines: [heading, first, second]).coalescingParagraphFragments()
+
+    #expect(result.lines.count == 2)
+    #expect(result.lines[0] == heading)
+    #expect(result.lines[1]
+      .text == "Exempt roles, teams, agents, apps, and users from this ruleset by adding them to the bypass list.")
+  }
+
+  @Test
+  func distinctVisionParagraphsStaySeparateEvenAtTightCSSSpacing() {
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.04, y: 0.30, width: 0.92, height: 0.025),
+      text: "The first paragraph ends here.",
+      recognitionGroupID: 4
+    )
+    let second = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.04, y: 0.329, width: 0.92, height: 0.025),
+      text: "The next paragraph starts here.",
+      recognitionGroupID: 5
+    )
+
+    let result = OCRResult(lines: [first, second]).coalescingParagraphFragments()
+
+    #expect(result.lines == [first, second])
+  }
+
+  @Test
+  func repeatedCoalescingDoesNotMergeColoredHeadingIntoBody() {
+    let surface = OverlaySourceSurface(
+      box: CGRect(x: 0.03, y: 0.80, width: 0.46, height: 0.18),
+      confidence: 0.8
+    )
+    let headingAppearance = OverlaySourceAppearance(
+      background: .white,
+      foreground: OverlayColor(red: 0.86, green: 0.42, blue: 0.26, alpha: 1),
+      confidence: 0.8,
+      foregroundConfidence: 0.2,
+      fontWeight: .bold
+    )
+    let bodyAppearance = OverlaySourceAppearance(
+      background: .white,
+      foreground: OverlayColor(red: 0.08, green: 0.08, blue: 0.08, alpha: 1),
+      confidence: 0.8,
+      foregroundConfidence: 0.2,
+      fontWeight: .regular
+    )
+    let heading = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.20, y: 0.846, width: 0.11, height: 0.027),
+      text: "細石器",
+      recognitionGroupID: 8,
+      appearance: headingAppearance,
+      surface: surface
+    )
+    let bodyFirst = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.04, y: 0.875, width: 0.44, height: 0.033),
+      text: "岩の小さな破片を木の棒や",
+      recognitionGroupID: 9,
+      appearance: bodyAppearance,
+      surface: surface
+    )
+    let bodySecond = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.04, y: 0.906, width: 0.44, height: 0.037),
+      text: "動物の骨にはめて使った。",
+      recognitionGroupID: 10,
+      appearance: bodyAppearance,
+      surface: surface
+    )
+
+    let once = OCRResult(lines: [heading, bodyFirst, bodySecond]).coalescingParagraphFragments()
+    let twice = once.coalescingParagraphFragments()
+
+    #expect(once.lines.count == 2)
+    #expect(twice.lines.count == 2)
+    #expect(twice.lines[0].text == "細石器")
+    #expect(twice.lines[1].text.contains("岩の小さな破片"))
+    #expect(twice.lines[1].recognitionGroupID != nil)
+  }
+
+  @Test
+  func absorbsSeparateJapaneseRubyIntoItsBaseRun() throws {
+    let rubyBox = CGRect(x: 0.208, y: 0.836, width: 0.096, height: 0.014)
+    let baseBox = CGRect(x: 0.202, y: 0.846, width: 0.110, height: 0.027)
+    let ruby = OCRResult.Line(
+      boundingBoxNormalized: rubyBox,
+      text: "さいせっき",
+      horizontalGlyphScale: 0.014,
+      replacementPatches: [OverlaySourcePatch(box: rubyBox)]
+    )
+    let base = OCRResult.Line(
+      boundingBoxNormalized: baseBox,
+      text: "細石器",
+      horizontalGlyphScale: 0.027,
+      replacementPatches: [OverlaySourcePatch(box: baseBox)]
+    )
+
+    let result = OCRResult(lines: [ruby, base]).absorbingRubyAnnotations()
+    let line = try #require(result.lines.first)
+
+    #expect(result.lines.count == 1)
+    #expect(line.text == "細石器")
+    #expect(line.boundingBoxNormalized == rubyBox.union(baseBox))
+    #expect(line.replacementPatches.count == 2)
+    #expect(line.horizontalGlyphScale == base.horizontalGlyphScale)
+  }
+
+  @Test
+  func sameVisionParagraphKeepsStronglyDifferentColorsSeparate() {
+    let orange = OverlaySourceAppearance(
+      background: .white,
+      foreground: OverlayColor(red: 0.86, green: 0.42, blue: 0.26, alpha: 1),
+      confidence: 0.8,
+      foregroundConfidence: 0.2,
+      fontWeight: .bold
+    )
+    let black = OverlaySourceAppearance(
+      background: .white,
+      foreground: .black,
+      confidence: 0.8,
+      foregroundConfidence: 0.2,
+      fontWeight: .regular
+    )
+    let heading = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1, y: 0.2, width: 0.3, height: 0.04),
+      text: "Heading",
+      recognitionGroupID: 3,
+      appearance: orange
+    )
+    let body = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1, y: 0.245, width: 0.3, height: 0.04),
+      text: "Body copy",
+      recognitionGroupID: 3,
+      appearance: black
+    )
+
+    #expect(OCRResult(lines: [heading, body]).coalescingParagraphFragments().lines.count == 2)
+  }
+
+  @Test
+  func joinsMatchingBodyRowsAcrossVisionParagraphsInsideOneSurface() throws {
+    let firstAppearance = OverlaySourceAppearance(
+      background: OverlayColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 1),
+      foreground: OverlayColor(red: 0.57, green: 0.57, blue: 0.59, alpha: 1),
+      confidence: 0.6,
+      foregroundConfidence: 0.12,
+      fontWeight: .semibold
+    )
+    var secondAppearance = firstAppearance
+    secondAppearance.fontWeight = .regular
+    let surface = OverlaySourceSurface(
+      box: CGRect(x: 0.38, y: 0.47, width: 0.25, height: 0.45),
+      confidence: 0.6
+    )
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.389, y: 0.786, width: 0.211, height: 0.021),
+      text: "Manual for direct control over the",
+      horizontalGlyphScale: 0.02,
+      recognitionGroupID: 4,
+      appearance: firstAppearance,
+      alignment: .leading,
+      surface: surface
+    )
+    let second = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.388, y: 0.822, width: 0.222, height: 0.031),
+      text: "RSSI threshold, confirmation delay,",
+      horizontalGlyphScale: 0.031,
+      recognitionGroupID: 5,
+      appearance: secondAppearance,
+      alignment: .leading,
+      surface: surface
+    )
+
+    let merged = try #require(OCRResult(lines: [first, second]).coalescingParagraphFragments().lines.first)
+
+    #expect(merged.text == "Manual for direct control over the RSSI threshold, confirmation delay,")
+  }
+
+  @Test
+  func joinsContinuousMultilineCardBodyWithoutDetectedSurface() throws {
+    let appearance = OverlaySourceAppearance(
+      background: OverlayColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 1),
+      foreground: OverlayColor(red: 0.51, green: 0.51, blue: 0.53, alpha: 1),
+      confidence: 0.64,
+      foregroundConfidence: 0.08,
+      fontWeight: .regular
+    )
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.3865, y: 0.6623, width: 0.2284, height: 0.0676),
+      text: "The borrowed block is the real workspace, so changes stay with it.",
+      rowCount: 2,
+      horizontalGlyphScale: 0.0257,
+      recognitionGroupID: 5,
+      appearance: appearance,
+      alignment: .leading
+    )
+    let second = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.3866, y: 0.7350, width: 0.2295, height: 0.0234),
+      text: "Directional focus and MFF cross the",
+      horizontalGlyphScale: 0.0234,
+      recognitionGroupID: 6,
+      appearance: {
+        var noisy = appearance
+        noisy.foregroundConfidence = 0.15
+        noisy.fontWeight = .semibold
+        return noisy
+      }(),
+      alignment: .leading
+    )
+    let third = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.3864, y: 0.7667, width: 0.2315, height: 0.0697),
+      text: "seam, while host and borrowed tiled windows share one switching order.",
+      rowCount: 2,
+      horizontalGlyphScale: 0.0270,
+      recognitionGroupID: 6,
+      appearance: appearance,
+      alignment: .leading
+    )
+    let fourth = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.3864, y: 0.8409, width: 0.2068, height: 0.0684),
+      text: "Activate it to switch over fully, or borrow it again to return it.",
+      rowCount: 2,
+      horizontalGlyphScale: 0.0276,
+      recognitionGroupID: 7,
+      appearance: appearance,
+      alignment: .leading
+    )
+
+    let merged = try #require(
+      OCRResult(lines: [first, second, third, fourth]).coalescingParagraphFragments().lines.first
+    )
+
+    #expect(merged.rowCount == 7)
+    #expect(merged.text.contains("Directional focus and MFF cross the seam"))
+  }
+
+  @Test(arguments: [
+    BodyAppearanceCase(
+      name: "foreground sampling jitter",
+      firstForeground: 0.50,
+      secondForeground: 0.65,
+      firstForegroundConfidence: 0.10,
+      secondForegroundConfidence: 0.12,
+      firstWeight: .regular
+    ),
+    BodyAppearanceCase(
+      name: "weak first-row confidence",
+      firstForeground: 0.50,
+      secondForeground: 0.53,
+      firstForegroundConfidence: 0.03,
+      secondForegroundConfidence: 0.12,
+      firstWeight: .regular
+    ),
+    BodyAppearanceCase(
+      name: "noisy first-row weight",
+      firstForeground: 0.50,
+      secondForeground: 0.53,
+      firstForegroundConfidence: 0.15,
+      secondForegroundConfidence: 0.10,
+      firstWeight: .semibold
+    ),
+  ])
+  func joinsSplitCardBodyDespiteLowContrastStyleNoise(_ testCase: BodyAppearanceCase) throws {
+    let background = OverlayColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 1)
+    let surface = OverlaySourceSurface(
+      box: CGRect(x: 0.06, y: 0.44, width: 0.26, height: 0.45),
+      confidence: 0.7
+    )
+    let firstAppearance = OverlaySourceAppearance(
+      background: background,
+      foreground: OverlayColor(
+        red: testCase.firstForeground,
+        green: testCase.firstForeground,
+        blue: testCase.firstForeground,
+        alpha: 1
+      ),
+      confidence: 0.6,
+      foregroundConfidence: testCase.firstForegroundConfidence,
+      fontWeight: testCase.firstWeight
+    )
+    let secondAppearance = OverlaySourceAppearance(
+      background: background,
+      foreground: OverlayColor(
+        red: testCase.secondForeground,
+        green: testCase.secondForeground,
+        blue: testCase.secondForeground,
+        alpha: 1
+      ),
+      confidence: 0.6,
+      foregroundConfidence: testCase.secondForegroundConfidence,
+      fontWeight: .regular
+    )
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.0828, y: 0.6667, width: 0.1512, height: 0.0260),
+      text: "Each profile has its own",
+      recognitionGroupID: 4,
+      appearance: firstAppearance,
+      alignment: .leading,
+      surface: surface
+    )
+    let remainder = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.0814, y: 0.7016, width: 0.2297, height: 0.1562),
+      text: "workspaces, app assignments, and shortcuts. Switch by hotkey or from the menu bar.",
+      rowCount: 5,
+      recognitionGroupID: 5,
+      appearance: secondAppearance,
+      alignment: .leading,
+      surface: surface
+    )
+
+    let result = OCRResult(lines: [first, remainder]).coalescingParagraphFragments()
+    let merged = try #require(result.lines.first)
+
+    #expect(result.lines.count == 1)
+    #expect(merged.rowCount == 6)
+  }
+
+  @Test
+  func joinsSingleRowsWhenLowContrastSamplingAloneChangesTheirWeight() {
+    let background = OverlayColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 1)
+    let regular = OverlaySourceAppearance(
+      background: background,
+      foreground: OverlayColor(red: 0.50, green: 0.50, blue: 0.52, alpha: 1),
+      confidence: 0.6,
+      foregroundConfidence: 0.11,
+      fontWeight: .regular
+    )
+    let noisySemibold = OverlaySourceAppearance(
+      background: background,
+      foreground: OverlayColor(red: 0.50, green: 0.50, blue: 0.52, alpha: 1),
+      confidence: 0.6,
+      foregroundConfidence: 0.17,
+      fontWeight: .semibold
+    )
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.7006, y: 0.6198, width: 0.2137, height: 0.0260),
+      text: "Copy apps and settings from one",
+      recognitionGroupID: 9,
+      appearance: regular,
+      alignment: .leading
+    )
+    let second = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.7006, y: 0.6550, width: 0.2122, height: 0.0210),
+      text: "profile or workspace into another",
+      recognitionGroupID: 9,
+      appearance: noisySemibold,
+      alignment: .leading
+    )
+
+    let result = OCRResult(lines: [first, second]).coalescingParagraphFragments()
+
+    #expect(result.lines.count == 1)
+    #expect(result.lines.first?.text == "Copy apps and settings from one profile or workspace into another")
+  }
+
+  @Test
+  func joinsIndentedContinuationAcrossVisionParagraphsInsideOneSurface() throws {
+    let appearance = OverlaySourceAppearance(
+      background: OverlayColor(red: 0.97, green: 0.97, blue: 0.97, alpha: 1),
+      foreground: OverlayColor(red: 0.12, green: 0.12, blue: 0.12, alpha: 1),
+      confidence: 0.7,
+      foregroundConfidence: 0.2,
+      fontWeight: .regular
+    )
+    let surface = OverlaySourceSurface(
+      box: CGRect(x: 0.04, y: 0.79, width: 0.20, height: 0.08),
+      confidence: 0.7
+    )
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.06, y: 0.819, width: 0.09, height: 0.017),
+      text: "鍵は私が",
+      horizontalGlyphScale: 0.017,
+      recognitionGroupID: 8,
+      appearance: appearance,
+      surface: surface
+    )
+    let second = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.078, y: 0.833, width: 0.13, height: 0.017),
+      text: "持っています。",
+      horizontalGlyphScale: 0.017,
+      recognitionGroupID: 9,
+      appearance: appearance,
+      surface: surface
+    )
+
+    let merged = try #require(OCRResult(lines: [first, second]).coalescingParagraphFragments().lines.first)
+
+    #expect(merged.text == "鍵は私が 持っています。")
+  }
+
+  @Test
+  func differentTypographyDoesNotMergeInsideTheSameSurface() {
+    let surface = OverlaySourceSurface(
+      box: CGRect(x: 0.38, y: 0.47, width: 0.25, height: 0.45),
+      confidence: 0.6
+    )
+    var titleAppearance = OverlaySourceAppearance(
+      background: OverlayColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 1),
+      foreground: .white,
+      confidence: 0.6,
+      foregroundConfidence: 0.8,
+      fontWeight: .semibold
+    )
+    titleAppearance.inkHeightScale = 0.04
+    let bodyAppearance = OverlaySourceAppearance(
+      background: titleAppearance.background,
+      foreground: OverlayColor(red: 0.57, green: 0.57, blue: 0.59, alpha: 1),
+      confidence: 0.6,
+      foregroundConfidence: 0.12,
+      fontWeight: .regular
+    )
+    let title = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.388, y: 0.613, width: 0.2, height: 0.044),
+      text: "Smart, or fully manual",
+      horizontalGlyphScale: 0.044,
+      recognitionGroupID: 1,
+      appearance: titleAppearance,
+      alignment: .leading,
+      surface: surface
+    )
+    let body = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.388, y: 0.675, width: 0.225, height: 0.031),
+      text: "Choose Conservative, Balanced, or",
+      horizontalGlyphScale: 0.031,
+      recognitionGroupID: 2,
+      appearance: bodyAppearance,
+      alignment: .leading,
+      surface: surface
+    )
+
+    #expect(OCRResult(lines: [title, body]).coalescingParagraphFragments().lines.count == 2)
+  }
+
+  @Test
+  func semiboldHeadingDoesNotMergeIntoLowContrastBodyFromTheSameVisionParagraph() {
+    let surface = OverlaySourceSurface(
+      box: CGRect(x: 0.03, y: 0.60, width: 0.46, height: 0.22),
+      confidence: 0.8
+    )
+    let headingAppearance = OverlaySourceAppearance(
+      background: .white,
+      foreground: OverlayColor(red: 0.10, green: 0.10, blue: 0.12, alpha: 1),
+      confidence: 0.7,
+      foregroundConfidence: 0.91,
+      fontWeight: .semibold
+    )
+    let bodyAppearance = OverlaySourceAppearance(
+      background: .white,
+      foreground: OverlayColor(red: 0.38, green: 0.38, blue: 0.42, alpha: 1),
+      confidence: 0.7,
+      foregroundConfidence: 0.08,
+      fontWeight: .regular
+    )
+    let heading = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.0625, y: 0.6395, width: 0.1192, height: 0.0303),
+      text: "Release notes",
+      horizontalGlyphScale: 0.0303,
+      recognitionGroupID: 12,
+      appearance: headingAppearance,
+      alignment: .leading,
+      surface: surface
+    )
+    let body = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.0610, y: 0.6977, width: 0.4041, height: 0.0305),
+      text: "Improved paragraph grouping, source restoration, and language-aware wrapping.",
+      horizontalGlyphScale: 0.0302,
+      recognitionGroupID: 13,
+      appearance: bodyAppearance,
+      alignment: .leading,
+      surface: surface
+    )
+
+    let result = OCRResult(lines: [heading, body]).coalescingParagraphFragments()
+
+    #expect(result.lines == [heading, body])
+  }
+
+  @Test
+  func lineGeometryOverridesIncorrectCenteredParagraphAlignment() throws {
+    let rows = [
+      OCRResult.Line(
+        boundingBoxNormalized: CGRect(x: 0.695, y: 0.675, width: 0.202, height: 0.024),
+        text: "Pause from the menu bar for 15",
+        recognitionGroupID: 9,
+        alignment: .center
+      ),
+      OCRResult.Line(
+        boundingBoxNormalized: CGRect(x: 0.695, y: 0.709, width: 0.229, height: 0.035),
+        text: "minutes to four hours, or choose an",
+        recognitionGroupID: 9,
+        alignment: .center
+      ),
+      OCRResult.Line(
+        boundingBoxNormalized: CGRect(x: 0.696, y: 0.748, width: 0.194, height: 0.029),
+        text: "exact resume time in Settings.",
+        recognitionGroupID: 9,
+        alignment: .center
+      ),
+    ]
+
+    let merged = try #require(OCRResult(lines: rows).coalescingParagraphFragments().lines.first)
+
+    #expect(merged.alignment == .leading)
+  }
+
+  @Test
+  func centeredVisionParagraphStillJoinsShortLeadingAlignedFinalRow() {
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.5307, y: 0.55, width: 0.4334, height: 0.0738),
+      text: "手でにぎったり、木のぼうの先 にくくりつけたりして、木材を",
+      rowCount: 2,
+      recognitionGroupID: 6,
+      alignment: .center
+    )
+    let final = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.5305, y: 0.6139, width: 0.3319, height: 0.0352),
+      text: "加工するのに使われた。",
+      recognitionGroupID: 6,
+      alignment: .center
+    )
+
+    let result = OCRResult(lines: [first, final]).coalescingParagraphFragments()
+
+    #expect(result.lines.count == 1)
+    #expect(result.lines[0].rowCount == 3)
+  }
+
+  @Test
+  func overlappingVisionParagraphsInsideOneBubbleStillCoalesce() {
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.0903, y: 0.44436, width: 0.3288, height: 0.0266),
+      text: "今日はいい天気ですね。",
+      recognitionGroupID: 1
+    )
+    let second = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.0906, y: 0.46875, width: 0.3406, height: 0.0479),
+      text: "次の週末もここで会いましょう。",
+      rowCount: 2,
+      recognitionGroupID: 2
+    )
+
+    let result = OCRResult(lines: [first, second]).coalescingParagraphFragments()
+
+    #expect(result.lines.count == 1)
+    #expect(result.lines[0].rowCount == 3)
+  }
+
+  @Test
+  func removesNestedWordObservationAlreadyCoveredByControlRow() {
+    let row = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.20, y: 0.70, width: 0.50, height: 0.06),
+      text: "| Teams | Apps | Users | Others"
+    )
+    let nested = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.36, y: 0.71, width: 0.06, height: 0.04),
+      text: "Apps"
+    )
+    let separate = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.05, y: 0.70, width: 0.05, height: 0.04),
+      text: "All"
+    )
+
+    let result = OCRResult(lines: [row, nested, separate]).removingNestedDuplicates()
+
+    #expect(result.lines == [row, separate])
+  }
+
+  @Test
+  func supplementalRecognitionAddsOnlyRowsMissingFromDocumentRecognition() {
+    let title = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.14, y: 0.13, width: 0.74, height: 0.07),
+      text: "Switch your whole setup at once."
+    )
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.70, y: 0.62, width: 0.21, height: 0.026),
+      text: "Copy apps and settings from one",
+      recognitionGroupID: 7
+    )
+    let final = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.70, y: 0.68, width: 0.22, height: 0.028),
+      text: "with a reviewable diff. Keep or skip",
+      recognitionGroupID: 8
+    )
+    var duplicatedFirst = first
+    duplicatedFirst.boundingBoxNormalized = CGRect(x: 0.701, y: 0.621, width: 0.209, height: 0.025)
+    duplicatedFirst.recognitionGroupID = nil
+    let missing = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.70, y: 0.655, width: 0.21, height: 0.021),
+      text: "profile or workspace into another"
+    )
+
+    let merged = OCRSupplementalMerger.addingUncovered(
+      [title, duplicatedFirst, missing],
+      to: [first, final]
+    )
+
+    #expect(merged.map(\.text) == [
+      "Switch your whole setup at once.",
+      "Copy apps and settings from one",
+      "profile or workspace into another",
+      "with a reviewable diff. Keep or skip",
+    ])
+  }
+
+  @Test
+  func keepsIdenticalLabelsWhenTheirBoxesDoNotOverlap() {
+    let first = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1, y: 0.1, width: 0.2, height: 0.05),
+      text: "Bypass list"
+    )
+    let second = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1, y: 0.4, width: 0.2, height: 0.05),
+      text: "Bypass list"
+    )
+
+    #expect(OCRResult(lines: [first, second]).removingNestedDuplicates().lines == [first, second])
+  }
+
+  @Test(arguments: [
+    SeparationCase(
+      name: "horizontal gap is too large",
+      lhs: verticalLine(x: 0.2, y: 0.2, width: 0.03, height: 0.2, text: "甲"),
+      rhs: verticalLine(x: 0.24, y: 0.2, width: 0.03, height: 0.2, text: "乙")
+    ),
+    SeparationCase(
+      name: "vertical overlap is too small",
+      lhs: verticalLine(x: 0.2, y: 0.1, width: 0.03, height: 0.1, text: "甲"),
+      rhs: verticalLine(x: 0.168, y: 0.18, width: 0.03, height: 0.1, text: "乙")
+    ),
+    SeparationCase(
+      name: "same column is not a neighboring column",
+      lhs: verticalLine(x: 0.2, y: 0.1, width: 0.03, height: 0.2, text: "甲"),
+      rhs: verticalLine(x: 0.202, y: 0.1, width: 0.03, height: 0.2, text: "乙")
+    ),
+    SeparationCase(
+      name: "different character scales stay separate",
+      lhs: verticalLine(x: 0.2, y: 0.1, width: 0.03, height: 0.2, text: "甲", scale: 0.03),
+      rhs: verticalLine(x: 0.168, y: 0.1, width: 0.03, height: 0.2, text: "乙", scale: 0.012)
+    ),
+    SeparationCase(
+      name: "horizontal paragraph stays separate",
+      lhs: verticalLine(x: 0.2, y: 0.1, width: 0.03, height: 0.2, text: "甲"),
+      rhs: OCRResult.Line(
+        boundingBoxNormalized: CGRect(x: 0.168, y: 0.1, width: 0.03, height: 0.2),
+        text: "caption"
+      )
+    ),
+  ])
+  func keepsUnrelatedParagraphsSeparate(_ testCase: SeparationCase) {
+    let result = OCRResult(lines: [testCase.lhs, testCase.rhs]).coalescingParagraphFragments()
+    #expect(result.lines.count == 2)
+  }
+
+  @Test
+  func preservesComponentPositionInVisionOrder() {
+    let heading = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1, y: 0.05, width: 0.5, height: 0.05),
+      text: "heading"
+    )
+    let right = verticalLine(x: 0.5, y: 0.2, width: 0.03, height: 0.2, text: "本当で")
+    let left = verticalLine(x: 0.468, y: 0.2, width: 0.03, height: 0.2, text: "すか")
+    let footer = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1, y: 0.8, width: 0.5, height: 0.05),
+      text: "footer"
+    )
+
+    let result = OCRResult(lines: [heading, right, left, footer]).coalescingParagraphFragments()
+    #expect(result.lines.map(\.text) == ["heading", "本当ですか", "footer"])
+  }
+
+  // MARK: Private
+
+  private static func verticalLine(
+    x: CGFloat,
+    y: CGFloat,
+    width: CGFloat,
+    height: CGFloat,
+    text: String,
+    scale: CGFloat = 0.03
+  ) -> OCRResult.Line {
+    OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: x, y: y, width: width, height: height),
+      text: text,
+      isVerticalBlock: true,
+      verticalCharScale: scale
+    )
+  }
+
+  private func verticalLine(
+    x: CGFloat,
+    y: CGFloat,
+    width: CGFloat,
+    height: CGFloat,
+    text: String,
+    scale: CGFloat = 0.03
+  ) -> OCRResult.Line {
+    Self.verticalLine(x: x, y: y, width: width, height: height, text: text, scale: scale)
+  }
+}

--- a/Tests/OCRResultTests.swift
+++ b/Tests/OCRResultTests.swift
@@ -230,6 +230,60 @@ struct OCRResultTests {
   }
 
   @Test
+  func keepsAdjacentBadgePairsAsIndependentControls() {
+    let gray = OverlaySourceAppearance(
+      background: OverlayColor(red: 0.35, green: 0.35, blue: 0.35, alpha: 1),
+      foreground: .white,
+      confidence: 0.7
+    )
+    let blue = OverlaySourceAppearance(
+      background: OverlayColor(red: 0.13, green: 0.51, blue: 0.76, alpha: 1),
+      foreground: .white,
+      confidence: 0.7
+    )
+    let green = OverlaySourceAppearance(
+      background: OverlayColor(red: 0.43, green: 0.67, blue: 0.15, alpha: 1),
+      foreground: .white,
+      confidence: 0.7
+    )
+    func badge(
+      _ text: String,
+      x: CGFloat,
+      width: CGFloat,
+      appearance: OverlaySourceAppearance,
+      detectsSurface: Bool = false
+    ) -> OCRResult.Line {
+      let box = CGRect(x: x, y: 0.345, width: width, height: 0.045)
+      return OCRResult.Line(
+        boundingBoxNormalized: box,
+        text: text,
+        recognitionGroupID: 1,
+        appearance: appearance,
+        surface: detectsSurface
+          ? OverlaySourceSurface(
+            box: box.insetBy(dx: -0.003, dy: -0.008),
+            confidence: 0.8
+          )
+          : nil
+      )
+    }
+    let badges = [
+      badge("release", x: 0.0275, width: 0.0465, appearance: gray, detectsSurface: true),
+      badge("v1.12.0", x: 0.0807, width: 0.0519, appearance: blue),
+      badge("downloads", x: 0.1488, width: 0.0692, appearance: gray),
+      badge("233", x: 0.2249, width: 0.0254, appearance: green),
+      badge("macOS", x: 0.2676, width: 0.0450, appearance: gray, detectsSurface: true),
+      badge("14+", x: 0.3218, width: 0.0277, appearance: blue),
+      badge("License", x: 0.3655, width: 0.0487, appearance: gray, detectsSurface: true),
+      badge("AGPL 3.0-only", x: 0.4164, width: 0.0969, appearance: blue),
+    ]
+
+    let result = OCRResult(lines: badges).coalescingParagraphFragments()
+
+    #expect(result.lines == badges)
+  }
+
+  @Test
   func keepsAdjacentMultilineCardBodiesSeparate() {
     let left = OCRResult.Line(
       boundingBoxNormalized: CGRect(x: 0.10, y: 0.40, width: 0.30, height: 0.15),

--- a/Tests/OCRResultTests.swift
+++ b/Tests/OCRResultTests.swift
@@ -365,6 +365,7 @@ struct OCRResultTests {
 
     #expect(result.lines.count == 1)
     #expect(merged.rowCount == 3)
+    #expect(abs(merged.horizontalLineAdvanceScale - 0.0377) < 0.001)
     #expect(merged.text == "Open the popover or fire any action from a global shortcut, even with no window open.")
   }
 
@@ -493,6 +494,53 @@ struct OCRResultTests {
     let result = OCRResult(lines: [first, second]).coalescingParagraphFragments()
 
     #expect(result.lines == [first, second])
+  }
+
+  @Test
+  func listItemsStaySeparateWhileIndentedContinuationRemainsAttached() throws {
+    let appearance = OverlaySourceAppearance(
+      background: OverlayColor(red: 0.04, green: 0.06, blue: 0.08, alpha: 1),
+      foreground: OverlayColor(red: 0.91, green: 0.94, blue: 0.98, alpha: 1),
+      confidence: 0.8,
+      foregroundConfidence: 0.8,
+      fontWeight: .regular
+    )
+    let item = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.04215, y: 0.71852, width: 0.92006, height: 0.03252),
+      text: "• Per-display workspaces: Pin a workspace to a display.",
+      horizontalGlyphScale: 0.03229,
+      recognitionGroupID: 8,
+      appearance: appearance,
+      alignment: .leading
+    )
+    let continuation = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.06250, y: 0.76771, width: 0.88663, height: 0.07708),
+      text: "Each display keeps its own active and recent workspace across relaunches.",
+      rowCount: 2,
+      horizontalGlyphScale: 0.03490,
+      recognitionGroupID: 9,
+      appearance: appearance,
+      alignment: .leading
+    )
+    let nextItem = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.04167, y: 0.86525, width: 0.86667, height: 0.04255),
+      text: "• Cross-display control: Jump focus between displays.",
+      horizontalGlyphScale: 0.04167,
+      recognitionGroupID: 10,
+      appearance: appearance,
+      alignment: .leading
+    )
+
+    let result = OCRResult(lines: [item, continuation, nextItem])
+      .coalescingParagraphFragments()
+
+    #expect(result.lines.count == 2)
+    let mergedItem = try #require(result.lines.first)
+    #expect(mergedItem
+      .text ==
+      "• Per-display workspaces: Pin a workspace to a display. Each display keeps its own active and recent workspace across relaunches.")
+    #expect(mergedItem.rowCount == 3)
+    #expect(result.lines.last == nextItem)
   }
 
   @Test

--- a/Tests/OCRTextTokenizationTests.swift
+++ b/Tests/OCRTextTokenizationTests.swift
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Testing
+@testable import SwiftyCrow
+
+@Suite("OCR text tokenization")
+struct OCRTextTokenizationTests {
+
+  @Test
+  func separatesEnclosingPunctuationFromCJKTitle() {
+    let text = "（旧石器時代の道具＝打製石器）"
+    let tokens = OCRTextTokenization.ranges(in: text).map { String(text[$0]) }
+
+    #expect(tokens == ["（", "旧石器時代の道具", "＝", "打製石器", "）"])
+  }
+
+  @Test
+  func keepsLatinWordsAndTechnicalPunctuationIndependent() {
+    let text = "Agent Skills #179"
+    let tokens = OCRTextTokenization.ranges(in: text).map { String(text[$0]) }
+
+    #expect(tokens == ["Agent", "Skills", "#", "179"])
+  }
+}

--- a/Tests/OverlayAttributedStyleTests.swift
+++ b/Tests/OverlayAttributedStyleTests.swift
@@ -502,6 +502,54 @@ struct OverlayAttributedStyleTests {
     #expect(OverlayTranslationPolicy.preservesSource(at: 0, in: [value]) == expectedPreservation)
   }
 
+  @Test(arguments: [
+    ("AGPL 3.0-only", true),
+    ("macOS 14+", true),
+    ("Chapter 2", false),
+  ])
+  func versionedTechnicalMetadataKeepsItsExactSourceValue(
+    _ text: String,
+    expectedPreservation: Bool
+  ) {
+    let value = source(text: text, box: CGRect(x: 0.1, y: 0.2, width: 0.15, height: 0.04))
+
+    #expect(OverlayTranslationPolicy.preservesSource(at: 0, in: [value]) == expectedPreservation)
+  }
+
+  @Test
+  func compactBadgeLabelsUseTheirTrailingValuesAsTranslationContext() {
+    let sources = [
+      source(text: "release", box: CGRect(x: 0.0275, y: 0.345, width: 0.0465, height: 0.045)),
+      source(text: "v1.12.0", box: CGRect(x: 0.0807, y: 0.345, width: 0.0519, height: 0.045)),
+      source(text: "downloads", box: CGRect(x: 0.1488, y: 0.345, width: 0.0692, height: 0.045)),
+      source(text: "233", box: CGRect(x: 0.2249, y: 0.345, width: 0.0254, height: 0.045)),
+      source(text: "macOS", box: CGRect(x: 0.2676, y: 0.345, width: 0.0450, height: 0.045)),
+      source(text: "14+", box: CGRect(x: 0.3218, y: 0.345, width: 0.0277, height: 0.045)),
+      source(text: "License", box: CGRect(x: 0.3655, y: 0.345, width: 0.0487, height: 0.045)),
+      source(text: "AGPL 3.0-only", box: CGRect(x: 0.4164, y: 0.345, width: 0.0969, height: 0.045)),
+    ]
+
+    #expect(OverlayTranslationPolicy.trailingContext(at: 0, in: sources) == "v1.12.0")
+    #expect(OverlayTranslationPolicy.trailingContext(at: 2, in: sources) == "233")
+    #expect(OverlayTranslationPolicy.trailingContext(at: 4, in: sources) == "14+")
+    #expect(OverlayTranslationPolicy.trailingContext(at: 6, in: sources) == "AGPL 3.0-only")
+    #expect(OverlayTranslationPolicy.trailingContext(at: 1, in: sources) == nil)
+    #expect(OverlayTranslationPolicy.trailingContext(at: 7, in: sources) == nil)
+  }
+
+  @Test
+  func contextualTranslationKeepsOnlyTheTranslatedLabel() {
+    #expect(
+      TranslationTextStructure.label(fromContextualTranslation: "라이선스: AGPL 3.0 전용")
+        == "라이선스"
+    )
+    #expect(
+      TranslationTextStructure.label(fromContextualTranslation: "릴리즈：v1.12.0")
+        == "릴리즈"
+    )
+    #expect(TranslationTextStructure.label(fromContextualTranslation: "구분자 없음") == nil)
+  }
+
   @Test
   func unmatchedStyleDoesNotReplaceThePlainTranslation() throws {
     var source = AttributedString("狼煙")

--- a/Tests/OverlayAttributedStyleTests.swift
+++ b/Tests/OverlayAttributedStyleTests.swift
@@ -1,0 +1,456 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Foundation
+import Testing
+@testable import SwiftyCrow
+
+@Suite("Attributed overlay styles")
+struct OverlayAttributedStyleTests {
+
+  // MARK: Internal
+
+  @Test
+  func appleAlignedAttributesMapSourceStylesOntoTranslatedWords() throws {
+    let sourceText = "Proposal #179. Agent Skills handles reusable capabilities."
+    let issueAppearance = OverlaySourceAppearance(
+      background: .black,
+      foreground: OverlayColor(red: 0.55, green: 0.58, blue: 0.63, alpha: 1),
+      confidence: 1,
+      foregroundConfidence: 1,
+      fontWeight: .regular
+    )
+    let linkAppearance = OverlaySourceAppearance(
+      background: .black,
+      foreground: OverlayColor(red: 0.18, green: 0.52, blue: 0.95, alpha: 1),
+      confidence: 1,
+      foregroundConfidence: 1,
+      fontWeight: .medium,
+      isUnderlined: true
+    )
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1, y: 0.2, width: 0.8, height: 0.1),
+      text: sourceText,
+      styleRuns: [
+        OverlaySourceStyleRun(
+          range: try range(of: "#179", in: sourceText),
+          box: CGRect(x: 0.2, y: 0.2, width: 0.08, height: 0.1),
+          appearance: issueAppearance
+        ),
+        OverlaySourceStyleRun(
+          range: try range(of: "Agent Skills", in: sourceText),
+          box: CGRect(x: 0.35, y: 0.2, width: 0.18, height: 0.1),
+          appearance: linkAppearance
+        ),
+      ]
+    )
+    var line = OverlayLine(
+      id: UUID(),
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "en-US")
+      ),
+      initialContent: .pending
+    )
+
+    let request = try #require(line.source.attributedTextForTranslation())
+    #expect(request.runs.compactMap(\.link).count == 2)
+
+    let targetText = "제안 #179에 관한 내용입니다. 에이전트 스킬은 재사용할 수 있습니다."
+    var target = AttributedString(targetText)
+    try tag("#179에", with: "swiftycrow-style://run/0", in: &target)
+    try tag("에이전트 스킬은", with: "swiftycrow-style://run/1", in: &target)
+    line.showTranslation(
+      targetText,
+      attributedText: target,
+      language: Locale.Language(identifier: "ko-KR")
+    )
+
+    let runs = line.displayedStyleRuns
+    #expect(runs.count == 2)
+    #expect((targetText as NSString).substring(with: runs[0].range) == "#179에")
+    #expect(runs[0].appearance.foreground == issueAppearance.foreground)
+    #expect((targetText as NSString).substring(with: runs[1].range) == "에이전트 스킬은")
+    #expect(runs[1].appearance.foreground == linkAppearance.foreground)
+    #expect(runs[1].appearance.isUnderlined)
+  }
+
+  @Test
+  func literalStyleMapperAlignsTechnicalTokensWithoutRetranslatingTheLine() throws {
+    var source = AttributedString("Proposal #179. Agent Skills handles reusable capabilities.")
+    try tag("#179", with: "swiftycrow-style://run/0", in: &source)
+    try tag("Agent Skills", with: "swiftycrow-style://run/1", in: &source)
+
+    let alignment = TranslationStyleMapper.align(
+      source: source,
+      target: "제안 #179에 관한 내용입니다. Agent Skills는 재사용할 수 있습니다."
+    )
+
+    #expect(alignment.unmatched.isEmpty)
+    #expect(alignment.target.runs.compactMap(\.link).count == 2)
+  }
+
+  @Test
+  func adjacentCodeFragmentsMoveAsWholeVisualTokens() throws {
+    let sourceText = "Runs on macOS 26 with build 2.10.0. Done."
+    let base = OverlaySourceAppearance(
+      background: .white,
+      foreground: OverlayColor(red: 0.42, green: 0.44, blue: 0.48, alpha: 1),
+      confidence: 1,
+      foregroundConfidence: 1,
+      fontWeight: .regular
+    )
+    let code = OverlaySourceAppearance(
+      background: OverlayColor(red: 0.91, green: 0.93, blue: 0.96, alpha: 1),
+      foreground: OverlayColor(red: 0.22, green: 0.24, blue: 0.28, alpha: 1),
+      confidence: 1,
+      foregroundConfidence: 1,
+      fontWeight: .regular,
+      fontDesign: .monospaced
+    )
+    // The final period is intentionally given the chip appearance to model
+    // Vision sampling bleed at the edge of `<code>2.10.0</code>.`.
+    let fragments = ["macOS", "26", "2", "10", "0", "."]
+    var cursor = 0
+    let styleRuns = fragments.compactMap { fragment -> OverlaySourceStyleRun? in
+      let searchRange = NSRange(location: cursor, length: (sourceText as NSString).length - cursor)
+      let range = (sourceText as NSString).range(of: fragment, range: searchRange)
+      guard range.location != NSNotFound else { return nil }
+      cursor = NSMaxRange(range)
+      return OverlaySourceStyleRun(range: range, box: .zero, appearance: code)
+    }
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1, y: 0.2, width: 0.8, height: 0.1),
+      text: sourceText,
+      appearance: base,
+      styleRuns: styleRuns
+    )
+    var line = OverlayLine(
+      id: UUID(),
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "en-US")
+      ),
+      initialContent: .pending
+    )
+
+    let attributedSource = try #require(line.source.attributedTextForTranslation())
+    let sourceSpans: [String] = attributedSource.runs.compactMap { run in
+      guard run.link != nil else { return nil }
+      return String(attributedSource.characters[run.range])
+    }
+    #expect(sourceSpans == ["macOS 26", "2.10.0"])
+
+    let target = "빌드 2.10.0으로 macOS 26에서 실행됩니다."
+    let alignment = TranslationStyleMapper.align(source: attributedSource, target: target)
+    #expect(alignment.unmatched.isEmpty)
+    line.showTranslation(
+      target,
+      attributedText: alignment.target,
+      language: Locale.Language(identifier: "ko-KR")
+    )
+    let targetSpans = line.displayedStyleRuns.map {
+      (target as NSString).substring(with: $0.range)
+    }
+    #expect(targetSpans == ["2.10.0", "macOS 26"])
+  }
+
+  @Test
+  func styleSpansNeverCoalesceAcrossARecoveredHardBreak() throws {
+    let sourceText = "Two checks are pending.\nThe orange surface remains visible."
+    let base = OverlaySourceAppearance(
+      background: OverlayColor(red: 1, green: 0.94, blue: 0.84, alpha: 1),
+      foreground: OverlayColor(red: 0.65, green: 0.40, blue: 0.02, alpha: 1),
+      confidence: 1,
+      foregroundConfidence: 0.2,
+      fontWeight: .regular
+    )
+    var emphasized = base
+    emphasized.fontWeight = .bold
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1, y: 0.2, width: 0.6, height: 0.1),
+      text: sourceText,
+      appearance: base,
+      styleRuns: [
+        OverlaySourceStyleRun(
+          range: try range(of: "Two checks are pending.", in: sourceText),
+          box: CGRect(x: 0.1, y: 0.2, width: 0.25, height: 0.04),
+          appearance: emphasized
+        ),
+        OverlaySourceStyleRun(
+          range: try range(of: "The", in: sourceText),
+          box: CGRect(x: 0.1, y: 0.25, width: 0.04, height: 0.04),
+          appearance: emphasized
+        ),
+      ]
+    )
+    let source = OverlayLine.Source(
+      recognized: recognized,
+      language: Locale.Language(identifier: "en-US")
+    )
+
+    let attributed = try #require(source.attributedTextForTranslation())
+    let spans = attributed.runs.compactMap { run in
+      run.link.map { _ in String(attributed.characters[run.range]) }
+    }
+
+    #expect(spans == ["Two checks are pending.", "The"])
+  }
+
+  @Test
+  func styleMapperUsesShortTranslatedAlternativeWhenLiteralChanges() throws {
+    var source = AttributedString("rameshsunkara opened this issue")
+    let link = URL(string: "swiftycrow-style://run/0")!
+    let range = try #require(source.range(of: "rameshsunkara"))
+    source[range].link = link
+
+    let alignment = TranslationStyleMapper.align(
+      source: source,
+      target: "라마쉬순카라가 이 이슈를 열었습니다.",
+      alternatives: [link: "라마쉬순카라"]
+    )
+
+    #expect(alignment.unmatched.isEmpty)
+    #expect(alignment.target.runs.compactMap(\.link) == [link])
+  }
+
+  @Test
+  func coloredEnclosingPunctuationKeepsItsForeground() throws {
+    let sourceText = "（旧石器）"
+    let base = OverlaySourceAppearance(
+      background: .white,
+      foreground: .black,
+      confidence: 1,
+      foregroundConfidence: 1,
+      fontWeight: .semibold
+    )
+    let orange = OverlaySourceAppearance(
+      background: .white,
+      foreground: OverlayColor(red: 0.86, green: 0.42, blue: 0.25, alpha: 1),
+      confidence: 1,
+      foregroundConfidence: 1,
+      fontWeight: .regular
+    )
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.2, y: 0.1, width: 0.6, height: 0.08),
+      text: sourceText,
+      appearance: base,
+      styleRuns: [
+        OverlaySourceStyleRun(
+          range: try range(of: "（", in: sourceText),
+          box: CGRect(x: 0.2, y: 0.1, width: 0.04, height: 0.08),
+          appearance: orange
+        ),
+        OverlaySourceStyleRun(
+          range: try range(of: "）", in: sourceText),
+          box: CGRect(x: 0.76, y: 0.1, width: 0.04, height: 0.08),
+          appearance: orange
+        ),
+      ]
+    )
+    let source = OverlayLine.Source(
+      recognized: recognized,
+      language: Locale.Language(identifier: "ja-JP")
+    )
+    let attributed = try #require(source.attributedTextForTranslation())
+    let alignment = TranslationStyleMapper.align(source: attributed, target: "(구석기)")
+
+    #expect(attributed.runs.compactMap(\.link).count == 2)
+    #expect(alignment.unmatched.isEmpty)
+    #expect(alignment.target.runs.compactMap(\.link).count == 2)
+  }
+
+  @Test
+  func oneRecognizedBracketMirrorsItsStyleToTheTranslatedPair() throws {
+    let sourceText = "旧石器）"
+    let orange = OverlaySourceAppearance(
+      background: .white,
+      foreground: OverlayColor(red: 0.86, green: 0.42, blue: 0.25, alpha: 1),
+      confidence: 1,
+      foregroundConfidence: 1,
+      fontWeight: .regular
+    )
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.2, y: 0.1, width: 0.6, height: 0.08),
+      text: sourceText,
+      appearance: OverlaySourceAppearance(
+        background: .white,
+        foreground: .black,
+        confidence: 1,
+        foregroundConfidence: 1,
+        fontWeight: .semibold
+      ),
+      styleRuns: [
+        OverlaySourceStyleRun(
+          range: try range(of: "）", in: sourceText),
+          box: CGRect(x: 0.76, y: 0.1, width: 0.04, height: 0.08),
+          appearance: orange
+        )
+      ]
+    )
+    var line = OverlayLine(
+      id: UUID(),
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "ja-JP")
+      ),
+      initialContent: .pending
+    )
+    let source = try #require(line.source.attributedTextForTranslation())
+    let alignment = TranslationStyleMapper.align(source: source, target: "(구석기)")
+    line.showTranslation(
+      "(구석기)",
+      attributedText: alignment.target,
+      language: Locale.Language(identifier: "ko-KR")
+    )
+
+    #expect(line.displayedStyleRuns.count == 2)
+    #expect(line.displayedStyleRuns.allSatisfy { $0.appearance.foreground == orange.foreground })
+  }
+
+  @Test
+  func monospacedCodeOnlyLineKeepsOriginalPixels() {
+    var appearance = OverlaySourceAppearance.fallback
+    appearance.fontDesign = .monospaced
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.2, y: 0.2, width: 0.3, height: 0.05),
+      text: ".github/instructions/*.instructions.md",
+      appearance: appearance
+    )
+    let source = OverlayLine.Source(
+      recognized: recognized,
+      language: Locale.Language(identifier: "en-US")
+    )
+    var spacedRecognition = recognized
+    spacedRecognition.text = ". github/instructions/*.instructions.md"
+    let spaced = OverlayLine.Source(
+      recognized: spacedRecognition,
+      language: Locale.Language(identifier: "en-US")
+    )
+
+    #expect(source.isProtectedLiteral)
+    #expect(spaced.isProtectedLiteral)
+  }
+
+  @Test
+  func compactTableMetadataBesideCodeKeepsOriginalPixels() {
+    var codeAppearance = OverlaySourceAppearance.fallback
+    codeAppearance.fontDesign = .monospaced
+    let label = source(text: "GitHub Copilot", box: CGRect(x: 0.05, y: 0.4, width: 0.15, height: 0.04))
+    let code = source(
+      text: ".github/instructions/*.instructions.md",
+      box: CGRect(x: 0.25, y: 0.4, width: 0.35, height: 0.04),
+      appearance: codeAppearance
+    )
+    let prose = source(
+      text: "This explanatory sentence should still be translated for the reader.",
+      box: CGRect(x: 0.05, y: 0.5, width: 0.7, height: 0.04)
+    )
+    let sources = [label, code, prose]
+
+    #expect(OverlayTranslationPolicy.preservesSource(at: 0, in: sources))
+    #expect(OverlayTranslationPolicy.preservesSource(at: 1, in: sources))
+    #expect(!OverlayTranslationPolicy.preservesSource(at: 2, in: sources))
+  }
+
+  @Test
+  func visualRepositoryMetadataKeepsOriginalPixels() {
+    let language = source(
+      text: "• Swift",
+      box: CGRect(x: 0.05, y: 0.8, width: 0.08, height: 0.04)
+    )
+    let count = source(
+      text: "& 572",
+      box: CGRect(x: 0.14, y: 0.8, width: 0.05, height: 0.04)
+    )
+    let prose = source(
+      text: "Chapter 2",
+      box: CGRect(x: 0.05, y: 0.9, width: 0.1, height: 0.04)
+    )
+    let sources = [language, count, prose]
+
+    #expect(OverlayTranslationPolicy.preservesSource(at: 0, in: sources))
+    #expect(OverlayTranslationPolicy.preservesSource(at: 1, in: sources))
+    #expect(!OverlayTranslationPolicy.preservesSource(at: 2, in: sources))
+  }
+
+  @Test(arguments: [
+    ("• Keep each bullet on a readable line.", false),
+    ("● All systems operational", false),
+    ("• Swift", true),
+    ("● Swift 94 11", true),
+  ])
+  func bulletPreservationDistinguishesProseFromCompactMetadata(
+    _ text: String,
+    expectedPreservation: Bool
+  ) {
+    let value = source(text: text, box: CGRect(x: 0.1, y: 0.2, width: 0.4, height: 0.04))
+
+    #expect(OverlayTranslationPolicy.preservesSource(at: 0, in: [value]) == expectedPreservation)
+  }
+
+  @Test
+  func unmatchedStyleDoesNotReplaceThePlainTranslation() throws {
+    var source = AttributedString("狼煙")
+    try tag("狼煙", with: "swiftycrow-style://run/0", in: &source)
+
+    let alignment = TranslationStyleMapper.align(
+      source: source,
+      target: "봉화입니다."
+    )
+
+    #expect(String(alignment.target.characters) == "봉화입니다.")
+    #expect(alignment.unmatched.map(\.text) == ["狼煙"])
+  }
+
+  @Test
+  func translationCannotTurnOneRecoveredLineBreakIntoABlankParagraph() {
+    let normalized = TranslationTextStructure.matchingSourceBreaks(
+      "두 개의 수표가 대기 중입니다.\n\n오렌지색 표면은 유지됩니다.",
+      source: "Two checks are pending.\nThe orange surface remains visible."
+    )
+
+    #expect(normalized == "두 개의 수표가 대기 중입니다.\n오렌지색 표면은 유지됩니다.")
+  }
+
+  @Test
+  func intentionalSourceParagraphSpacingIsRetained() {
+    let normalized = TranslationTextStructure.matchingSourceBreaks(
+      "첫 문단입니다.\n\n\n둘째 문단입니다.",
+      source: "First paragraph.\n\nSecond paragraph."
+    )
+
+    #expect(normalized == "첫 문단입니다.\n\n둘째 문단입니다.")
+  }
+
+  // MARK: Private
+
+  private func range(of substring: String, in text: String) throws -> NSRange {
+    let range = (text as NSString).range(of: substring)
+    return try #require(range.location != NSNotFound ? range : nil)
+  }
+
+  private func tag(
+    _ substring: String,
+    with link: String,
+    in attributed: inout AttributedString
+  ) throws {
+    let range = try #require(attributed.range(of: substring))
+    attributed[range].link = URL(string: link)
+  }
+
+  private func source(
+    text: String,
+    box: CGRect,
+    appearance: OverlaySourceAppearance = .fallback
+  ) -> OverlayLine.Source {
+    OverlayLine.Source(
+      recognized: OCRResult.Line(
+        boundingBoxNormalized: box,
+        text: text,
+        appearance: appearance
+      ),
+      language: Locale.Language(identifier: "en-US")
+    )
+  }
+}

--- a/Tests/OverlayAttributedStyleTests.swift
+++ b/Tests/OverlayAttributedStyleTests.swift
@@ -198,6 +198,119 @@ struct OverlayAttributedStyleTests {
   }
 
   @Test
+  func leadingEmphasisUsesTheTrailingBodyAsItsBaseStyle() throws {
+    let text = "Apple Translation supplies the"
+    let regular = OverlaySourceAppearance(
+      background: .white,
+      foreground: .black,
+      confidence: 1,
+      foregroundConfidence: 1,
+      fontWeight: .regular
+    )
+    var medium = regular
+    medium.fontWeight = .medium
+    var semibold = regular
+    semibold.fontWeight = .semibold
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1, y: 0.2, width: 0.8, height: 0.08),
+      text: text,
+      appearance: medium,
+      styleRuns: [
+        OverlaySourceStyleRun(
+          range: try range(of: "Apple", in: text),
+          box: CGRect(x: 0.1, y: 0.2, width: 0.12, height: 0.08),
+          appearance: semibold
+        ),
+        OverlaySourceStyleRun(
+          range: try range(of: "Translation", in: text),
+          box: CGRect(x: 0.23, y: 0.2, width: 0.24, height: 0.08),
+          appearance: medium
+        ),
+        OverlaySourceStyleRun(
+          range: try range(of: "supplies", in: text),
+          box: CGRect(x: 0.48, y: 0.2, width: 0.18, height: 0.08),
+          appearance: regular
+        ),
+        OverlaySourceStyleRun(
+          range: try range(of: "the", in: text),
+          box: CGRect(x: 0.67, y: 0.2, width: 0.08, height: 0.08),
+          appearance: regular
+        ),
+      ]
+    )
+    let source = OverlayLine.Source(
+      recognized: recognized,
+      language: Locale.Language(identifier: "en-US")
+    )
+
+    let attributed = try #require(source.attributedTextForTranslation())
+    let spans = attributed.runs.compactMap { run in
+      run.link.map { _ in String(attributed.characters[run.range]) }
+    }
+
+    #expect(source.appearance.fontWeight == .regular)
+    #expect(spans == ["Apple Translation"])
+  }
+
+  @Test
+  func linkWordsCoalesceAcrossUnderlineSamplingJitter() throws {
+    let text = "Open the translation report, compare"
+    let base = OverlaySourceAppearance(
+      background: .black,
+      foreground: .white,
+      confidence: 1,
+      foregroundConfidence: 1,
+      fontWeight: .medium
+    )
+    let blue = OverlayColor(red: 0.30, green: 0.57, blue: 1, alpha: 1)
+    var firstWord = base
+    firstWord.foreground = blue
+    firstWord.fontWeight = .bold
+    firstWord.isUnderlined = true
+    var secondWord = firstWord
+    secondWord.fontWeight = .semibold
+    secondWord.isUnderlined = false
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1, y: 0.2, width: 0.8, height: 0.08),
+      text: text,
+      appearance: base,
+      styleRuns: [
+        OverlaySourceStyleRun(
+          range: try range(of: "translation", in: text),
+          box: CGRect(x: 0.28, y: 0.2, width: 0.24, height: 0.08),
+          appearance: firstWord
+        ),
+        OverlaySourceStyleRun(
+          range: try range(of: "report", in: text),
+          box: CGRect(x: 0.53, y: 0.2, width: 0.14, height: 0.08),
+          appearance: secondWord
+        ),
+      ]
+    )
+    let source = OverlayLine.Source(
+      recognized: recognized,
+      language: Locale.Language(identifier: "en-US")
+    )
+    let attributed = try #require(source.attributedTextForTranslation())
+    let linkedRuns = attributed.runs.filter { $0.link != nil }
+    let linked = try #require(linkedRuns.first)
+    let link = try #require(linked.link)
+
+    #expect(linkedRuns.count == 1)
+    #expect(String(attributed.characters[linked.range]) == "translation report")
+
+    let alignment = TranslationStyleMapper.align(
+      source: attributed,
+      target: "번역 보고서를 열고 비교합니다.",
+      alternatives: [link: "번역 보고서"]
+    )
+    let targetRuns = alignment.target.runs.filter { $0.link != nil }
+    let targetRun = try #require(targetRuns.first)
+    #expect(targetRuns.count == 1)
+    #expect(String(alignment.target.characters[targetRun.range]) == "번역 보고서")
+  }
+
+  @Test
   func styleMapperUsesShortTranslatedAlternativeWhenLiteralChanges() throws {
     var source = AttributedString("rameshsunkara opened this issue")
     let link = URL(string: "swiftycrow-style://run/0")!

--- a/Tests/OverlayLayoutEngineTests.swift
+++ b/Tests/OverlayLayoutEngineTests.swift
@@ -746,6 +746,36 @@ struct OverlayLayoutEngineTests {
   }
 
   @Test
+  func compactSurfaceRestorationCoversTheFullSourceGlyphHeight() {
+    let canvas = CGSize(width: 1_000, height: 500)
+    let patch = OverlaySourcePatch(box: CGRect(x: 0.2, y: 0.4, width: 0.1, height: 0.04))
+    let surface = OverlaySourceSurface(
+      box: CGRect(x: 0.195, y: 0.38, width: 0.11, height: 0.08),
+      confidence: 0.35,
+      clippingBox: CGRect(x: 0.19, y: 0.37, width: 0.12, height: 0.10)
+    )
+
+    let ordinary = OverlayLayoutEngine.replacementFrame(
+      for: patch,
+      sourceLayout: .horizontal(rows: 1),
+      in: canvas,
+      displayScale: 1
+    )
+    let clippedControl = OverlayLayoutEngine.replacementFrame(
+      for: patch,
+      sourceLayout: .horizontal(rows: 1),
+      sourceSurface: surface,
+      in: canvas,
+      displayScale: 1
+    )
+
+    #expect(clippedControl.minY < ordinary.minY)
+    #expect(clippedControl.maxY > ordinary.maxY)
+    #expect(clippedControl.minY == 186)
+    #expect(clippedControl.maxY == 234)
+  }
+
+  @Test
   func horizontalTranslationKeepsTheSourceTopEdge() throws {
     let canvas = CGSize(width: 2_178, height: 1_228)
     let line = translatedLine(

--- a/Tests/OverlayLayoutEngineTests.swift
+++ b/Tests/OverlayLayoutEngineTests.swift
@@ -30,6 +30,18 @@ struct OverlayLayoutEngineTests {
     }
   }
 
+  struct NeighborAlignmentCase: Sendable, CustomTestStringConvertible {
+    let name: String
+    let subject: CGRect
+    let neighbor: CGRect
+    let fallback: OverlayTextAlignment
+    let expected: OverlayTextAlignment
+
+    var testDescription: String {
+      name
+    }
+  }
+
   @Test(arguments: [
     EdgeCase(name: "left", box: CGRect(x: 0.01, y: 0.2, width: 0.06, height: 0.3)),
     EdgeCase(name: "right", box: CGRect(x: 0.93, y: 0.2, width: 0.06, height: 0.3)),
@@ -210,11 +222,6 @@ struct OverlayLayoutEngineTests {
 
   @Test(arguments: [
     PageAlignmentCase(
-      name: "wide hero on the page center axis",
-      box: CGRect(x: 0.14, y: 0.13, width: 0.74, height: 0.08),
-      expected: .center
-    ),
-    PageAlignmentCase(
       name: "left edge label",
       box: CGRect(x: 0.01, y: 0.25, width: 0.12, height: 0.04),
       expected: .leading
@@ -236,6 +243,87 @@ struct OverlayLayoutEngineTests {
 
     let placement = try #require(
       OverlayLayoutEngine.placements(for: [line], in: CGSize(width: 1_000, height: 600)).first
+    )
+
+    #expect(placement.alignment == testCase.expected)
+  }
+
+  @Test
+  func wideListRowsDoNotInventCenterAlignment() {
+    var title = translatedLine(
+      id: lineID(22),
+      box: CGRect(x: 0.06384, y: 0.58941, width: 0.89040, height: 0.06547),
+      sourceIsVertical: false,
+      text: "SwiftUI 목록을 자동으로 스크롤하는 방법",
+      target: "ko-KR"
+    )
+    var detail = translatedLine(
+      id: lineID(23),
+      box: CGRect(x: 0.06051, y: 0.65625, width: 0.89136, height: 0.06175),
+      sourceIsVertical: false,
+      sourceRows: 2,
+      text: "검색 결과의 상세 설명",
+      target: "ko-KR"
+    )
+    title.source.alignment = nil
+    detail.source.alignment = .leading
+
+    let placements = OverlayLayoutEngine.placements(
+      for: [title, detail],
+      in: CGSize(width: 1_438, height: 1_232)
+    )
+
+    #expect(placements.first { $0.line.id == title.id }?.alignment == .leading)
+    #expect(placements.first { $0.line.id == detail.id }?.alignment == .leading)
+  }
+
+  @Test(arguments: [
+    NeighborAlignmentCase(
+      name: "nearby rows share a center axis",
+      subject: CGRect(x: 0.19186, y: 0.77907, width: 0.15407, height: 0.02558),
+      neighbor: CGRect(x: 0.07558, y: 0.83721, width: 0.38227, height: 0.05832),
+      fallback: .leading,
+      expected: .center
+    ),
+    NeighborAlignmentCase(
+      name: "nearby rows share a trailing edge",
+      subject: CGRect(x: 0.78757, y: 0.42456, width: 0.14286, height: 0.03331),
+      neighbor: CGRect(x: 0.56686, y: 0.48333, width: 0.36483, height: 0.05853),
+      fallback: .leading,
+      expected: .trailing
+    ),
+    NeighborAlignmentCase(
+      name: "left aligned hero rows override a centered Vision result",
+      subject: CGRect(x: 0.22075, y: 0.10162, width: 0.51934, height: 0.05437),
+      neighbor: CGRect(x: 0.21799, y: 0.17438, width: 0.57130, height: 0.02946),
+      fallback: .center,
+      expected: .leading
+    ),
+  ])
+  func neighboringBlockGeometryOverridesIncorrectVisionAlignment(
+    _ testCase: NeighborAlignmentCase
+  ) throws {
+    var subject = translatedLine(
+      id: lineID(20),
+      box: testCase.subject,
+      sourceIsVertical: false,
+      text: "주요 번역",
+      target: "ko-KR"
+    )
+    let neighbor = translatedLine(
+      id: lineID(21),
+      box: testCase.neighbor,
+      sourceIsVertical: false,
+      sourceRows: 2,
+      text: "주변 번역 문단",
+      target: "ko-KR"
+    )
+    subject.source.alignment = testCase.fallback
+
+    let placement = try #require(
+      OverlayLayoutEngine
+        .placements(for: [subject, neighbor], in: CGSize(width: 1_600, height: 1_000))
+        .first { $0.line.id == subject.id }
     )
 
     #expect(placement.alignment == testCase.expected)

--- a/Tests/OverlayLayoutEngineTests.swift
+++ b/Tests/OverlayLayoutEngineTests.swift
@@ -1,0 +1,1028 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import SwiftyCrow
+
+@Suite("Overlay layout engine")
+struct OverlayLayoutEngineTests {
+
+  // MARK: Internal
+
+  struct EdgeCase: Sendable, CustomTestStringConvertible {
+    let name: String
+    let box: CGRect
+
+    var testDescription: String {
+      name
+    }
+  }
+
+  struct PageAlignmentCase: Sendable, CustomTestStringConvertible {
+    let name: String
+    let box: CGRect
+    let expected: OverlayTextAlignment
+
+    var testDescription: String {
+      name
+    }
+  }
+
+  @Test(arguments: [
+    EdgeCase(name: "left", box: CGRect(x: 0.01, y: 0.2, width: 0.06, height: 0.3)),
+    EdgeCase(name: "right", box: CGRect(x: 0.93, y: 0.2, width: 0.06, height: 0.3)),
+    EdgeCase(name: "top", box: CGRect(x: 0.45, y: 0.01, width: 0.06, height: 0.3)),
+    EdgeCase(name: "bottom", box: CGRect(x: 0.45, y: 0.69, width: 0.06, height: 0.3)),
+  ])
+  func translationUsesOriginalFrameAtCanvasEdges(_ testCase: EdgeCase) throws {
+    let canvas = CGSize(width: 1_024, height: 480)
+    let line = translatedLine(
+      box: testCase.box,
+      sourceIsVertical: true,
+      text: "Sorry for dropping by so suddenly, Yukie-san.",
+      target: "en-US"
+    )
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+    let safe = CGRect(origin: .zero, size: canvas).insetBy(dx: 4, dy: 4)
+    #expect(safe.contains(placement.sourceFrame))
+    #expect(safe.contains(placement.frame))
+    #expect(placement.frame == placement.sourceFrame)
+    #expect(placement.placementBounds == placement.sourceFrame)
+    #expect(placement.fontSize >= 4)
+  }
+
+  @Test
+  func rightEdgeTranslationDoesNotExpandTowardTheInterior() throws {
+    let canvas = CGSize(width: 1_024, height: 480)
+    let box = CGRect(x: 0.89, y: 0.04, width: 0.07, height: 0.2)
+    let line = translatedLine(
+      box: box,
+      sourceIsVertical: true,
+      text: "I have something important to tell you today.",
+      target: "en-US"
+    )
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+    #expect(placement.frame == placement.sourceFrame)
+    #expect(placement.frame.maxX <= canvas.width - 4)
+  }
+
+  @Test
+  func longTranslationStaysInsideDetectedSourceSurface() throws {
+    let canvas = CGSize(width: 1_024, height: 1_536)
+    var line = translatedLine(
+      box: CGRect(x: 0.06, y: 0.04, width: 0.07, height: 0.23),
+      sourceIsVertical: true,
+      text: "Sorry for dropping by so suddenly, Yukie-san.",
+      target: "en-US"
+    )
+    line.source.surface = OverlaySourceSurface(
+      box: CGRect(x: 0.025, y: 0.02, width: 0.115, height: 0.27),
+      confidence: 0.9
+    )
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+    let surface = pixelRect(line.source.surface!.box, canvas: canvas)
+
+    #expect(surface.contains(placement.frame))
+    #expect(placement.placementBounds.contains(placement.frame))
+    #expect(CoreTextTypesetter.horizontalWordsFit(
+      text: line.displayedText,
+      language: line.displayedLanguage,
+      fontSize: placement.fontSize,
+      constrainedToWidth: placement.frame.width
+    ))
+  }
+
+  @Test
+  func tinyHorizontalSourceShrinksTranslationInsteadOfGrowing() throws {
+    let canvas = CGSize(width: 1_024, height: 480)
+    let box = CGRect(x: 0.1, y: 0.1, width: 0.03, height: 0.025)
+    let line = translatedLine(
+      box: box,
+      sourceIsVertical: false,
+      text: "Readable translated sentence.",
+      target: "en-US"
+    )
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+    #expect(placement.frame == placement.sourceFrame)
+    #expect(placement.fontSize <= 8)
+    #expect(placement.lineLimit ?? 0 >= 1)
+  }
+
+  @Test
+  func shorterHorizontalTranslationKeepsOriginalSourceRowWidth() throws {
+    let canvas = CGSize(width: 1_000, height: 500)
+    let line = translatedLine(
+      box: CGRect(x: 0.2, y: 0.2, width: 0.5, height: 0.06),
+      sourceIsVertical: false,
+      text: "짧음",
+      target: "ko"
+    )
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.frame == placement.sourceFrame)
+  }
+
+  @Test
+  func compactHorizontalControlUsesItsDetectedSurface() throws {
+    let canvas = CGSize(width: 1_000, height: 600)
+    var line = translatedLine(
+      box: CGRect(x: 0.40, y: 0.40, width: 0.10, height: 0.03),
+      sourceIsVertical: false,
+      text: "안정된 상태",
+      target: "ko-KR"
+    )
+    line.source.surface = OverlaySourceSurface(
+      box: CGRect(x: 0.39, y: 0.385, width: 0.14, height: 0.06),
+      confidence: 0.8
+    )
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.frame.width > placement.sourceFrame.width)
+    #expect(placement.frame.height > placement.sourceFrame.height)
+    #expect(placement.frame.contains(
+      CGPoint(x: placement.sourceFrame.midX, y: placement.sourceFrame.midY)
+    ))
+  }
+
+  @Test
+  func compactControlInfersCenterAlignmentFromItsSurfaceMargins() throws {
+    let canvas = CGSize(width: 1_600, height: 1_000)
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.3227, y: 0.3605, width: 0.0363, height: 0.0163),
+      text: "Stable",
+      horizontalGlyphScale: 0.0163,
+      alignment: .leading,
+      surface: OverlaySourceSurface(
+        box: CGRect(x: 0.3212, y: 0.3500, width: 0.0426, height: 0.0333),
+        confidence: 0.8
+      )
+    )
+    var line = OverlayLine(
+      id: UUID(),
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "en-US")
+      ),
+      initialContent: .pending
+    )
+    line.showTranslation("안정된", language: Locale.Language(identifier: "ko-KR"))
+    let surfaceFrame = pixelRect(line.source.surface!.box, canvas: canvas)
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.alignment == .center)
+    #expect(abs(placement.frame.midX - surfaceFrame.midX) < 0.01)
+    #expect(placement.frame.height > placement.sourceFrame.height)
+  }
+
+  @Test
+  func leadingCompactControlRetainsItsVisualPadding() throws {
+    let canvas = CGSize(width: 1_000, height: 600)
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.102, y: 0.40, width: 0.05, height: 0.03),
+      text: "Status",
+      horizontalGlyphScale: 0.03,
+      alignment: .leading,
+      surface: OverlaySourceSurface(
+        box: CGRect(x: 0.10, y: 0.385, width: 0.10, height: 0.06),
+        confidence: 0.8
+      )
+    )
+    var line = OverlayLine(
+      id: UUID(),
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "en-US")
+      ),
+      initialContent: .pending
+    )
+    line.showTranslation("상태", language: Locale.Language(identifier: "ko-KR"))
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.alignment == .leading)
+    #expect(placement.frame.minX > placement.sourceFrame.minX)
+  }
+
+  @Test(arguments: [
+    PageAlignmentCase(
+      name: "wide hero on the page center axis",
+      box: CGRect(x: 0.14, y: 0.13, width: 0.74, height: 0.08),
+      expected: .center
+    ),
+    PageAlignmentCase(
+      name: "left edge label",
+      box: CGRect(x: 0.01, y: 0.25, width: 0.12, height: 0.04),
+      expected: .leading
+    ),
+    PageAlignmentCase(
+      name: "right edge label",
+      box: CGRect(x: 0.87, y: 0.25, width: 0.12, height: 0.04),
+      expected: .trailing
+    ),
+  ])
+  func pageGeometryOverridesIncorrectVisionAlignment(_ testCase: PageAlignmentCase) throws {
+    var line = translatedLine(
+      box: testCase.box,
+      sourceIsVertical: false,
+      text: "짧은 번역",
+      target: "ko-KR"
+    )
+    line.source.alignment = .leading
+
+    let placement = try #require(
+      OverlayLayoutEngine.placements(for: [line], in: CGSize(width: 1_000, height: 600)).first
+    )
+
+    #expect(placement.alignment == testCase.expected)
+  }
+
+  @Test
+  func pageCenteredHeroDoesNotCenterAVisuallySeparateCardColumn() {
+    var eyebrow = translatedLine(
+      id: lineID(0),
+      box: CGRect(x: 0.45, y: 0.07, width: 0.10, height: 0.03),
+      sourceIsVertical: false,
+      text: "프로필",
+      target: "ko-KR"
+    )
+    var hero = translatedLine(
+      id: lineID(1),
+      box: CGRect(x: 0.14, y: 0.13, width: 0.72, height: 0.08),
+      sourceIsVertical: false,
+      text: "한 번에 전체 설정을 변경하세요.",
+      target: "ko-KR"
+    )
+    var cardBody = translatedLine(
+      id: lineID(2),
+      box: CGRect(x: 0.40, y: 0.65, width: 0.20, height: 0.16),
+      sourceIsVertical: false,
+      sourceRows: 4,
+      text: "카드 본문은 원본의 왼쪽 정렬을 유지합니다.",
+      target: "ko-KR"
+    )
+    eyebrow.source.alignment = .leading
+    hero.source.alignment = .leading
+    cardBody.source.alignment = .leading
+
+    let placements = OverlayLayoutEngine.placements(
+      for: [eyebrow, hero, cardBody],
+      in: CGSize(width: 1_000, height: 600)
+    )
+
+    #expect(placements.first { $0.line.id == eyebrow.id }?.alignment == .center)
+    #expect(placements.first { $0.line.id == hero.id }?.alignment == .center)
+    #expect(placements.first { $0.line.id == cardBody.id }?.alignment == .leading)
+  }
+
+  @Test
+  func largeCardSurfaceDoesNotOverrideParagraphAlignment() throws {
+    let canvas = CGSize(width: 1_000, height: 600)
+    var line = translatedLine(
+      box: CGRect(x: 0.18, y: 0.30, width: 0.20, height: 0.15),
+      sourceIsVertical: false,
+      sourceRows: 3,
+      text: "원본 카드 본문의 왼쪽 정렬을 유지합니다.",
+      target: "ko-KR"
+    )
+    line.source.alignment = .leading
+    line.source.surface = OverlaySourceSurface(
+      box: CGRect(x: 0.08, y: 0.20, width: 0.40, height: 0.35),
+      confidence: 0.8
+    )
+
+    let placement = try #require(
+      OverlayLayoutEngine.placements(for: [line], in: canvas).first
+    )
+
+    #expect(placement.alignment == .leading)
+  }
+
+  @Test
+  func heroTitleCanExceedTheOldFixedFontCap() throws {
+    let canvas = CGSize(width: 2_170, height: 1_352)
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1424, y: 0.1329, width: 0.7384, height: 0.0746),
+      text: "Switch your whole setup at once.",
+      horizontalGlyphScale: 0.0740,
+      horizontalInkScale: 0.0580,
+      alignment: .center
+    )
+    var line = OverlayLine(
+      id: UUID(),
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "en-US")
+      ),
+      initialContent: .pending
+    )
+    line.showTranslation(
+      "한 번에 전체 설정을 변경하세요.",
+      language: Locale.Language(identifier: "ko-KR")
+    )
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.fontSize > 72)
+    #expect(CoreTextTypesetter.fits(
+      text: placement.line.displayedText,
+      language: placement.line.displayedLanguage,
+      flow: placement.flow,
+      fontSize: placement.fontSize,
+      in: placement.frame.size
+    ))
+  }
+
+  @Test
+  func horizontalCardTitleDoesNotExpandToTheWholeCardSurface() throws {
+    let canvas = CGSize(width: 1_000, height: 600)
+    var line = translatedLine(
+      box: CGRect(x: 0.12, y: 0.20, width: 0.20, height: 0.05),
+      sourceIsVertical: false,
+      text: "번역된 카드 제목",
+      target: "ko-KR"
+    )
+    line.source.surface = OverlaySourceSurface(
+      box: CGRect(x: 0.08, y: 0.10, width: 0.40, height: 0.70),
+      confidence: 0.8
+    )
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.frame == placement.sourceFrame)
+  }
+
+  @Test
+  func horizontalControlUsesWordGlyphHeightInsteadOfIconInflatedLineBox() throws {
+    let canvas = CGSize(width: 1_196, height: 610)
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.67, y: 0.72, width: 0.18, height: 0.076),
+      text: "+ Add bypass",
+      horizontalGlyphScale: 0.07,
+      horizontalInkScale: 0.034
+    )
+    var line = OverlayLine(
+      id: UUID(0),
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "en")
+      ),
+      initialContent: .pending
+    )
+    line.showTranslation("+ 우회 추가", language: Locale.Language(identifier: "ko"))
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.fontSize < 33)
+    #expect(placement.fontSize > 26)
+  }
+
+  @Test
+  func multilineWebBodyUsesItsVisionRowScaleInsteadOfThinInkHeight() throws {
+    let canvas = CGSize(width: 2_172, height: 1_216)
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.0756, y: 0.6551, width: 0.2358, height: 0.1816),
+      text: "Pull a workspace to the top, bottom, left, or right. The two blocks tile beside each other with separate BSP layouts, and windows stay on their own side.",
+      rowCount: 5,
+      horizontalGlyphScale: 0.0279,
+      horizontalInkScale: 0.0150
+    )
+    var line = OverlayLine(
+      id: UUID(),
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "en-US")
+      ),
+      initialContent: .pending
+    )
+    line.showTranslation(
+      "작업 공간을 위쪽, 아래쪽, 왼쪽 또는 오른쪽으로 당기십시오. 두 개의 블록은 별도의 BSP 레이아웃으로 나란히 타일링되며, 창문은 각각 다른 쪽에 유지됩니다.",
+      language: Locale.Language(identifier: "ko-KR")
+    )
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.fontSize >= 31)
+    #expect(placement.fontSize <= 33)
+    #expect(CoreTextTypesetter.fits(
+      text: placement.line.displayedText,
+      language: placement.line.displayedLanguage,
+      flow: placement.flow,
+      fontSize: placement.fontSize,
+      in: placement.frame.size
+    ))
+  }
+
+  @Test
+  func smallLowContrastFooterTrustsItsVisionGlyphBox() throws {
+    let canvas = CGSize(width: 1_600, height: 1_000)
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.06, y: 0.87, width: 0.15, height: 0.021),
+      text: "Last updated five minutes ago",
+      horizontalGlyphScale: 0.0184,
+      horizontalInkScale: 0.00625
+    )
+    var line = OverlayLine(
+      id: UUID(),
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "en-US")
+      ),
+      initialContent: .pending
+    )
+    line.showTranslation("마지막 업데이트는 5분 전입니다", language: Locale.Language(identifier: "ko-KR"))
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.fontSize >= 17)
+    #expect(placement.fontSize <= 18)
+  }
+
+  @Test
+  func smallMultilineTableCellBalancesLineBoxAndInkScale() throws {
+    let canvas = CGSize(width: 1_600, height: 1_000)
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.55, y: 0.46, width: 0.30, height: 0.045),
+      text: "Use one balanced body frame without absorbing the next table row.",
+      rowCount: 2,
+      horizontalGlyphScale: 0.0212,
+      horizontalInkScale: 0.007
+    )
+    var line = OverlayLine(
+      id: UUID(),
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "en-US")
+      ),
+      initialContent: .pending
+    )
+    line.showTranslation(
+      "다음 표 행을 흡수하지 않고 균형 잡힌 본문 프레임을 사용하십시오.",
+      language: Locale.Language(identifier: "ko-KR")
+    )
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.fontSize >= 16)
+    #expect(placement.fontSize <= 18)
+  }
+
+  @Test
+  func compactBoldLabelDoesNotInflateItsPointSize() throws {
+    let canvas = CGSize(width: 1_880, height: 1_438)
+    func makeLine(weight: OverlayFontWeight) -> OverlayLine {
+      var appearance = OverlaySourceAppearance.fallback
+      appearance.fontWeight = weight
+      let recognized = OCRResult.Line(
+        boundingBoxNormalized: CGRect(x: 0.12, y: 0.45, width: 0.04, height: 0.019),
+        text: "Tool",
+        horizontalGlyphScale: 0.019,
+        appearance: appearance
+      )
+      var line = OverlayLine(
+        id: UUID(),
+        source: OverlayLine.Source(
+          recognized: recognized,
+          language: Locale.Language(identifier: "en-US")
+        ),
+        initialContent: .pending
+      )
+      line.showTranslation("도구", language: Locale.Language(identifier: "ko-KR"))
+      return line
+    }
+
+    let regular = try #require(OverlayLayoutEngine.placements(for: [makeLine(weight: .regular)], in: canvas).first)
+    let bold = try #require(OverlayLayoutEngine.placements(for: [makeLine(weight: .bold)], in: canvas).first)
+
+    #expect(bold.fontSize <= regular.fontSize + 0.5)
+    #expect(bold.fontSize >= 20)
+  }
+
+  @Test
+  func compactTranslationRetainsTheSourceGlyphScale() throws {
+    let canvas = CGSize(width: 1_024, height: 1_536)
+    var appearance = OverlaySourceAppearance.fallback
+    appearance.fontWeight = .medium
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.75625, y: 0.8125, width: 0.15625, height: 0.01042),
+      text: "明日また会いましょう",
+      horizontalGlyphScale: 16 / canvas.height,
+      appearance: appearance
+    )
+    var line = OverlayLine(
+      id: UUID(0),
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "ja-JP")
+      ),
+      initialContent: .pending
+    )
+    line.showTranslation("내일 다시 만나요.", language: Locale.Language(identifier: "ko-KR"))
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.fontSize >= 13)
+  }
+
+  @Test
+  func furiganaInflatedBodyUsesTheBaseGlyphScale() throws {
+    let canvas = CGSize(width: 1_314, height: 1_898)
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.045, y: 0.546, width: 0.437, height: 0.102),
+      text: "木のぼうの先にくくりつけて、動物や魚をとるためのやりとして使われた。",
+      rowCount: 3,
+      horizontalGlyphScale: 0.0355,
+      horizontalInkScale: 0.0101
+    )
+    var line = OverlayLine(
+      id: UUID(),
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "ja-JP")
+      ),
+      initialContent: .pending
+    )
+    line.showTranslation(
+      "나무 막대 끝에 묶어 동물이나 물고기를 잡는 창으로 사용되었습니다.",
+      language: Locale.Language(identifier: "ko-KR")
+    )
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.fontSize >= 32)
+    #expect(placement.fontSize <= 38)
+    #expect(CoreTextTypesetter.fits(
+      text: placement.line.displayedText,
+      language: placement.line.displayedLanguage,
+      flow: placement.flow,
+      fontSize: placement.fontSize,
+      in: placement.frame.size
+    ))
+  }
+
+  @Test
+  func verticalSourceKeepsNarrowRestorationBleedNearBubbleEdges() {
+    let canvas = CGSize(width: 1_000, height: 1_000)
+    let patch = OverlaySourcePatch(box: CGRect(x: 0.2, y: 0.2, width: 0.1, height: 0.2))
+    let horizontal = OverlayLayoutEngine.replacementFrame(
+      for: patch,
+      sourceLayout: .horizontal(rows: 1),
+      in: canvas,
+      displayScale: 1
+    )
+    let vertical = OverlayLayoutEngine.replacementFrame(
+      for: patch,
+      sourceLayout: .vertical(characterScale: 0.04, progression: .rightToLeft),
+      in: canvas,
+      displayScale: 1
+    )
+
+    #expect(horizontal.minX < vertical.minX)
+    #expect(horizontal.minY == 199)
+    #expect(vertical.minY == 198)
+    #expect(vertical.width <= 106)
+    #expect(horizontal.width >= 128)
+  }
+
+  @Test
+  func multilineHorizontalPatchGetsOnlyVerticalAntialiasingBleed() {
+    let canvas = CGSize(width: 2_000, height: 1_200)
+    let patch = OverlaySourcePatch(box: CGRect(x: 0.2, y: 0.6, width: 0.2, height: 0.025))
+    let singleLine = OverlayLayoutEngine.replacementFrame(
+      for: patch,
+      sourceLayout: .horizontal(rows: 1),
+      in: canvas,
+      displayScale: 2
+    )
+    let multiline = OverlayLayoutEngine.replacementFrame(
+      for: patch,
+      sourceLayout: .horizontal(rows: 5),
+      in: canvas,
+      displayScale: 2
+    )
+
+    #expect(singleLine.minY >= 719)
+    #expect(singleLine.maxY <= 751)
+    #expect(multiline.minY < singleLine.minY)
+    #expect(multiline.maxY > singleLine.maxY)
+    #expect(multiline.minY >= 717)
+    #expect(multiline.maxY <= 753)
+  }
+
+  @Test
+  func horizontalTranslationKeepsTheSourceTopEdge() throws {
+    let canvas = CGSize(width: 2_178, height: 1_228)
+    let line = translatedLine(
+      box: CGRect(x: 0.38808, y: 0.675, width: 0.22674, height: 0.1317),
+      sourceIsVertical: false,
+      sourceRows: 4,
+      text: "Conservative, Balanced, Fast 중에서 선택하고 Amado가 급격한 신호 손실을 걸러내게 하십시오.",
+      target: "ko-KR"
+    )
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(abs(placement.frame.minY - placement.sourceFrame.minY) < 0.5)
+  }
+
+  @Test
+  func tallerHorizontalTranslationShrinksInsideSource() throws {
+    let canvas = CGSize(width: 1_000, height: 600)
+    var line = translatedLine(
+      box: CGRect(x: 0.36, y: 0.42, width: 0.16, height: 0.035),
+      sourceIsVertical: false,
+      text: "번역문이 원문보다 여러 줄 길어지면 추가된 높이만큼 위와 아래로 나누어 확장합니다.",
+      target: "ko-KR"
+    )
+    line.source.surface = OverlaySourceSurface(
+      box: CGRect(x: 0.25, y: 0.25, width: 0.40, height: 0.40),
+      confidence: 0.9
+    )
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.frame == placement.sourceFrame)
+    #expect(placement.placementBounds == placement.sourceFrame)
+  }
+
+  @Test
+  func widerVerticalTranslationShrinksInsideSource() throws {
+    let canvas = CGSize(width: 1_000, height: 600)
+    var line = translatedLine(
+      box: CGRect(x: 0.44, y: 0.25, width: 0.05, height: 0.28),
+      sourceIsVertical: true,
+      text: "번역문이 길어져 세로쓰기 열이 늘어나더라도 원문의 중심 위치를 유지합니다.",
+      target: "ko-KR"
+    )
+    line.source.surface = OverlaySourceSurface(
+      box: CGRect(x: 0.28, y: 0.18, width: 0.38, height: 0.42),
+      confidence: 0.9
+    )
+
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+
+    #expect(placement.frame == placement.sourceFrame)
+    #expect(placement.placementBounds == placement.sourceFrame)
+  }
+
+  @Test
+  func pendingVerticalSourceDoesNotCreateAReplacementChip() {
+    let canvas = CGSize(width: 1_024, height: 480)
+    let line = sourceLine(
+      box: CGRect(x: 0.4, y: 0.2, width: 0.06, height: 0.3),
+      sourceIsVertical: true,
+      initialContent: .pending
+    )
+    #expect(line.textFlow == .vertical(.rightToLeft))
+    #expect(OverlayLayoutEngine.placements(for: [line], in: canvas).isEmpty)
+  }
+
+  @Test
+  func fixedTranslationFrameDoesNotCoverPendingSourceText() throws {
+    let canvas = CGSize(width: 2_178, height: 1_228)
+    let pending = sourceLine(
+      id: UUID(1),
+      box: CGRect(x: 0.43605, y: 0.07474, width: 0.13663, height: 0.03359),
+      sourceIsVertical: false,
+      initialContent: .pending
+    )
+    let heading = translatedLine(
+      id: UUID(2),
+      box: CGRect(x: 0.16555, y: 0.13639, width: 0.68491, height: 0.09125),
+      sourceIsVertical: false,
+      text: "걸어 나가세요. 귀하의 Mac이 종료됩니다.",
+      target: "ko-KR"
+    )
+
+    let placement = try #require(
+      OverlayLayoutEngine.placements(for: [pending, heading], in: canvas).first
+    )
+    let pendingFrame = pixelRect(pending.source.box, canvas: canvas)
+    let intersection = placement.frame.intersection(pendingFrame)
+
+    #expect(intersection.isNull || intersection.isEmpty)
+  }
+
+  @Test
+  func sameWritingSystemSourceLeavesOriginalPixelsUntouched() {
+    let line = sourceLine(
+      box: CGRect(x: 0.4, y: 0.2, width: 0.06, height: 0.3),
+      sourceIsVertical: true,
+      initialContent: .source
+    )
+    #expect(OverlayLayoutEngine.placements(for: [line], in: CGSize(width: 1_024, height: 480)).isEmpty)
+  }
+
+  @Test
+  func verticalTranslationUsesCoreTextFrameThatFits() throws {
+    let canvas = CGSize(width: 600, height: 600)
+    let line = translatedLine(
+      box: CGRect(x: 0.4, y: 0.1, width: 0.16, height: 0.55),
+      sourceIsVertical: true,
+      text: "2026年8月27日です。OKなら今すぐ始めよう。",
+      target: "ja"
+    )
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: canvas).first)
+    #expect(placement.line.textFlow == .vertical(.rightToLeft))
+    #expect(CoreTextTypesetter.fits(
+      text: line.displayedText,
+      language: line.displayedLanguage,
+      flow: line.textFlow,
+      fontSize: placement.fontSize,
+      in: placement.frame.size
+    ))
+    let image = CoreTextTypesetter.verticalGlyphImage(
+      text: line.displayedText,
+      language: line.displayedLanguage,
+      fontSize: placement.fontSize,
+      size: placement.frame.size,
+      scale: 2,
+      progression: .rightToLeft
+    )
+    #expect(image != nil)
+  }
+
+  @Test
+  func horizontalAccessibilityPreferenceReflowsVerticalTranslation() throws {
+    let line = translatedLine(
+      box: CGRect(x: 0.4, y: 0.1, width: 0.16, height: 0.55),
+      sourceIsVertical: true,
+      text: "今日は晴れです",
+      target: "ja"
+    )
+    let placement = try #require(
+      OverlayLayoutEngine.placements(
+        for: [line],
+        in: CGSize(width: 600, height: 600),
+        prefersHorizontalTextLayout: true
+      ).first
+    )
+    #expect(placement.flow == .horizontal(.leftToRight))
+    #expect(placement.lineLimit != nil)
+  }
+
+  @Test
+  func horizontalArabicUsesTrailingAlignment() throws {
+    let line = translatedLine(
+      box: CGRect(x: 0.2, y: 0.2, width: 0.4, height: 0.1),
+      sourceIsVertical: false,
+      text: "لدي شيء مهم لأخبرك به",
+      target: "ar"
+    )
+    let placement = try #require(
+      OverlayLayoutEngine.placements(for: [line], in: CGSize(width: 800, height: 400)).first
+    )
+    #expect(placement.line.textFlow == .horizontal(.rightToLeft))
+    #expect(placement.alignment == .trailing)
+  }
+
+  @Test
+  func verticalOriginHorizontalTranslationIsCentered() throws {
+    let line = translatedLine(
+      box: CGRect(x: 0.2, y: 0.2, width: 0.08, height: 0.3),
+      sourceIsVertical: true,
+      text: "A horizontal translation",
+      target: "en-US"
+    )
+    let placement = try #require(
+      OverlayLayoutEngine.placements(for: [line], in: CGSize(width: 800, height: 400)).first
+    )
+    #expect(placement.alignment == .center)
+  }
+
+  @Test
+  func adjacentSourceFramesRemainSeparate() {
+    let canvas = CGSize(width: 1_000, height: 500)
+    let first = translatedLine(
+      id: UUID(1),
+      box: CGRect(x: 0.40, y: 0.2, width: 0.06, height: 0.28),
+      sourceIsVertical: true,
+      text: "The first translated sentence is readable.",
+      target: "en-US"
+    )
+    let second = translatedLine(
+      id: UUID(2),
+      box: CGRect(x: 0.54, y: 0.2, width: 0.06, height: 0.28),
+      sourceIsVertical: true,
+      text: "The second translated sentence is readable.",
+      target: "en-US"
+    )
+    let placements = OverlayLayoutEngine.placements(for: [first, second], in: canvas)
+    #expect(placements.count == 2)
+    let intersection = placements[0].frame.intersection(placements[1].frame)
+    #expect(intersection.isNull || intersection.isEmpty)
+  }
+
+  @Test
+  func observedProblemMatrixHasSixContainedNonOverlappingLabels() {
+    let canvas = CGSize(width: 1_024, height: 1_536)
+    let rows: [(CGRect, String)] = [
+      (CGRect(x: 0.89375, y: 0.03958, width: 0.06875, height: 0.19167), "I have something important to tell you today."),
+      (CGRect(x: 0.05937, y: 0.03750, width: 0.06563, height: 0.22708), "Sorry for dropping by so suddenly, Yukie-san."),
+      (CGRect(x: 0.58750, y: 0.38333, width: 0.05938, height: 0.12083), "I still cannot believe it."),
+      (CGRect(x: 0.42187, y: 0.38125, width: 0.06250, height: 0.11458), "Is that really true?"),
+      (CGRect(x: 0.40625, y: 0.68125, width: 0.05625, height: 0.10417), "If that is OK, let us start right now."),
+      (CGRect(x: 0.06250, y: 0.68125, width: 0.05625, height: 0.10833), "It is August 27, 2026."),
+    ]
+    let lines = rows.enumerated().map { index, row in
+      translatedLine(
+        id: lineID(index),
+        box: row.0,
+        sourceIsVertical: true,
+        text: row.1,
+        target: "en-US"
+      )
+    }
+    let placements = OverlayLayoutEngine.placements(for: lines, in: canvas)
+    let safeBounds = CGRect(origin: .zero, size: canvas).insetBy(dx: 4, dy: 4)
+
+    #expect(placements.count == 6)
+    #expect(placements.allSatisfy { safeBounds.contains($0.frame) && safeBounds.contains($0.sourceFrame) })
+    #expect(pairwiseNonOverlapping(placements.map(\.frame)))
+    #expect(placements.allSatisfy { placement in
+      centerDistance(placement.frame, placement.sourceFrame)
+        <= max(24, placement.sourceFrame.width / 2)
+    })
+    #expect(placements.allSatisfy { $0.fontSize >= 4 })
+    let adjacentDistances = placements[2...3].map {
+      centerDistance($0.frame, $0.sourceFrame)
+    }
+    #expect(
+      adjacentDistances.allSatisfy { $0 <= 30 },
+      "Adjacent center distances: \(adjacentDistances)"
+    )
+    #expect(
+      abs(adjacentDistances[0] - adjacentDistances[1]) < 1,
+      "Adjacent center distances: \(adjacentDistances)"
+    )
+    #expect(placements.allSatisfy { placement in
+      CoreTextTypesetter.fits(
+        text: placement.line.displayedText,
+        language: placement.line.displayedLanguage,
+        flow: placement.flow,
+        fontSize: placement.fontSize,
+        in: placement.frame.size
+      )
+    })
+  }
+
+  @Test
+  func observedTamilProblemMatrixKeepsAdjacentLabelsSeparate() {
+    let canvas = CGSize(width: 1_024, height: 1_536)
+    let sentence = "இது தெளிவாக வாசிக்கக்கூடிய சோதனை வாக்கியம்."
+    let rows: [(CGRect, String)] = [
+      (CGRect(x: 0.89375, y: 0.03958, width: 0.06875, height: 0.19167), sentence),
+      (CGRect(x: 0.05937, y: 0.03750, width: 0.06563, height: 0.22708), "\(sentence) \(sentence)"),
+      (CGRect(x: 0.58750, y: 0.38333, width: 0.05938, height: 0.12083), sentence),
+      (CGRect(x: 0.42187, y: 0.38125, width: 0.06250, height: 0.11458), "ஆம்."),
+      (CGRect(x: 0.40625, y: 0.68125, width: 0.05625, height: 0.10417), "OK · \(sentence)"),
+      (CGRect(x: 0.06250, y: 0.68125, width: 0.05625, height: 0.10833), "2026 · \(sentence)"),
+    ]
+    let lines = rows.enumerated().map { index, row in
+      translatedLine(
+        id: lineID(index),
+        box: row.0,
+        sourceIsVertical: true,
+        text: row.1,
+        target: "ta-Taml-IN"
+      )
+    }
+
+    let placements = OverlayLayoutEngine.placements(for: lines, in: canvas)
+
+    #expect(placements.count == 6)
+    #expect(pairwiseNonOverlapping(placements.map(\.frame)))
+  }
+
+  @Test
+  func observedNormalMatrixHasFourNonOverlappingLabelsAfterCoalescing() {
+    let canvas = CGSize(width: 1_024, height: 1_536)
+    let rows: [(CGRect, Bool, String)] = [
+      (CGRect(x: 0.11562, y: 0.04792, width: 0.06875, height: 0.20833), true, "The weather is nice today."),
+      (
+        CGRect(x: 0.09030, y: 0.44436, width: 0.34095, height: 0.07231),
+        false,
+        "The weather is nice today. Let us meet here again next weekend."
+      ),
+      (CGRect(x: 0.60000, y: 0.64792, width: 0.06250, height: 0.11875), true, "Yes, I am looking forward to it."),
+      (CGRect(x: 0.38750, y: 0.64583, width: 0.05938, height: 0.14167), true, "Let us meet again tomorrow."),
+    ]
+    let lines = rows.enumerated().map { index, row in
+      translatedLine(
+        id: lineID(index),
+        box: row.0,
+        sourceIsVertical: row.1,
+        sourceRows: index == 1 ? 3 : 1,
+        text: row.2,
+        target: "en-US"
+      )
+    }
+    let placements = OverlayLayoutEngine.placements(for: lines, in: canvas)
+    #expect(placements.count == 4)
+    #expect(pairwiseNonOverlapping(placements.map(\.frame)))
+  }
+
+  @Test
+  func unavailableTranslationAlsoLeavesSourceUntouched() {
+    var line = sourceLine(
+      box: CGRect(x: 0.4, y: 0.2, width: 0.06, height: 0.3),
+      sourceIsVertical: true,
+      initialContent: .pending
+    )
+    line.showUnavailable()
+    #expect(line.isUnavailable)
+    #expect(OverlayLayoutEngine.placements(for: [line], in: CGSize(width: 1_024, height: 480)).isEmpty)
+  }
+
+  @Test
+  func degenerateCanvasProducesFiniteContainedFrames() {
+    let line = translatedLine(
+      box: CGRect(x: -2, y: 4, width: 10, height: 0),
+      sourceIsVertical: false,
+      text: "Text",
+      target: "en-US"
+    )
+    let canvas = CGSize(width: 3, height: 2)
+    let placements = OverlayLayoutEngine.placements(for: [line], in: canvas)
+    #expect(placements.count == 1)
+    #expect(placements[0].frame.minX.isFinite)
+    #expect(placements[0].frame.minY.isFinite)
+    #expect(CGRect(origin: .zero, size: canvas).contains(placements[0].frame))
+  }
+
+  // MARK: Private
+
+  private func translatedLine(
+    id: UUID = UUID(0),
+    box: CGRect,
+    sourceIsVertical: Bool,
+    sourceRows: Int = 1,
+    text: String,
+    target: String
+  ) -> OverlayLine {
+    var line = sourceLine(
+      id: id,
+      box: box,
+      sourceIsVertical: sourceIsVertical,
+      sourceRows: sourceRows,
+      initialContent: .pending
+    )
+    line.showTranslation(text, language: Locale.Language(identifier: target))
+    return line
+  }
+
+  private func sourceLine(
+    id: UUID = UUID(0),
+    box: CGRect,
+    sourceIsVertical: Bool,
+    sourceRows: Int = 1,
+    initialContent: OverlayLine.InitialContent
+  ) -> OverlayLine {
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: box,
+      text: "今日は大切な話があります",
+      rowCount: sourceIsVertical ? 2 : sourceRows,
+      isVerticalBlock: sourceIsVertical,
+      verticalCharScale: sourceIsVertical ? max(0.018, box.width / 2) : 0
+    )
+    return OverlayLine(
+      id: id,
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "ja")
+      ),
+      initialContent: initialContent
+    )
+  }
+
+  private func pixelRect(_ normalized: CGRect, canvas: CGSize) -> CGRect {
+    CGRect(
+      x: normalized.minX * canvas.width,
+      y: normalized.minY * canvas.height,
+      width: normalized.width * canvas.width,
+      height: normalized.height * canvas.height
+    )
+  }
+
+  private func pairwiseNonOverlapping(_ frames: [CGRect]) -> Bool {
+    for lhs in frames.indices {
+      for rhs in frames.indices where rhs > lhs {
+        let intersection = frames[lhs].intersection(frames[rhs])
+        if !intersection.isNull, !intersection.isEmpty { return false }
+      }
+    }
+    return true
+  }
+
+  private func centerDistance(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+    hypot(lhs.midX - rhs.midX, lhs.midY - rhs.midY)
+  }
+
+  private func lineID(_ index: Int) -> UUID {
+    UUID(uuidString: String(format: "00000000-0000-0000-0000-%012d", index + 1))!
+  }
+}

--- a/Tests/OverlayLayoutEngineTests.swift
+++ b/Tests/OverlayLayoutEngineTests.swift
@@ -477,7 +477,8 @@ struct OverlayLayoutEngineTests {
       text: "Pull a workspace to the top, bottom, left, or right. The two blocks tile beside each other with separate BSP layouts, and windows stay on their own side.",
       rowCount: 5,
       horizontalGlyphScale: 0.0279,
-      horizontalInkScale: 0.0150
+      horizontalInkScale: 0.0150,
+      horizontalLineAdvanceScale: 0.036
     )
     var line = OverlayLine(
       id: UUID(),
@@ -496,12 +497,15 @@ struct OverlayLayoutEngineTests {
 
     #expect(placement.fontSize >= 31)
     #expect(placement.fontSize <= 33)
+    #expect(placement.lineHeightMultiple > 1)
+    #expect(placement.lineHeightMultiple <= 1.6)
     #expect(CoreTextTypesetter.fits(
       text: placement.line.displayedText,
       language: placement.line.displayedLanguage,
       flow: placement.flow,
       fontSize: placement.fontSize,
-      in: placement.frame.size
+      in: placement.frame.size,
+      lineHeightMultiple: placement.lineHeightMultiple
     ))
   }
 

--- a/Tests/OverlayLayoutEngineTests.swift
+++ b/Tests/OverlayLayoutEngineTests.swift
@@ -330,6 +330,46 @@ struct OverlayLayoutEngineTests {
   }
 
   @Test
+  func inlineControlLabelPreservesItsLeadingAnchor() throws {
+    var heading = translatedLine(
+      id: lineID(30),
+      box: CGRect(x: 0.52735, y: 0.60399, width: 0.19822, height: 0.03265),
+      sourceIsVertical: false,
+      text: "본문 옆으로 전환",
+      target: "ko-KR"
+    )
+    var label = translatedLine(
+      id: lineID(31),
+      box: CGRect(x: 0.56977, y: 0.66250, width: 0.14680, height: 0.02396),
+      sourceIsVertical: false,
+      text: "자동 번역",
+      target: "ko-KR"
+    )
+    var body = translatedLine(
+      id: lineID(32),
+      box: CGRect(x: 0.52616, y: 0.71117, width: 0.36054, height: 0.05654),
+      sourceIsVertical: false,
+      sourceRows: 2,
+      text: "스위치 그래픽과 보조 문장은 별도로 유지되어야 합니다.",
+      target: "ko-KR"
+    )
+    heading.source.alignment = .leading
+    label.source.alignment = nil
+    body.source.alignment = .leading
+
+    let placement = try #require(
+      OverlayLayoutEngine
+        .placements(
+          for: [heading, label, body],
+          in: CGSize(width: 1_600, height: 1_000)
+        )
+        .first { $0.line.id == label.id }
+    )
+
+    #expect(placement.alignment == .leading)
+  }
+
+  @Test
   func pageCenteredHeroDoesNotCenterAVisuallySeparateCardColumn() {
     var eyebrow = translatedLine(
       id: lineID(0),

--- a/Tests/OverlaySourceAppearanceAnalyzerTests.swift
+++ b/Tests/OverlaySourceAppearanceAnalyzerTests.swift
@@ -1,0 +1,674 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import SwiftyCrow
+
+@Suite("Overlay source appearance")
+struct OverlaySourceAppearanceAnalyzerTests {
+
+  // MARK: Internal
+
+  @Test
+  func findsLightBackgroundAndDarkForegroundAroundGlyphs() throws {
+    let image = try makeImage(
+      background: CGColor(gray: 0.94, alpha: 1),
+      glyph: CGColor(gray: 0.04, alpha: 1)
+    )
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: sourceResult(),
+      from: image
+    )
+    let patch = try #require(analyzed.lines.first?.replacementPatches.first)
+
+    #expect(patch.appearance.background.red > 0.85)
+    #expect(patch.appearance.foreground.red < 0.1)
+    #expect(patch.appearance.confidence > 0.5)
+    #expect(analyzed.lines[0].horizontalInkScale > 0.45)
+    #expect(analyzed.lines[0].horizontalInkScale < 0.6)
+  }
+
+  @Test
+  func findsDarkBackgroundAndLightForegroundAroundGlyphs() throws {
+    let image = try makeImage(
+      background: CGColor(gray: 0.06, alpha: 1),
+      glyph: CGColor(gray: 0.96, alpha: 1)
+    )
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: sourceResult(),
+      from: image
+    )
+    let patch = try #require(analyzed.lines.first?.replacementPatches.first)
+
+    #expect(patch.appearance.background.red < 0.15)
+    #expect(patch.appearance.foreground.red > 0.9)
+    #expect(patch.appearance.confidence > 0.5)
+  }
+
+  @Test
+  func preservesColoredSourceGlyphs() throws {
+    let image = try makeImage(
+      background: CGColor(gray: 0, alpha: 1),
+      glyph: CGColor(red: 0.05, green: 0.52, blue: 1, alpha: 1)
+    )
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: sourceResult(),
+      from: image
+    )
+    let foreground = try #require(analyzed.lines.first?.appearance.foreground)
+
+    #expect(foreground.blue > 0.9)
+    #expect(foreground.green > foreground.red * 4)
+  }
+
+  @Test
+  func shortColoredBulletDoesNotBecomeTheLineForeground() throws {
+    let image = try makeRepositoryMetadataImage()
+    let text = "• Swift"
+    let bulletBox = CGRect(x: 0.10, y: 0.30, width: 0.08, height: 0.40)
+    let wordBox = CGRect(x: 0.24, y: 0.30, width: 0.52, height: 0.40)
+    let line = OCRResult.Line(
+      boundingBoxNormalized: bulletBox.union(wordBox),
+      text: text,
+      replacementPatches: [
+        OverlaySourcePatch(box: bulletBox),
+        OverlaySourcePatch(box: wordBox),
+      ],
+      styleRuns: [
+        OverlaySourceStyleRun(range: NSRange(location: 0, length: 1), box: bulletBox),
+        OverlaySourceStyleRun(range: NSRange(location: 2, length: 5), box: wordBox),
+      ]
+    )
+
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: [line]),
+      from: image
+    )
+    let result = try #require(analyzed.lines.first)
+
+    #expect(result.appearance.foreground.red > result.appearance.foreground.blue * 0.8)
+    #expect(result.appearance.foreground.red < 0.8)
+    #expect(!result.styleRuns[0].appearance.isUnderlined)
+  }
+
+  @Test
+  func thickerGlyphCoverageProducesHeavierWeight() throws {
+    let thin = try makeImage(
+      background: CGColor(gray: 0, alpha: 1),
+      glyph: CGColor(gray: 1, alpha: 1),
+      glyphWidth: 4
+    )
+    let thick = try makeImage(
+      background: CGColor(gray: 0, alpha: 1),
+      glyph: CGColor(gray: 1, alpha: 1),
+      glyphWidth: 20
+    )
+    let thinAppearance = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: sourceResult(),
+      from: thin
+    ).lines[0].appearance
+    let thickAppearance = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: sourceResult(),
+      from: thick
+    ).lines[0].appearance
+
+    #expect(thinAppearance.fontWeight.rawValue < thickAppearance.fontWeight.rawValue)
+    #expect(thinAppearance.inkCoverage < thickAppearance.inkCoverage)
+  }
+
+  @Test
+  func consolidatesWordPatchesOnOneFlatBackground() throws {
+    let image = try makeImage(background: CGColor(gray: 0.1, alpha: 1), glyph: nil)
+    let line = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.2, y: 0.3, width: 0.6, height: 0.4),
+      text: "Two words",
+      replacementPatches: [
+        OverlaySourcePatch(box: CGRect(x: 0.22, y: 0.35, width: 0.2, height: 0.3)),
+        OverlaySourcePatch(box: CGRect(x: 0.58, y: 0.35, width: 0.2, height: 0.3)),
+      ]
+    )
+
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: [line]),
+      from: image
+    )
+
+    #expect(analyzed.lines[0].replacementPatches.count == 1)
+    #expect(analyzed.lines[0].replacementPatches[0].box == line.boundingBoxNormalized)
+  }
+
+  @Test
+  func keepsWordPatchesWhenAControlCrossesDifferentBackgrounds() throws {
+    let image = try makeSplitBackgroundImage()
+    let patches = [
+      OverlaySourcePatch(box: CGRect(x: 0.12, y: 0.35, width: 0.22, height: 0.3)),
+      OverlaySourcePatch(box: CGRect(x: 0.66, y: 0.35, width: 0.22, height: 0.3)),
+    ]
+    let line = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.1, y: 0.3, width: 0.8, height: 0.4),
+      text: "Split control",
+      replacementPatches: patches
+    )
+
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: [line]),
+      from: image
+    )
+
+    #expect(analyzed.lines[0].replacementPatches.count == 2)
+  }
+
+  @Test
+  func samplesInlineCodeSurfaceInsideLongWordBox() throws {
+    let image = try makeInlineCodeImage()
+    let text = ".github/instructions/*.instructions.md"
+    let source = CGRect(x: 0.25, y: 0.39, width: 0.5, height: 0.22)
+    let line = OCRResult.Line(
+      boundingBoxNormalized: source,
+      text: text,
+      replacementPatches: [OverlaySourcePatch(box: source)],
+      styleRuns: [
+        OverlaySourceStyleRun(
+          range: NSRange(location: 0, length: (text as NSString).length),
+          box: source
+        )
+      ]
+    )
+
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: [line]),
+      from: image
+    )
+    let style = try #require(analyzed.lines.first?.styleRuns.first?.appearance)
+    let patch = try #require(analyzed.lines.first?.replacementPatches.first)
+
+    #expect(style.background.red > 0.11)
+    #expect(style.background.red < 0.2)
+    #expect(patch.appearance.background == style.background)
+    #expect(!patch.erasesDistinctSurface)
+    #expect(style.fontDesign == .monospaced)
+  }
+
+  @Test
+  func highContrastCompactFillIsBackgroundRatherThanUnderlineInk() throws {
+    let image = try makeHighContrastInlineCodeImage()
+    let text = "build 2.10.0"
+    let source = CGRect(x: 0.2, y: 0.34, width: 0.6, height: 0.32)
+    let line = OCRResult.Line(
+      boundingBoxNormalized: source,
+      text: text,
+      replacementPatches: [OverlaySourcePatch(box: source)],
+      styleRuns: [
+        OverlaySourceStyleRun(
+          range: NSRange(location: 0, length: (text as NSString).length),
+          box: source
+        )
+      ]
+    )
+
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: [line]),
+      from: image
+    )
+    let style = try #require(analyzed.lines.first?.styleRuns.first?.appearance)
+
+    #expect(style.background.red > 0.8)
+    #expect(style.foreground.red < 0.4)
+    #expect(!style.isUnderlined)
+  }
+
+  @Test
+  func embeddedInlineCodeErasesItsOldSurfaceToTheParentBackground() throws {
+    let image = try makeInlineCodeImage()
+    let code = ".github/instructions/*.instructions.md"
+    let text = "Run \(code) now"
+    let codeBox = CGRect(x: 0.25, y: 0.39, width: 0.5, height: 0.22)
+    let line = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.05, y: 0.25, width: 0.9, height: 0.5),
+      text: text,
+      replacementPatches: [
+        OverlaySourcePatch(box: CGRect(x: 0.05, y: 0.39, width: 0.15, height: 0.22)),
+        OverlaySourcePatch(box: codeBox),
+        OverlaySourcePatch(box: CGRect(x: 0.80, y: 0.39, width: 0.15, height: 0.22)),
+      ],
+      styleRuns: [
+        OverlaySourceStyleRun(range: (text as NSString).range(of: code), box: codeBox)
+      ]
+    )
+
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: [line]),
+      from: image
+    )
+    let analyzedLine = try #require(analyzed.lines.first)
+    let erasers = analyzedLine.replacementPatches.filter(\.erasesDistinctSurface)
+    let eraser = try #require(
+      erasers.max {
+        $0.box.width * $0.box.height < $1.box.width * $1.box.height
+      }
+    )
+
+    #expect(eraser.appearance.background.red < 0.1)
+    #expect(eraser.box.width > codeBox.width)
+    #expect(eraser.box.height > codeBox.height)
+  }
+
+  @Test
+  func separatelyRecognizedInlineCodeIsReclassifiedAfterRowCoalescing() throws {
+    let image = try makeInlineCodeImage()
+    let code = ".github/instructions/*.instructions.md"
+    let leftBox = CGRect(x: 0.05, y: 0.39, width: 0.15, height: 0.22)
+    let codeBox = CGRect(x: 0.25, y: 0.39, width: 0.5, height: 0.22)
+    let rightBox = CGRect(x: 0.80, y: 0.39, width: 0.15, height: 0.22)
+    let lines = [
+      OCRResult.Line(
+        boundingBoxNormalized: leftBox,
+        text: "Run",
+        replacementPatches: [OverlaySourcePatch(box: leftBox)],
+        styleRuns: [OverlaySourceStyleRun(range: NSRange(location: 0, length: 3), box: leftBox)]
+      ),
+      OCRResult.Line(
+        boundingBoxNormalized: codeBox,
+        text: code,
+        replacementPatches: [OverlaySourcePatch(box: codeBox)],
+        styleRuns: [
+          OverlaySourceStyleRun(
+            range: NSRange(location: 0, length: (code as NSString).length),
+            box: codeBox
+          )
+        ]
+      ),
+      OCRResult.Line(
+        boundingBoxNormalized: rightBox,
+        text: "now",
+        replacementPatches: [OverlaySourcePatch(box: rightBox)],
+        styleRuns: [OverlaySourceStyleRun(range: NSRange(location: 0, length: 3), box: rightBox)]
+      ),
+    ]
+
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: lines),
+      from: image
+    )
+    let line = try #require(analyzed.lines.first)
+
+    #expect(analyzed.lines.count == 1)
+    #expect(line.text == "Run \(code) now")
+    #expect(line.replacementPatches.contains { $0.erasesDistinctSurface })
+    #expect(line.appearance.background.red < 0.1)
+  }
+
+  @Test
+  func hyphenatedStandaloneBadgeKeepsItsOwnSurface() throws {
+    let image = try makeStandaloneBadgeImage()
+    let text = "On-device"
+    let lineBox = CGRect(x: 0.31, y: 0.39, width: 0.38, height: 0.22)
+    let line = OCRResult.Line(
+      boundingBoxNormalized: lineBox,
+      text: text,
+      replacementPatches: [
+        OverlaySourcePatch(box: CGRect(x: 0.33, y: 0.39, width: 0.08, height: 0.22)),
+        OverlaySourcePatch(box: CGRect(x: 0.42, y: 0.39, width: 0.04, height: 0.22)),
+        OverlaySourcePatch(box: CGRect(x: 0.47, y: 0.39, width: 0.20, height: 0.22)),
+      ],
+      styleRuns: [
+        OverlaySourceStyleRun(range: NSRange(location: 0, length: 2), box: CGRect(x: 0.33, y: 0.39, width: 0.08, height: 0.22)),
+        OverlaySourceStyleRun(range: NSRange(location: 2, length: 1), box: CGRect(x: 0.42, y: 0.39, width: 0.04, height: 0.22)),
+        OverlaySourceStyleRun(range: NSRange(location: 3, length: 6), box: CGRect(x: 0.47, y: 0.39, width: 0.20, height: 0.22)),
+      ]
+    )
+
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: [line]),
+      from: image
+    )
+    let analyzedLine = try #require(analyzed.lines.first)
+
+    #expect(analyzedLine.replacementPatches.allSatisfy { !$0.erasesDistinctSurface })
+    #expect(analyzedLine.replacementPatches.allSatisfy { $0.appearance.background.blue > 0.25 })
+  }
+
+  @Test
+  func clampsSamplingAtImageEdges() throws {
+    let image = try makeImage(
+      background: CGColor(red: 0.18, green: 0.65, blue: 0.42, alpha: 1),
+      glyph: nil
+    )
+    let line = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.96, y: 0.96, width: 0.08, height: 0.08),
+      text: "edge",
+      replacementPatches: [OverlaySourcePatch(box: CGRect(x: 0.96, y: 0.96, width: 0.08, height: 0.08))]
+    )
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: [line]),
+      from: image
+    )
+    let patch = try #require(analyzed.lines.first?.replacementPatches.first)
+
+    #expect(patch.appearance.confidence > 0.9)
+    #expect(patch.appearance.background.green > 0.55)
+  }
+
+  @Test
+  func findsClosedFlatSurfaceAroundSourceText() throws {
+    let image = try makeBubbleImage()
+    let source = CGRect(x: 0.4, y: 0.25, width: 0.2, height: 0.5)
+    let line = OCRResult.Line(
+      boundingBoxNormalized: source,
+      text: "Text",
+      replacementPatches: [OverlaySourcePatch(box: source)]
+    )
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: [line]),
+      from: image
+    )
+    let surface = try #require(analyzed.lines.first?.surface)
+
+    #expect(surface.confidence > 0.5)
+    #expect(surface.box.width > 0.55)
+    #expect(surface.box.width < 0.85)
+    #expect(surface.box.contains(CGPoint(x: source.midX, y: source.midY)))
+    let clippingBox = try #require(surface.clippingBox)
+    #expect(clippingBox.contains(surface.box))
+    #expect(clippingBox.width > surface.box.width)
+    #expect(surface.cornerRadiusFraction == 0.35)
+  }
+
+  @Test
+  func framedDocumentIsNotTreatedAsOneTextSurface() throws {
+    let image = try makeFramedDocumentImage()
+    let source = CGRect(x: 0.3, y: 0.04, width: 0.4, height: 0.08)
+    let line = OCRResult.Line(
+      boundingBoxNormalized: source,
+      text: "Document title",
+      replacementPatches: [OverlaySourcePatch(box: source)]
+    )
+
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: [line]),
+      from: image
+    )
+
+    #expect(analyzed.lines.first?.surface == nil)
+  }
+
+  @Test
+  func extendsVerticalRestorationOnlyToNearbyMissedInk() throws {
+    let image = try makeVerticalMissedGlyphImage()
+    let source = CGRect(x: 0.44, y: 0.35, width: 0.12, height: 0.25)
+    let line = OCRResult.Line(
+      boundingBoxNormalized: source,
+      text: "ています",
+      isVerticalBlock: true,
+      verticalCharScale: 0.12,
+      replacementPatches: [OverlaySourcePatch(box: source)]
+    )
+
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: [line]),
+      from: image
+    )
+    let patch = try #require(analyzed.lines.first?.replacementPatches.first)
+    let surface = try #require(analyzed.lines.first?.surface)
+
+    #expect(patch.box.minY < source.minY)
+    #expect(patch.box.maxY > source.maxY)
+    #expect(surface.box.contains(patch.box))
+  }
+
+  @Test
+  func restoresChromaticRubyWithoutCrossingTheBorderAboveIt() throws {
+    let image = try makeChromaticRubyImage()
+    let source = CGRect(x: 0.25, y: 0.55, width: 0.5, height: 0.22)
+    let line = OCRResult.Line(
+      boundingBoxNormalized: source,
+      text: "ナイフ型石器",
+      horizontalGlyphScale: source.height,
+      replacementPatches: [OverlaySourcePatch(box: source)]
+    )
+
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: [line]),
+      from: image
+    )
+    let patches = try #require(analyzed.lines.first?.replacementPatches)
+    let ruby = try #require(patches.first { $0.box.minY < source.minY })
+
+    #expect(ruby.box.minY > 0.44)
+    #expect(ruby.box.maxY <= source.minY)
+  }
+
+  // MARK: Private
+
+  private func sourceResult() -> OCRResult {
+    let patch = CGRect(x: 0.32, y: 0.18, width: 0.36, height: 0.64)
+    return OCRResult(lines: [
+      OCRResult.Line(
+        boundingBoxNormalized: patch,
+        text: "Text",
+        replacementPatches: [OverlaySourcePatch(box: patch)]
+      )
+    ])
+  }
+
+  private func makeImage(
+    background: CGColor,
+    glyph: CGColor?,
+    glyphWidth: CGFloat = 12
+  ) throws -> CGImage {
+    let width = 100
+    let height = 100
+    let context = try #require(CGContext(
+      data: nil,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(background)
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    if let glyph {
+      context.setFillColor(glyph)
+      context.fill(CGRect(x: 50 - glyphWidth / 2, y: 24, width: glyphWidth, height: 52))
+    }
+    return try #require(context.makeImage())
+  }
+
+  private func makeBubbleImage() throws -> CGImage {
+    let context = try #require(CGContext(
+      data: nil,
+      width: 200,
+      height: 200,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(gray: 0.45, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 200, height: 200))
+    context.setFillColor(CGColor(gray: 0.98, alpha: 1))
+    context.fillEllipse(in: CGRect(x: 20, y: 12, width: 160, height: 176))
+    context.setStrokeColor(CGColor(gray: 0.02, alpha: 1))
+    context.setLineWidth(4)
+    context.strokeEllipse(in: CGRect(x: 20, y: 12, width: 160, height: 176))
+    context.setFillColor(CGColor(gray: 0.02, alpha: 1))
+    context.fill(CGRect(x: 91, y: 58, width: 18, height: 84))
+    return try #require(context.makeImage())
+  }
+
+  private func makeRepositoryMetadataImage() throws -> CGImage {
+    let context = try #require(CGContext(
+      data: nil,
+      width: 200,
+      height: 100,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(red: 0.04, green: 0.06, blue: 0.08, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 200, height: 100))
+    context.setFillColor(CGColor(red: 0.98, green: 0.30, blue: 0.22, alpha: 1))
+    context.fillEllipse(in: CGRect(x: 22, y: 42, width: 12, height: 12))
+    context.setFillColor(CGColor(red: 0.58, green: 0.60, blue: 0.64, alpha: 1))
+    for x in stride(from: 52, through: 142, by: 18) {
+      context.fill(CGRect(x: x, y: 34, width: 10, height: 32))
+    }
+    return try #require(context.makeImage())
+  }
+
+  private func makeFramedDocumentImage() throws -> CGImage {
+    let context = try #require(CGContext(
+      data: nil,
+      width: 200,
+      height: 200,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(gray: 0.05, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 200, height: 200))
+    context.setFillColor(CGColor(gray: 0.98, alpha: 1))
+    context.fill(CGRect(x: 3, y: 3, width: 194, height: 194))
+    context.setFillColor(CGColor(gray: 0.05, alpha: 1))
+    context.fill(CGRect(x: 60, y: 174, width: 80, height: 10))
+    return try #require(context.makeImage())
+  }
+
+  private func makeVerticalMissedGlyphImage() throws -> CGImage {
+    let width = 200
+    let height = 240
+    let context = try #require(CGContext(
+      data: nil,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(gray: 0.45, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    context.setFillColor(CGColor(gray: 0.98, alpha: 1))
+    context.fillEllipse(in: CGRect(x: 28, y: 16, width: 144, height: 208))
+    context.setStrokeColor(CGColor(gray: 0.02, alpha: 1))
+    context.setLineWidth(4)
+    context.strokeEllipse(in: CGRect(x: 28, y: 16, width: 144, height: 208))
+    context.setFillColor(CGColor(gray: 0.02, alpha: 1))
+    context.fill(CGRect(x: 94, y: 96, width: 12, height: 48))
+    context.fill(CGRect(x: 94, y: 70, width: 12, height: 16))
+    context.fill(CGRect(x: 94, y: 154, width: 12, height: 16))
+    return try #require(context.makeImage())
+  }
+
+  private func makeChromaticRubyImage() throws -> CGImage {
+    let width = 200
+    let height = 140
+    let context = try #require(CGContext(
+      data: nil,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.translateBy(x: 0, y: CGFloat(height))
+    context.scaleBy(x: 1, y: -1)
+    context.setFillColor(CGColor(gray: 0.98, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    context.setFillColor(CGColor(gray: 0.2, alpha: 1))
+    context.fill(CGRect(x: 48, y: 67, width: 104, height: 2))
+    context.setFillColor(CGColor(red: 0.88, green: 0.40, blue: 0.20, alpha: 1))
+    context.fill(CGRect(x: 58, y: 78, width: 84, height: 25))
+    for x in stride(from: 72, through: 128, by: 14) {
+      context.fill(CGRect(x: x, y: 72, width: 7, height: 4))
+    }
+    return try #require(context.makeImage())
+  }
+
+  private func makeSplitBackgroundImage() throws -> CGImage {
+    let context = try #require(CGContext(
+      data: nil,
+      width: 100,
+      height: 100,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(gray: 0.08, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 50, height: 100))
+    context.setFillColor(CGColor(gray: 0.35, alpha: 1))
+    context.fill(CGRect(x: 50, y: 0, width: 50, height: 100))
+    return try #require(context.makeImage())
+  }
+
+  private func makeInlineCodeImage() throws -> CGImage {
+    let context = try #require(CGContext(
+      data: nil,
+      width: 200,
+      height: 100,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(red: 0.04, green: 0.055, blue: 0.07, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 200, height: 100))
+    context.setFillColor(CGColor(red: 0.14, green: 0.16, blue: 0.19, alpha: 1))
+    context.fill(CGRect(x: 38, y: 33, width: 124, height: 34))
+    context.setFillColor(CGColor(gray: 0.92, alpha: 1))
+    for x in stride(from: 52, through: 146, by: 8) {
+      context.fill(CGRect(x: x, y: 41, width: 3, height: 18))
+    }
+    return try #require(context.makeImage())
+  }
+
+  private func makeStandaloneBadgeImage() throws -> CGImage {
+    let context = try #require(CGContext(
+      data: nil,
+      width: 200,
+      height: 100,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(gray: 0.98, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 200, height: 100))
+    context.setFillColor(CGColor(red: 0.58, green: 0.48, blue: 0.92, alpha: 1))
+    context.fill(CGRect(x: 58, y: 33, width: 84, height: 34))
+    context.setFillColor(CGColor(gray: 0.12, alpha: 1))
+    for x in stride(from: 68, through: 128, by: 8) {
+      context.fill(CGRect(x: x, y: 41, width: 3, height: 18))
+    }
+    return try #require(context.makeImage())
+  }
+
+  private func makeHighContrastInlineCodeImage() throws -> CGImage {
+    let context = try #require(CGContext(
+      data: nil,
+      width: 200,
+      height: 100,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(red: 0.07, green: 0.08, blue: 0.10, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 200, height: 100))
+    context.setFillColor(CGColor(red: 0.92, green: 0.93, blue: 0.95, alpha: 1))
+    context.fill(CGRect(x: 40, y: 34, width: 120, height: 32))
+    context.setFillColor(CGColor(red: 0.20, green: 0.22, blue: 0.26, alpha: 1))
+    for x in stride(from: 54, through: 144, by: 9) {
+      context.fill(CGRect(x: x, y: 42, width: 3, height: 16))
+    }
+    return try #require(context.makeImage())
+  }
+}

--- a/Tests/OverlaySourceAppearanceAnalyzerTests.swift
+++ b/Tests/OverlaySourceAppearanceAnalyzerTests.swift
@@ -12,12 +12,12 @@ struct OverlaySourceAppearanceAnalyzerTests {
   // MARK: Internal
 
   @Test
-  func findsLightBackgroundAndDarkForegroundAroundGlyphs() throws {
+  func findsLightBackgroundAndDarkForegroundAroundGlyphs() async throws {
     let image = try makeImage(
       background: CGColor(gray: 0.94, alpha: 1),
       glyph: CGColor(gray: 0.04, alpha: 1)
     )
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: sourceResult(),
       from: image
     )
@@ -31,12 +31,12 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func findsDarkBackgroundAndLightForegroundAroundGlyphs() throws {
+  func findsDarkBackgroundAndLightForegroundAroundGlyphs() async throws {
     let image = try makeImage(
       background: CGColor(gray: 0.06, alpha: 1),
       glyph: CGColor(gray: 0.96, alpha: 1)
     )
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: sourceResult(),
       from: image
     )
@@ -48,12 +48,12 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func preservesColoredSourceGlyphs() throws {
+  func preservesColoredSourceGlyphs() async throws {
     let image = try makeImage(
       background: CGColor(gray: 0, alpha: 1),
       glyph: CGColor(red: 0.05, green: 0.52, blue: 1, alpha: 1)
     )
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: sourceResult(),
       from: image
     )
@@ -64,7 +64,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func shortColoredBulletDoesNotBecomeTheLineForeground() throws {
+  func shortColoredBulletDoesNotBecomeTheLineForeground() async throws {
     let image = try makeRepositoryMetadataImage()
     let text = "• Swift"
     let bulletBox = CGRect(x: 0.10, y: 0.30, width: 0.08, height: 0.40)
@@ -82,7 +82,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       ]
     )
 
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: [line]),
       from: image
     )
@@ -94,7 +94,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func thickerGlyphCoverageProducesHeavierWeight() throws {
+  func thickerGlyphCoverageProducesHeavierWeight() async throws {
     let thin = try makeImage(
       background: CGColor(gray: 0, alpha: 1),
       glyph: CGColor(gray: 1, alpha: 1),
@@ -105,11 +105,11 @@ struct OverlaySourceAppearanceAnalyzerTests {
       glyph: CGColor(gray: 1, alpha: 1),
       glyphWidth: 20
     )
-    let thinAppearance = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let thinAppearance = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: sourceResult(),
       from: thin
     ).lines[0].appearance
-    let thickAppearance = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let thickAppearance = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: sourceResult(),
       from: thick
     ).lines[0].appearance
@@ -119,7 +119,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func consolidatesWordPatchesOnOneFlatBackground() throws {
+  func consolidatesWordPatchesOnOneFlatBackground() async throws {
     let image = try makeImage(background: CGColor(gray: 0.1, alpha: 1), glyph: nil)
     let line = OCRResult.Line(
       boundingBoxNormalized: CGRect(x: 0.2, y: 0.3, width: 0.6, height: 0.4),
@@ -130,7 +130,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       ]
     )
 
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: [line]),
       from: image
     )
@@ -140,7 +140,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func keepsWordPatchesWhenAControlCrossesDifferentBackgrounds() throws {
+  func keepsWordPatchesWhenAControlCrossesDifferentBackgrounds() async throws {
     let image = try makeSplitBackgroundImage()
     let patches = [
       OverlaySourcePatch(box: CGRect(x: 0.12, y: 0.35, width: 0.22, height: 0.3)),
@@ -152,7 +152,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       replacementPatches: patches
     )
 
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: [line]),
       from: image
     )
@@ -161,7 +161,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func samplesInlineCodeSurfaceInsideLongWordBox() throws {
+  func samplesInlineCodeSurfaceInsideLongWordBox() async throws {
     let image = try makeInlineCodeImage()
     let text = ".github/instructions/*.instructions.md"
     let source = CGRect(x: 0.25, y: 0.39, width: 0.5, height: 0.22)
@@ -177,7 +177,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       ]
     )
 
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: [line]),
       from: image
     )
@@ -192,7 +192,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func highContrastCompactFillIsBackgroundRatherThanUnderlineInk() throws {
+  func highContrastCompactFillIsBackgroundRatherThanUnderlineInk() async throws {
     let image = try makeHighContrastInlineCodeImage()
     let text = "build 2.10.0"
     let source = CGRect(x: 0.2, y: 0.34, width: 0.6, height: 0.32)
@@ -208,7 +208,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       ]
     )
 
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: [line]),
       from: image
     )
@@ -220,7 +220,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func embeddedInlineCodeErasesItsOldSurfaceToTheParentBackground() throws {
+  func embeddedInlineCodeErasesItsOldSurfaceToTheParentBackground() async throws {
     let image = try makeInlineCodeImage()
     let code = ".github/instructions/*.instructions.md"
     let text = "Run \(code) now"
@@ -238,7 +238,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       ]
     )
 
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: [line]),
       from: image
     )
@@ -256,7 +256,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func separatelyRecognizedInlineCodeIsReclassifiedAfterRowCoalescing() throws {
+  func separatelyRecognizedInlineCodeIsReclassifiedAfterRowCoalescing() async throws {
     let image = try makeInlineCodeImage()
     let code = ".github/instructions/*.instructions.md"
     let leftBox = CGRect(x: 0.05, y: 0.39, width: 0.15, height: 0.22)
@@ -288,7 +288,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       ),
     ]
 
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: lines),
       from: image
     )
@@ -301,7 +301,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func hyphenatedStandaloneBadgeKeepsItsOwnSurface() throws {
+  func hyphenatedStandaloneBadgeKeepsItsOwnSurface() async throws {
     let image = try makeStandaloneBadgeImage()
     let text = "On-device"
     let lineBox = CGRect(x: 0.31, y: 0.39, width: 0.38, height: 0.22)
@@ -320,7 +320,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       ]
     )
 
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: [line]),
       from: image
     )
@@ -331,7 +331,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func compactSurfaceIgnoresParentColorLeakingIntoOCRBox() throws {
+  func compactSurfaceIgnoresParentColorLeakingIntoOCRBox() async throws {
     let image = try makeLeakingBadgeImage()
     let source = CGRect(x: 0.29, y: 0.38, width: 0.42, height: 0.32)
     let line = OCRResult.Line(
@@ -347,7 +347,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       ]
     )
 
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: [line]),
       from: image
     )
@@ -361,7 +361,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func clampsSamplingAtImageEdges() throws {
+  func clampsSamplingAtImageEdges() async throws {
     let image = try makeImage(
       background: CGColor(red: 0.18, green: 0.65, blue: 0.42, alpha: 1),
       glyph: nil
@@ -371,7 +371,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       text: "edge",
       replacementPatches: [OverlaySourcePatch(box: CGRect(x: 0.96, y: 0.96, width: 0.08, height: 0.08))]
     )
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: [line]),
       from: image
     )
@@ -382,7 +382,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func findsClosedFlatSurfaceAroundSourceText() throws {
+  func findsClosedFlatSurfaceAroundSourceText() async throws {
     let image = try makeBubbleImage()
     let source = CGRect(x: 0.4, y: 0.25, width: 0.2, height: 0.5)
     let line = OCRResult.Line(
@@ -390,7 +390,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       text: "Text",
       replacementPatches: [OverlaySourcePatch(box: source)]
     )
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: [line]),
       from: image
     )
@@ -407,7 +407,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func framedDocumentIsNotTreatedAsOneTextSurface() throws {
+  func framedDocumentIsNotTreatedAsOneTextSurface() async throws {
     let image = try makeFramedDocumentImage()
     let source = CGRect(x: 0.3, y: 0.04, width: 0.4, height: 0.08)
     let line = OCRResult.Line(
@@ -416,7 +416,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       replacementPatches: [OverlaySourcePatch(box: source)]
     )
 
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: [line]),
       from: image
     )
@@ -425,7 +425,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func extendsVerticalRestorationOnlyToNearbyMissedInk() throws {
+  func extendsVerticalRestorationOnlyToNearbyMissedInk() async throws {
     let image = try makeVerticalMissedGlyphImage()
     let source = CGRect(x: 0.44, y: 0.35, width: 0.12, height: 0.25)
     let line = OCRResult.Line(
@@ -436,7 +436,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       replacementPatches: [OverlaySourcePatch(box: source)]
     )
 
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: [line]),
       from: image
     )
@@ -449,7 +449,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
-  func restoresChromaticRubyWithoutCrossingTheBorderAboveIt() throws {
+  func restoresChromaticRubyWithoutCrossingTheBorderAboveIt() async throws {
     let image = try makeChromaticRubyImage()
     let source = CGRect(x: 0.25, y: 0.55, width: 0.5, height: 0.22)
     let line = OCRResult.Line(
@@ -459,7 +459,7 @@ struct OverlaySourceAppearanceAnalyzerTests {
       replacementPatches: [OverlaySourcePatch(box: source)]
     )
 
-    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+    let analyzed = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
       to: OCRResult(lines: [line]),
       from: image
     )

--- a/Tests/OverlaySourceAppearanceAnalyzerTests.swift
+++ b/Tests/OverlaySourceAppearanceAnalyzerTests.swift
@@ -331,6 +331,36 @@ struct OverlaySourceAppearanceAnalyzerTests {
   }
 
   @Test
+  func compactSurfaceIgnoresParentColorLeakingIntoOCRBox() throws {
+    let image = try makeLeakingBadgeImage()
+    let source = CGRect(x: 0.29, y: 0.38, width: 0.42, height: 0.32)
+    let line = OCRResult.Line(
+      boundingBoxNormalized: source,
+      text: "High-fidelity",
+      horizontalGlyphScale: source.height,
+      replacementPatches: [OverlaySourcePatch(box: source)],
+      styleRuns: [
+        OverlaySourceStyleRun(
+          range: NSRange(location: 0, length: ("High-fidelity" as NSString).length),
+          box: source
+        )
+      ]
+    )
+
+    let analyzed = OverlaySourceAppearanceAnalyzer.applyingAppearances(
+      to: OCRResult(lines: [line]),
+      from: image
+    )
+    let analyzedLine = try #require(analyzed.lines.first)
+
+    #expect(analyzedLine.surface != nil)
+    #expect(analyzedLine.appearance.background.red > 0.85)
+    #expect(analyzedLine.appearance.foreground.red > 0.3)
+    #expect(analyzedLine.appearance.foreground.blue > 0.6)
+    #expect(analyzedLine.horizontalInkScale > 0.05)
+  }
+
+  @Test
   func clampsSamplingAtImageEdges() throws {
     let image = try makeImage(
       background: CGColor(red: 0.18, green: 0.65, blue: 0.42, alpha: 1),
@@ -647,6 +677,33 @@ struct OverlaySourceAppearanceAnalyzerTests {
     context.setFillColor(CGColor(gray: 0.12, alpha: 1))
     for x in stride(from: 68, through: 128, by: 8) {
       context.fill(CGRect(x: x, y: 41, width: 3, height: 18))
+    }
+    return try #require(context.makeImage())
+  }
+
+  private func makeLeakingBadgeImage() throws -> CGImage {
+    let context = try #require(CGContext(
+      data: nil,
+      width: 240,
+      height: 120,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(red: 0.09, green: 0.095, blue: 0.11, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 240, height: 120))
+    context.setFillColor(CGColor(red: 0.93, green: 0.90, blue: 1, alpha: 1))
+    context.addPath(CGPath(
+      roundedRect: CGRect(x: 45, y: 42, width: 150, height: 36),
+      cornerWidth: 18,
+      cornerHeight: 18,
+      transform: nil
+    ))
+    context.fillPath()
+    context.setFillColor(CGColor(red: 0.45, green: 0.28, blue: 0.76, alpha: 1))
+    for x in stride(from: 76, through: 164, by: 8) {
+      context.fill(CGRect(x: x, y: 51, width: 4, height: 18))
     }
     return try #require(context.makeImage())
   }

--- a/Tests/OverlayTextFlowTests.swift
+++ b/Tests/OverlayTextFlowTests.swift
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Foundation
+import Testing
+@testable import SwiftyCrow
+
+// MARK: - OverlayTextFlowTests
+
+@Suite("Overlay text flow")
+struct OverlayTextFlowTests {
+
+  // MARK: Internal
+
+  struct TranslationCase: Sendable, CustomTestStringConvertible {
+    let name: String
+    let sourceIsVertical: Bool
+    let target: String
+    let text: String
+    let expected: OverlayTextFlow
+
+    var testDescription: String {
+      name
+    }
+  }
+
+  struct WrittenLanguageCase: Sendable, CustomTestStringConvertible {
+    let lhs: String
+    let rhs: String
+    let expected: Bool
+
+    var testDescription: String {
+      "\(lhs) and \(rhs)"
+    }
+  }
+
+  @Test(arguments: [
+    TranslationCase(
+      name: "vertical Japanese to English",
+      sourceIsVertical: true,
+      target: "en-US",
+      text: "I have something important to tell you today.",
+      expected: .horizontal(.leftToRight)
+    ),
+    TranslationCase(
+      name: "vertical Japanese to Arabic",
+      sourceIsVertical: true,
+      target: "ar",
+      text: "لدي شيء مهم لأخبرك به",
+      expected: .horizontal(.rightToLeft)
+    ),
+    TranslationCase(
+      name: "vertical Japanese to Hebrew",
+      sourceIsVertical: true,
+      target: "he",
+      text: "יש לי משהו חשוב לומר לך",
+      expected: .horizontal(.rightToLeft)
+    ),
+    TranslationCase(
+      name: "vertical Japanese stays vertical",
+      sourceIsVertical: true,
+      target: "ja",
+      text: "今日は大切な話があります",
+      expected: .vertical(.rightToLeft)
+    ),
+    TranslationCase(
+      name: "vertical Simplified Chinese stays vertical",
+      sourceIsVertical: true,
+      target: "zh-Hans",
+      text: "今天有重要的事情告诉你",
+      expected: .vertical(.rightToLeft)
+    ),
+    TranslationCase(
+      name: "vertical Korean stays vertical",
+      sourceIsVertical: true,
+      target: "ko",
+      text: "오늘 중요한 이야기가 있어요",
+      expected: .vertical(.rightToLeft)
+    ),
+    TranslationCase(
+      name: "CJK dominant mixed script stays vertical",
+      sourceIsVertical: true,
+      target: "ja",
+      text: "OKなら今すぐ始めよう",
+      expected: .vertical(.rightToLeft)
+    ),
+    TranslationCase(
+      name: "Latin dominant mixed script becomes horizontal",
+      sourceIsVertical: true,
+      target: "en-US",
+      text: "Meet ゆきえ at the station",
+      expected: .horizontal(.leftToRight)
+    ),
+    TranslationCase(
+      name: "mixed script tie follows English target",
+      sourceIsVertical: true,
+      target: "en-US",
+      text: "AB世界",
+      expected: .horizontal(.leftToRight)
+    ),
+    TranslationCase(
+      name: "mixed script tie follows Japanese target",
+      sourceIsVertical: true,
+      target: "ja",
+      text: "AB世界",
+      expected: .vertical(.rightToLeft)
+    ),
+    TranslationCase(
+      name: "actual Japanese output overrides English metadata",
+      sourceIsVertical: true,
+      target: "en-US",
+      text: "今日は晴れです",
+      expected: .vertical(.rightToLeft)
+    ),
+    TranslationCase(
+      name: "actual Latin output overrides Japanese metadata",
+      sourceIsVertical: true,
+      target: "ja",
+      text: "SwiftyCrow",
+      expected: .horizontal(.leftToRight)
+    ),
+    TranslationCase(
+      name: "Japanese punctuation falls back to target script",
+      sourceIsVertical: true,
+      target: "ja",
+      text: "！？……",
+      expected: .vertical(.rightToLeft)
+    ),
+    TranslationCase(
+      name: "Japanese digits fall back to target script",
+      sourceIsVertical: true,
+      target: "ja",
+      text: "2026",
+      expected: .vertical(.rightToLeft)
+    ),
+    TranslationCase(
+      name: "English digits fall back to target script",
+      sourceIsVertical: true,
+      target: "en-US",
+      text: "2026",
+      expected: .horizontal(.leftToRight)
+    ),
+    TranslationCase(
+      name: "Mongolian columns advance left to right",
+      sourceIsVertical: true,
+      target: "mn-Mong",
+      text: "ᠮᠣᠩᠭᠣᠯ",
+      expected: .vertical(.leftToRight)
+    ),
+    TranslationCase(
+      name: "horizontal Japanese source remains horizontal",
+      sourceIsVertical: false,
+      target: "ja",
+      text: "今日は晴れです",
+      expected: .horizontal(.leftToRight)
+    ),
+  ])
+  func resolvesFromDisplayedString(_ testCase: TranslationCase) {
+    var line = makeLine(vertical: testCase.sourceIsVertical, initialContent: .pending)
+    line.showTranslation(
+      testCase.text,
+      language: Locale.Language(identifier: testCase.target)
+    )
+    #expect(line.textFlow == testCase.expected)
+    #expect(line.displayedText == testCase.text)
+  }
+
+  @Test
+  func pendingAndUnavailableContentPreserveSourceFlow() {
+    var line = makeLine(vertical: true, initialContent: .pending)
+    #expect(line.textFlow == .vertical(.rightToLeft))
+    #expect(line.displayedText == line.source.text)
+    #expect(line.isPending)
+
+    line.showUnavailable()
+    #expect(line.textFlow == .vertical(.rightToLeft))
+    #expect(line.displayedText == line.source.text)
+    #expect(line.isUnavailable)
+  }
+
+  @Test
+  func completedTranslationDoesNotLeakIntoFreshLiveTick() {
+    let id = UUID(0)
+    var previous = makeLine(id: id, vertical: true, initialContent: .pending)
+    previous.showTranslation("Previous result", language: Locale.Language(identifier: "en-US"))
+
+    let next = makeLine(id: previous.id, vertical: true, initialContent: .pending)
+    #expect(next.id == previous.id)
+    #expect(next.translatedText == nil)
+    #expect(next.isPending)
+    #expect(next.textFlow == .vertical(.rightToLeft))
+  }
+
+  @Test
+  func blankTranslationBecomesExplicitFallback() {
+    var line = makeLine(vertical: true, initialContent: .pending)
+    line.showTranslation("  \n", language: Locale.Language(identifier: "en-US"))
+    #expect(line.isUnavailable)
+    #expect(line.displayedText == line.source.text)
+  }
+
+  @Test
+  func systemHorizontalTextPreferenceOverridesVerticalCapableTranslation() {
+    var line = makeLine(vertical: true, initialContent: .pending)
+    line.showTranslation("今日は晴れです", language: Locale.Language(identifier: "ja"))
+    #expect(line.textFlow == .vertical(.rightToLeft))
+    #expect(line.textFlow(prefersHorizontalTextLayout: true) == .horizontal(.leftToRight))
+  }
+
+  @Test(arguments: [
+    WrittenLanguageCase(lhs: "en-US", rhs: "en-GB", expected: true),
+    WrittenLanguageCase(lhs: "ja", rhs: "ja-JP", expected: true),
+    WrittenLanguageCase(lhs: "zh-Hans", rhs: "zh-Hant", expected: false),
+    WrittenLanguageCase(lhs: "sr-Cyrl", rhs: "sr-Latn", expected: false),
+    WrittenLanguageCase(lhs: "ko", rhs: "ja", expected: false),
+  ])
+  func comparesLanguageAndScriptButIgnoresRegion(_ testCase: WrittenLanguageCase) {
+    let lhs = Locale.Language(identifier: testCase.lhs)
+    let rhs = Locale.Language(identifier: testCase.rhs)
+    #expect(lhs.usesSameWritingSystem(as: rhs) == testCase.expected)
+  }
+
+  @Test
+  func findsOnlyShortTateChuYokoRuns() throws {
+    let text = "2026年8月27日 OK ABCDE"
+    let substrings = try CoreTextTypesetter.horizontalInVerticalRanges(in: text).map { range in
+      let swiftRange = try #require(Range(range, in: text))
+      return String(text[swiftRange])
+    }
+    #expect(substrings == ["2026", "8", "27", "OK"])
+  }
+
+  // MARK: Private
+
+  private func makeLine(
+    id: UUID = UUID(0),
+    vertical: Bool,
+    initialContent: OverlayLine.InitialContent
+  ) -> OverlayLine {
+    let recognized = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0.4, y: 0.2, width: vertical ? 0.08 : 0.4, height: 0.3),
+      text: "今日は大切な話があります",
+      rowCount: vertical ? 2 : 1,
+      isVerticalBlock: vertical,
+      verticalCharScale: vertical ? 0.035 : 0
+    )
+    return OverlayLine(
+      id: id,
+      source: OverlayLine.Source(
+        recognized: recognized,
+        language: Locale.Language(identifier: "ja")
+      ),
+      initialContent: initialContent
+    )
+  }
+}
+
+extension UUID {
+  fileprivate init(_ value: UInt8) {
+    self.init(uuid: (
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      value
+    ))
+  }
+}

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "c0a65910959c2c6910e52ff9f739675ee497c88fb8a3958d2c7864051f6fea3b",
   "pins" : [
     {
       "identity" : "combine-schedulers",

--- a/web/index.html
+++ b/web/index.html
@@ -40,7 +40,7 @@
     <p class="sub">Translate anything on your screen.<br />Entirely on your Mac.</p>
     <div class="cta">
       <a class="btn btn-primary download-link" href="https://github.com/PangMo5/SwiftyCrow/releases/download/v__VERSION__/SwiftyCrow-__VERSION__.dmg">Download for macOS</a>
-      <a class="btn btn-link source-link" href="https://github.com/PangMo5/SwiftyCrow/archive/refs/tags/v__VERSION__.tar.gz">Source code&nbsp;&rsaquo;</a>
+      <a class="btn btn-link" href="https://github.com/PangMo5/SwiftyCrow">View on GitHub&nbsp;&rsaquo;</a>
     </div>
     <div class="brew">
       <code id="brew-cmd">brew install --cask PangMo5/tap/swiftycrow</code>
@@ -210,7 +210,7 @@
     <div class="cta">
       <a class="btn btn-primary download-link" href="https://github.com/PangMo5/SwiftyCrow/releases/download/v__VERSION__/SwiftyCrow-__VERSION__.dmg">Download for macOS</a>
       <a class="btn btn-link" href="./releases.html">Release notes&nbsp;&rsaquo;</a>
-      <a class="btn btn-link source-link" href="https://github.com/PangMo5/SwiftyCrow/archive/refs/tags/v__VERSION__.tar.gz">Source code&nbsp;&rsaquo;</a>
+      <a class="btn btn-link" href="https://github.com/PangMo5/SwiftyCrow">View on GitHub&nbsp;&rsaquo;</a>
     </div>
     <div class="brew">
       <code id="brew-cmd-2">brew install --cask PangMo5/tap/swiftycrow</code>
@@ -252,10 +252,6 @@
       // Only trust an https github.com asset URL before rewriting the button.
       if (dmg && /^https:\/\/github\.com\//.test(dmg.browser_download_url)) {
         document.querySelectorAll("a.download-link").forEach((a) => { a.href = dmg.browser_download_url; });
-      }
-      if (/^v?\d+\.\d+\.\d+$/.test(rel.tag_name || "")) {
-        const sourceURL = "https://github.com/PangMo5/SwiftyCrow/archive/refs/tags/" + encodeURIComponent(rel.tag_name) + ".tar.gz";
-        document.querySelectorAll("a.source-link").forEach((a) => { a.href = sourceURL; });
       }
     } catch (e) { /* keep the static fallback */ }
   })();


### PR DESCRIPTION
## Summary

- Preserve source layout, line height, list boundaries, badges, and inline styles in translated overlays
- Improve overlay alignment, live refresh performance, and dragging behavior
- Rename the top and bottom source actions to `View on GitHub` and link them to the repository
- Remove release-time rewrites to source archive downloads

## Validation

- Web JavaScript syntax checked with `node --check`
- Verified exactly two GitHub CTAs and no remaining source archive rewrites
- `git diff --check` passed