### PR TITLE
perf(overlay): refresh from current frames with adaptive capture cadence

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For more details, see [docs/LANGUAGE_MODELS.md](docs/LANGUAGE_MODELS.md).
 ## Configuration
 
 Settings live in `~/.config/SwiftyCrow/config.toml`, grouped into tables that
-mirror the in-app Settings tabs: `[capture]`, `[languages]`, `[overlay]`,
+mirror the in-app Settings tabs: `[languages]`, `[overlay]`,
 `[shortcuts]`, `[translation]`, and `[updates]`. Edits made in the app or by
 hand are kept in sync.
 

--- a/Sources/App/AppFeature.swift
+++ b/Sources/App/AppFeature.swift
@@ -78,6 +78,10 @@ struct AppFeature {
                 await send(.capture(.toggleLiveRequested))
               case .close:
                 await send(.capture(.dismissOverlay))
+              case .sourceInteractionBegan:
+                await send(.capture(.sourceInteractionBegan))
+              case .sourceInteractionEnded:
+                await send(.capture(.sourceInteractionEnded))
               }
             }
           },

--- a/Sources/Capture/CaptureFeature.swift
+++ b/Sources/Capture/CaptureFeature.swift
@@ -16,6 +16,8 @@ struct CaptureFeature {
 
   enum CancelID {
     case live
+    case preparation
+    case recognition
     case translation
   }
 
@@ -32,11 +34,22 @@ struct CaptureFeature {
     var strategy: TranslationStrategy
     var target: String
     var text: String
+    var attributedText: AttributedString? = nil
   }
 
   struct TranslationRequestContext: Equatable, Sendable {
     var strategy: TranslationStrategy
     var target: String
+    var imageSize: CGSize
+    var sources: [UUID: OverlayLine.Source]
+
+    func matches(_ sources: [OverlayLine.Source], previous: [OverlayLine?], imageSize: CGSize) -> Bool {
+      guard self.imageSize == imageSize, self.sources.count == sources.count else { return false }
+      return sources.indices.allSatisfy { index in
+        guard let id = previous[index]?.id, let requested = self.sources[id] else { return false }
+        return sources[index].canReuseTranslation(relativeTo: requested, imageSize: imageSize)
+      }
+    }
   }
 
   @ObservableState
@@ -67,6 +80,12 @@ struct CaptureFeature {
     /// deliberately reused for visual stability, so identity alone cannot tell
     /// an old translation from the current request.
     var translationGeneration = 0
+    var captureGeneration = 0
+    var recognitionGeneration = 0
+    var lastFrameSignature: LiveFrame.Signature?
+    var recognitionSettings: LiveFrame.Settings?
+    var isSourceInteracting = false
+    var translationCacheOrder = [TranslationCacheKey]()
     var translationCache = [TranslationCacheKey: TranslatedText]()
     var translationRequestContext: TranslationRequestContext?
 
@@ -76,7 +95,11 @@ struct CaptureFeature {
 
   enum Action {
     case captureIsTakingLong
-    case captureResponse(Result<LiveCapture, any Error>)
+    case liveFrameResponse(generation: Int, frame: OverlayFrame, result: Result<LiveFrame, any Error>)
+    case liveCaptureResponse(generation: Int, frame: OverlayFrame, result: Result<LiveCapture, any Error>)
+    case sourceInteractionBegan
+    case sourceInteractionEnded
+    case translationFinished(generation: Int)
     case copyTranslationRequested
     case dismissOverlay
     case selectRegionRequested
@@ -102,6 +125,11 @@ struct CaptureFeature {
     Reduce { state, action in
       switch action {
       case .dismissOverlay:
+        state.captureGeneration += 1
+        state.recognitionGeneration += 1
+        state.lastFrameSignature = nil
+        state.recognitionSettings = nil
+        state.isSourceInteracting = false
         state.translationGeneration += 1
         state.overlayActive = false
         state.isLive = false
@@ -115,6 +143,8 @@ struct CaptureFeature {
         state.translationUnavailable = false
         return .merge(
           .cancel(id: CancelID.live),
+          .cancel(id: CancelID.recognition),
+          .cancel(id: CancelID.preparation),
           .cancel(id: CancelID.translation)
         )
 
@@ -144,29 +174,103 @@ struct CaptureFeature {
         state.overlayPlacementID += 1
         return .send(.setLive(true))
 
+      case .sourceInteractionBegan:
+        guard state.isLive, !state.isSourceInteracting else { return .none }
+        state.isSourceInteracting = true
+        state.captureGeneration += 1
+        state.recognitionGeneration += 1
+        state.lastFrameSignature = nil
+        state.recognitionSettings = nil
+        state.translationGeneration += 1
+        state.overlayLines = []
+        state.backdrop = nil
+        state.isCapturing = false
+        state.isTranslating = false
+        state.isPreparingRecognition = false
+        state.translationRequestContext = nil
+        return .merge(
+          .cancel(id: CancelID.live),
+          .cancel(id: CancelID.recognition),
+          .cancel(id: CancelID.preparation),
+          .cancel(id: CancelID.translation)
+        )
+
+      case .sourceInteractionEnded:
+        guard state.isSourceInteracting else { return .none }
+        state.isSourceInteracting = false
+        guard state.isLive, state.overlayActive else { return .none }
+        return .send(.setLive(true))
+
+      case .liveFrameResponse(let generation, let frame, let result):
+        guard
+          state.isLive, !state.isSourceInteracting,
+          generation == state.captureGeneration, frame == state.overlayFrame
+        else { return .none }
+        switch result {
+        case .failure(let error):
+          return captureFailed(error, into: &state)
+        case .success(let snapshot):
+          let settings = LiveFrame.Settings(state.settings)
+          // The capture loop never waits for OCR. Unchanged pixels retain the
+          // current recognition/translation, including an in-flight request.
+          guard snapshot.signature != state.lastFrameSignature || settings != state.recognitionSettings else {
+            return .none
+          }
+          state.lastFrameSignature = snapshot.signature
+          state.recognitionSettings = settings
+          state.recognitionGeneration += 1
+          state.translationGeneration += 1
+          state.translationRequestContext = nil
+          state.overlayLines = []
+          state.backdrop = nil
+          state.isTranslating = false
+          state.isCapturing = true
+          state.lastError = nil
+          let recognitionGeneration = state.recognitionGeneration
+          return .merge(
+            .cancel(id: CancelID.translation),
+            .run { [ocr, clock] send in
+              let result = await Result {
+                let recognized = try await withDeadline(CaptureDeadline.ocr, stage: .ocr, clock: clock) {
+                  try Task.checkCancellation()
+                  return try await ocr.recognizeText(snapshot.backdrop.image, settings.source)
+                }
+                try Task.checkCancellation()
+                return LiveCapture(
+                  backdrop: settings.mode == .window ? snapshot.backdrop : nil,
+                  imageSize: snapshot.imageSize,
+                  result: recognized
+                )
+              }
+              try Task.checkCancellation()
+              await send(.liveCaptureResponse(generation: recognitionGeneration, frame: frame, result: result))
+            }
+            .cancellable(id: CancelID.recognition, cancelInFlight: true)
+          )
+        }
+
+      case .liveCaptureResponse(let generation, let frame, let result):
+        guard
+          state.isLive, !state.isSourceInteracting,
+          generation == state.recognitionGeneration,
+          frame == state.overlayFrame,
+          state.recognitionSettings == LiveFrame.Settings(state.settings)
+        else { return .none }
+        // Validate and apply in the same reducer action. Forwarding an untagged
+        // response allowed a queued scroll/dismissal to invalidate it in between.
+        switch result {
+        case .success(let capture):
+          return captureSucceeded(capture, into: &state)
+        case .failure(let error):
+          return captureFailed(error, into: &state)
+        }
+
       case .captureIsTakingLong:
         // Only while this live session's very first capture is still outstanding;
         // isCapturing is cleared by the first response either way.
         guard state.isLive, state.isCapturing else { return .none }
         state.isPreparingRecognition = true
         return .none
-
-      case .captureResponse(.failure(let error)):
-        state.isCapturing = false
-        state.isPreparingRecognition = false
-        state.lastError = error.localizedDescription
-        if let screenError = error as? ScreenCaptureError, screenError == .permissionRequired {
-          state.isLive = false
-          return .cancel(id: CancelID.live)
-        }
-        return .none
-
-      case .captureResponse(.success(let capture)):
-        state.isCapturing = false
-        state.isPreparingRecognition = false
-        state.lastError = nil
-        state.imageSize = capture.imageSize
-        return applyOCRResult(capture, into: &state)
 
       case .copyTranslationRequested:
         let text = state.overlayLines
@@ -179,63 +283,59 @@ struct CaptureFeature {
           NSPasteboard.general.setString(text, forType: .string)
         }
 
-      case .setLive(let isLive):
-        if isLive, !state.overlayActive {
-          state.isLive = false
-          state.isCapturing = false
-          return .cancel(id: CancelID.live)
-        }
+      case .setLive(let requested):
+        let isLive = requested && state.overlayActive
+        state.captureGeneration += 1
+        state.recognitionGeneration += 1
+        state.lastFrameSignature = nil
+        state.recognitionSettings = nil
+        state.isSourceInteracting = false
         state.isLive = isLive
         state.isCapturing = isLive
+        state.lastError = nil
         // Toggling Live discards stale results so the overlay doesn't keep
         // showing the previous capture across the transition.
         state.overlayLines = []
+        state.backdrop = nil
         state.translationGeneration += 1
         state.isTranslating = false
         state.translationRequestContext = nil
         state.isPreparingRecognition = false
         state.translationUnavailable = false
         if isLive {
+          let generation = state.captureGeneration
           return .merge(
+            .cancel(id: CancelID.recognition),
             .cancel(id: CancelID.translation),
             .run { [clock] send in
               // If the first capture hasn't landed by now, say why instead of
               // leaving an empty frame with a spinner on it.
               try await clock.sleep(for: .seconds(2))
               await send(.captureIsTakingLong)
-            },
-            .run { [
-              ocr,
-              settings = state.$settings,
-              overlayFrame = state.$overlayFrame
-            ] send in
-              // Serialize the probe and first real recognition. Starting both
-              // against a cold Vision daemon made the first capture slower and
-              // could leave two expensive document requests competing.
-              await ocr.warmUp()
+            }
+            .cancellable(id: CancelID.preparation, cancelInFlight: true),
+            .run { [overlayFrame = state.$overlayFrame] send in
+              // OCR joins an existing warm-up itself. Don't run an additional
+              // probe on the critical path of every scroll/restart.
               let cadenceClock = ContinuousClock()
+              var cadence = LiveCaptureCadence()
               while !Task.isCancelled {
                 let tickStarted = cadenceClock.now
-                let snapshot = settings.wrappedValue
                 let frame = overlayFrame.wrappedValue
-                // Every stage inside runCapture is deadline-bounded, so a tick
-                // that stalls fails and the loop moves on to the next one. An
-                // unbounded tick used to park this loop for good: no retry, no
-                // error, and isCapturing left true — the overlay just spun.
+                // Capture has its own deadline. OCR runs in another effect,
+                // so even a cold Vision model cannot stop change detection.
                 let result = await Result {
-                  try await runCapture(
-                    settings: snapshot,
-                    overlayFrame: frame
-                  )
+                  try await captureFrame(overlayFrame: frame)
                 }
+                try Task.checkCancellation()
                 if case .failure(let error) = result {
                   Log.capture.error("Live tick failed: \(error.localizedDescription, privacy: .public)")
                 }
-                await send(.captureResponse(result))
+                await send(.liveFrameResponse(generation: generation, frame: frame, result: result))
                 let elapsed = tickStarted.duration(to: cadenceClock.now)
                 if
                   let delay = LiveCaptureCadence.remainingDelay(
-                    interval: .seconds(snapshot.capture.interval),
+                    interval: cadence.interval(after: try? result.get().signature),
                     elapsed: elapsed
                   )
                 {
@@ -246,7 +346,12 @@ struct CaptureFeature {
             .cancellable(id: CancelID.live, cancelInFlight: true)
           )
         } else {
-          return .merge(.cancel(id: CancelID.live), .cancel(id: CancelID.translation))
+          return .merge(
+            .cancel(id: CancelID.live),
+            .cancel(id: CancelID.recognition),
+            .cancel(id: CancelID.preparation),
+            .cancel(id: CancelID.translation)
+          )
         }
 
       case .toggleLiveRequested:
@@ -264,6 +369,11 @@ struct CaptureFeature {
           return .send(.dismissOverlay)
         }
         return .send(.overlayPlaced(state.overlayFrame.rect))
+
+      case .translationFinished(let generation):
+        guard generation == state.translationGeneration else { return .none }
+        state.translationRequestContext = nil
+        return .none
 
       case .translationUnavailable(let generation, let lineIDs, let message):
         guard generation == state.translationGeneration else { return .none }
@@ -298,10 +408,15 @@ struct CaptureFeature {
           text: text,
           attributedText: text == translation.text ? translation.attributedText : nil
         )
+        state.translationCacheOrder.removeAll { $0 == key }
+        state.translationCacheOrder.append(key)
         state.translationCache[key] = translation
+        if state.translationCacheOrder.count > 512 {
+          state.translationCache.removeValue(forKey: state.translationCacheOrder.removeFirst())
+        }
         if
           let index = state.overlayLines.firstIndex(where: { $0.id == lineID }),
-          state.overlayLines[index].isPending
+          state.overlayLines[index].isPending || state.overlayLines[index].translatedText == translation.text
         {
           state.overlayLines[index].showTranslation(
             translation.text,
@@ -310,9 +425,6 @@ struct CaptureFeature {
           )
         }
         state.isTranslating = state.overlayLines.contains(where: \.isPending)
-        if !state.isTranslating {
-          state.translationRequestContext = nil
-        }
         if !state.isTranslating, !state.overlayLines.contains(where: \.isUnavailable) {
           // Every requested line resolved, so a previous missing-model warning
           // is stale even if this live session started with a failed tick.
@@ -364,13 +476,15 @@ struct CaptureFeature {
       languages: lineSources,
       in: state.overlayLines
     )
-    let stableSources = result.lines.indices.map { index in
-      let source = OverlayLine.Source(
+    let rawSources = result.lines.indices.map { index in
+      OverlayLine.Source(
         recognized: result.lines[index],
         language: lineSources[index].localeLanguage
       )
-      guard let previous = previousMatches[index] else { return source }
-      return source.stabilized(relativeTo: previous.source, imageSize: capture.imageSize)
+    }
+    let stableSources = rawSources.indices.map { index in
+      guard let previous = previousMatches[index] else { return rawSources[index] }
+      return rawSources[index].stabilized(relativeTo: previous.source, imageSize: capture.imageSize)
     }
     let preservesSource = stableSources.indices.map {
       OverlayTranslationPolicy.preservesSource(at: $0, in: stableSources)
@@ -378,12 +492,11 @@ struct CaptureFeature {
     let sourceSetIsUnchanged = result.lines.count == state.overlayLines.count
       && previousMatches.allSatisfy { $0 != nil }
     if
-      state.isTranslating,
+      let context = state.translationRequestContext,
       sourceSetIsUnchanged,
-      state.translationRequestContext == TranslationRequestContext(
-        strategy: strategy,
-        target: targetLanguage.code
-      )
+      context.strategy == strategy,
+      context.target == targetLanguage.code,
+      context.matches(rawSources, previous: previousMatches, imageSize: capture.imageSize)
     {
       // Keep the in-flight batch alive. Replacing it every live tick meant a
       // batch slower than the capture interval could be cancelled and restarted
@@ -419,7 +532,8 @@ struct CaptureFeature {
         source: source.maximalIdentifier,
         strategy: strategy,
         target: targetLanguage.code,
-        text: translationLine.requestText
+        text: translationLine.requestText,
+        attributedText: translationLine.attributedText
       )
       let needsTranslation = !sameLanguage && !preservesSource[index]
       let cached = needsTranslation ? cache[key] : nil
@@ -459,7 +573,9 @@ struct CaptureFeature {
     let translationKeys = keys
     state.translationRequestContext = TranslationRequestContext(
       strategy: strategy,
-      target: targetLanguage.code
+      target: targetLanguage.code,
+      imageSize: capture.imageSize,
+      sources: Dictionary(uniqueKeysWithValues: zip(newLines, rawSources).map { ($0.id, $1) })
     )
     return Effect<Action>.run { send in
       // One session per source language; each response or explicit fallback
@@ -470,6 +586,7 @@ struct CaptureFeature {
             var remaining = Set(batch.items.map(\.id))
             do {
               for try await result in translation.translateBatch(batch.items, batch.source, target, strategy) {
+                try Task.checkCancellation()
                 remaining.remove(result.id)
                 if let key = translationKeys[result.id] {
                   await send(
@@ -488,7 +605,7 @@ struct CaptureFeature {
             } catch is CancellationError {
               return
             } catch {
-              guard !remaining.isEmpty else { return }
+              guard !Task.isCancelled, !remaining.isEmpty else { return }
               await send(
                 .translationUnavailable(
                   generation: generation,
@@ -498,12 +615,14 @@ struct CaptureFeature {
               )
               return
             }
-            if !remaining.isEmpty {
+            if !Task.isCancelled, !remaining.isEmpty {
               await send(.translationUnavailable(generation: generation, lineIDs: remaining, message: nil))
             }
           }
         }
       }
+      guard !Task.isCancelled else { return }
+      await send(.translationFinished(generation: generation))
     }
     .cancellable(id: CancelID.translation, cancelInFlight: true)
   }
@@ -536,16 +655,37 @@ struct CaptureFeature {
     }
   }
 
-  private func runCapture(
-    settings: AppSettings,
-    overlayFrame: OverlayFrame
-  ) async throws -> LiveCapture {
-    // The live overlay is always placed over a region while running. Exclude
-    // this process so the transparent overlay never becomes the next OCR input.
-    //
-    // Both stages are bounded separately so the log names whichever one stalled:
-    // ScreenCaptureKit and Vision each talk to a daemon that is cold on the first
-    // use after an idle period and can stop answering entirely.
+  private func captureSucceeded(_ capture: LiveCapture, into state: inout State) -> Effect<Action> {
+    state.isCapturing = false
+    state.isPreparingRecognition = false
+    state.lastError = nil
+    state.imageSize = capture.imageSize
+    return .merge(.cancel(id: CancelID.preparation), applyOCRResult(capture, into: &state))
+  }
+
+  private func captureFailed(_ error: any Error, into state: inout State) -> Effect<Action> {
+    state.recognitionGeneration += 1
+    state.lastFrameSignature = nil // Retry even when the next pixels are identical.
+    state.isCapturing = false
+    state.isPreparingRecognition = false
+    state.lastError = error.localizedDescription
+    state.translationGeneration += 1
+    state.translationRequestContext = nil
+    state.overlayLines = []
+    state.backdrop = nil
+    state.isTranslating = false
+    if error as? ScreenCaptureError == .permissionRequired {
+      state.isLive = false
+    }
+    return .merge(
+      .cancel(id: CancelID.preparation),
+      .cancel(id: CancelID.recognition),
+      .cancel(id: CancelID.translation),
+      state.isLive ? .none : .cancel(id: CancelID.live)
+    )
+  }
+
+  private func captureFrame(overlayFrame: OverlayFrame) async throws -> LiveFrame {
     let image = try await withDeadline(
       CaptureDeadline.screenCapture,
       stage: .screenCapture,
@@ -557,28 +697,43 @@ struct CaptureFeature {
         ProcessInfo.processInfo.processIdentifier
       )
     }
-    let result = try await withDeadline(CaptureDeadline.ocr, stage: .ocr, clock: clock) { [ocr] in
-      try await ocr.recognizeText(image, settings.languages.source)
-    }
-    // Window mode retains the immutable capture directly. Encoding every tick
-    // to PNG and decoding it again in SwiftUI added work and allocation churn
-    // precisely while the live overlay was trying to refresh.
-    let needsBackdrop = settings.overlay.liveMode == .window
-    return LiveCapture(
-      backdrop: needsBackdrop ? OverlayBackdrop(image: image) : nil,
-      imageSize: CGSize(width: image.width, height: image.height),
-      result: result
-    )
+    try Task.checkCancellation()
+    return try LiveFrame(image: image)
   }
 }
 
 // MARK: - LiveCaptureCadence
 
-enum LiveCaptureCadence {
-  /// Keeps the configured interval start-to-start. Processing time already
+struct LiveCaptureCadence {
+
+  // MARK: Internal
+
+  /// Keeps the adaptive interval start-to-start. Processing time already
   /// consumes part of the interval and must not be added to it again.
   static func remainingDelay(interval: Duration, elapsed: Duration) -> Duration? {
     guard elapsed < interval else { return nil }
     return interval - elapsed
   }
+
+  /// Rapidly follow an active screen, then avoid repeatedly waking the capture
+  /// daemon at that rate for a static page. Gestures bypass this delay by
+  /// restarting the loop. Errors back off without parking it permanently.
+  mutating func interval(after signature: LiveFrame.Signature?) -> Duration {
+    guard let signature else {
+      failures = min(3, failures + 1)
+      unchangedSamples = 0
+      return .milliseconds(500 * (1 << (failures - 1)))
+    }
+    failures = 0
+    unchangedSamples = signature == previousSignature ? min(3, unchangedSamples + 1) : 0
+    previousSignature = signature
+    return unchangedSamples >= 3 ? .milliseconds(500) : .milliseconds(150)
+  }
+
+  // MARK: Private
+
+  private var previousSignature: LiveFrame.Signature?
+  private var unchangedSamples = 0
+  private var failures = 0
+
 }

--- a/Sources/Capture/LiveFrame.swift
+++ b/Sources/Capture/LiveFrame.swift
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import CryptoKit
+import Foundation
+
+/// A captured frame can invalidate stale text before the much slower OCR stage
+/// finishes. Only the digest lives in reducer state; pixels belong to the OCR
+/// effect (and, in detached mode, the displayed backdrop).
+struct LiveFrame: Sendable {
+
+  // MARK: Lifecycle
+
+  init(image: CGImage) throws {
+    guard let data = image.dataProvider?.data else {
+      throw ScreenCaptureError.unreadableImage
+    }
+    // Hash actual pixels, excluding uninitialized row padding. Exact equality
+    // avoids missing small labels/scrolls that a thumbnail can erase.
+    let bytes = data as Data
+    let rowLength = (image.width * image.bitsPerPixel + 7) / 8
+    guard rowLength <= image.bytesPerRow, bytes.count >= image.bytesPerRow * image.height else {
+      throw ScreenCaptureError.unreadableImage
+    }
+    var hasher = SHA256()
+    for row in 0..<image.height {
+      let start = row * image.bytesPerRow
+      hasher.update(data: bytes[start..<(start + rowLength)])
+    }
+    signature = Signature(
+      digest: Data(hasher.finalize()),
+      width: image.width,
+      height: image.height,
+      bitsPerPixel: image.bitsPerPixel,
+      bitmapInfo: image.bitmapInfo.rawValue
+    )
+    backdrop = OverlayBackdrop(image: image)
+  }
+
+  // MARK: Internal
+
+  struct Signature: Equatable, Sendable {
+    var digest: Data
+    var width: Int
+    var height: Int
+    var bitsPerPixel: Int
+    var bitmapInfo: UInt32
+  }
+
+  struct Settings: Equatable, Sendable {
+    init(_ settings: AppSettings) {
+      source = settings.languages.source
+      target = settings.languages.target
+      strategy = settings.translation.strategy
+      mode = settings.overlay.liveMode
+    }
+
+    var source: Language
+    var target: Language
+    var strategy: TranslationStrategy
+    var mode: OverlayLiveMode
+  }
+
+  let backdrop: OverlayBackdrop
+  let signature: Signature
+
+  var imageSize: CGSize {
+    CGSize(width: signature.width, height: signature.height)
+  }
+}

--- a/Sources/Capture/RegionCaptureFeature.swift
+++ b/Sources/Capture/RegionCaptureFeature.swift
@@ -180,7 +180,7 @@ struct RegionCaptureFeature {
         }
         if
           let index = state.overlayLines.firstIndex(where: { $0.id == id }),
-          state.overlayLines[index].isPending
+          (state.overlayLines[index].isPending || state.overlayLines[index].translatedText == text)
         {
           state.overlayLines[index].showTranslation(
             text,

--- a/Sources/Dependencies/OCRClient.swift
+++ b/Sources/Dependencies/OCRClient.swift
@@ -26,6 +26,7 @@ extension OCRClient: DependencyKey {
       // A capture that starts while the proactive probe is loading the model
       // joins that work instead of issuing a second cold Vision request.
       await VisionWarmUp.shared.waitForInFlight()
+      try Task.checkCancellation()
       var request = RecognizeDocumentsRequest()
       if language.isAuto {
         request.textRecognitionOptions.automaticallyDetectLanguage = true
@@ -35,6 +36,7 @@ extension OCRClient: DependencyKey {
       let clock = ContinuousClock()
       let started = clock.now
       let observations = try await request.perform(on: image)
+      try Task.checkCancellation()
       // Always timed: a cold model load and a genuine stall look identical from
       // the UI, and the duration is the only thing that separates them.
       let elapsed = clock.now - started
@@ -147,6 +149,8 @@ extension OCRClient: DependencyKey {
           Log.ocr.debug(
             "Supplemental recognition added \(lines.count - previousCount, privacy: .public) lines in \((clock.now - supplementalStarted).loggedSeconds, privacy: .public)s"
           )
+        } catch is CancellationError {
+          throw CancellationError()
         } catch {
           // Document recognition remains a complete result on its own. Surface
           // the supplemental failure, but do not turn a successful capture into
@@ -156,11 +160,14 @@ extension OCRClient: DependencyKey {
           )
         }
       }
+      try Task.checkCancellation()
       let correctedLines: [OCRResult.Line]
       let languageCode = language.localeLanguage.languageCode?.identifier
       if language.isAuto || languageCode == "ja" {
         do {
           correctedLines = try await JapaneseRubyOCRCorrector.correcting(lines, in: image)
+        } catch is CancellationError {
+          throw CancellationError()
         } catch {
           Log.ocr.error(
             "Base-glyph OCR failed: \(error.localizedDescription, privacy: .public)"
@@ -170,10 +177,12 @@ extension OCRClient: DependencyKey {
       } else {
         correctedLines = lines
       }
+      try Task.checkCancellation()
       let result = await OverlaySourceAppearanceAnalyzer.applyingAppearances(
         to: OCRResult(lines: correctedLines).removingNestedDuplicates(),
         from: image
       ).coalescingParagraphFragments()
+      try Task.checkCancellation()
       let postProcessingElapsed = clock.now - postProcessingStarted
       Log.ocr.debug(
         "Post-processing produced \(result.lines.count, privacy: .public) lines in \(postProcessingElapsed.loggedSeconds, privacy: .public)s"

--- a/Sources/Dependencies/OverlayClient.swift
+++ b/Sources/Dependencies/OverlayClient.swift
@@ -53,6 +53,8 @@ struct OverlayRenderState: Equatable, Sendable {
 enum OverlayUserAction: Sendable {
   case toggleLive
   case close
+  case sourceInteractionBegan
+  case sourceInteractionEnded
 }
 
 // MARK: - OverlayClient

--- a/Sources/Dependencies/ScreenCaptureClient.swift
+++ b/Sources/Dependencies/ScreenCaptureClient.swift
@@ -33,7 +33,10 @@ enum ScreenCaptureError: Error, LocalizedError, Equatable {
   case emptyRegion
   case noDisplay
   case permissionRequired
+  case unreadableImage
   case windowUnavailable
+
+  // MARK: Internal
 
   var errorDescription: String? {
     switch self {
@@ -45,6 +48,8 @@ enum ScreenCaptureError: Error, LocalizedError, Equatable {
       "Screen Recording permission is required. Allow it in System Settings and restart the app."
     case .windowUnavailable:
       "That window is no longer available to capture."
+    case .unreadableImage:
+      "The captured image has no readable pixel data."
     }
   }
 }

--- a/Sources/Dependencies/TranslationClient.swift
+++ b/Sources/Dependencies/TranslationClient.swift
@@ -137,6 +137,7 @@ extension TranslationClient: DependencyKey {
           do {
             var styledTargets = [UUID: String]()
             for try await response in session.translate(batch: requests) {
+              try Task.checkCancellation()
               if !receivedFirstResponse {
                 receivedFirstResponse = true
                 let elapsed = clock.now - started
@@ -156,13 +157,18 @@ extension TranslationClient: DependencyKey {
                 translatedLabel,
                 source: sourceLine.text
               )
-              if #available(macOS 26.4, *), sourceLine.attributedText != nil {
-                styledTargets[id] = targetText
-                continue
+              var attributedTarget: AttributedString?
+              if #available(macOS 26.4, *), let attributedSource = sourceLine.attributedText {
+                let alignment = TranslationStyleMapper.align(source: attributedSource, target: targetText)
+                attributedTarget = alignment.target
+                if !alignment.unmatched.isEmpty { styledTargets[id] = targetText }
               }
+              // Text is usable now. Optional style-snippet translation must
+              // never hold an entire paragraph behind the rest of the batch.
               continuation.yield(TranslationLine(
                 id: id,
-                text: targetText
+                text: targetText,
+                attributedText: attributedTarget
               ))
             }
             if #available(macOS 26.4, *), !styledTargets.isEmpty {
@@ -237,6 +243,7 @@ extension TranslationClient: DependencyKey {
 
     if !snippetRequests.isEmpty {
       for try await response in session.translate(batch: snippetRequests) {
+        try Task.checkCancellation()
         guard
           let requestID = response.clientIdentifier.flatMap(UUID.init(uuidString:)),
           let owner = snippetOwners[requestID]

--- a/Sources/Models/AppSettings.swift
+++ b/Sources/Models/AppSettings.swift
@@ -14,7 +14,6 @@ struct AppSettings: Codable, Equatable, Sendable {
   init(from decoder: any Decoder) throws {
     let c = try decoder.container(keyedBy: CodingKeys.self)
     let d = AppSettings()
-    capture = try c.decodeIfPresent(CaptureSettings.self, forKey: .capture) ?? d.capture
     languages = try c.decodeIfPresent(LanguageSettings.self, forKey: .languages) ?? d.languages
     overlay = try c.decodeIfPresent(OverlaySettings.self, forKey: .overlay) ?? d.overlay
     shortcuts = try c.decodeIfPresent(ShortcutSettings.self, forKey: .shortcuts) ?? d.shortcuts
@@ -24,27 +23,12 @@ struct AppSettings: Codable, Equatable, Sendable {
 
   // MARK: Internal
 
-  var capture = CaptureSettings()
   var languages = LanguageSettings()
   var overlay = OverlaySettings()
   var shortcuts = ShortcutSettings()
   var translation = TranslationSettings()
   var updates = UpdateSettings()
 
-}
-
-// MARK: - CaptureSettings
-
-struct CaptureSettings: Codable, Equatable, Sendable {
-  init() { }
-
-  init(from decoder: any Decoder) throws {
-    let c = try decoder.container(keyedBy: CodingKeys.self)
-    let d = CaptureSettings()
-    interval = try c.decodeIfPresent(Double.self, forKey: .interval) ?? d.interval
-  }
-
-  var interval = 0.8
 }
 
 // MARK: - LanguageSettings
@@ -202,7 +186,6 @@ enum UpdateCheckInterval: String, Codable, Equatable, Sendable, CaseIterable, Id
     }
   }
 }
-
 
 // MARK: - TranslationStrategy
 

--- a/Sources/Models/OverlayLine.swift
+++ b/Sources/Models/OverlayLine.swift
@@ -115,8 +115,16 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
     /// Removes sub-pixel Vision noise without pinning text that genuinely moved.
     /// A live capture is normally the same static pixels every tick, but Vision's
     /// boxes can wander by a few capture pixels and make the replacement visibly
-    /// breathe. Small changes use a dead band, moderate changes are damped, and
-    /// a real layout/scroll jump is accepted immediately.
+    /// breathe. Keep typography stable for tiny recognition noise, but always
+    /// use current geometry: damped masks reveal the original glyphs on scroll.
+    func canReuseTranslation(relativeTo previous: Self, imageSize: CGSize) -> Bool {
+      text == previous.text
+        && language == previous.language
+        && Self.hasSameOrientation(layout, previous.layout)
+        && Self.centerDistance(box, previous.box, imageSize: imageSize) <= 12
+        && Self.maximumEdgeDelta(box, previous.box, imageSize: imageSize) <= 24
+    }
+
     func stabilized(relativeTo previous: Self, imageSize: CGSize) -> Self {
       guard
         text == previous.text,
@@ -124,25 +132,18 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
         Self.hasSameOrientation(layout, previous.layout),
         imageSize.width > 0,
         imageSize.height > 0,
-        Self.maximumEdgeDelta(box, previous.box, imageSize: imageSize) <= 24
+        Self.maximumEdgeDelta(box, previous.box, imageSize: imageSize) <= 4
       else { return self }
 
       var result = self
-      result.box = Self.stabilizedRect(box, previous.box, imageSize: imageSize)
       result.layout = previous.layout
       result.horizontalGlyphScale = previous.horizontalGlyphScale
       result.horizontalInkScale = previous.horizontalInkScale
       result.horizontalLineAdvanceScale = previous.horizontalLineAdvanceScale
       result.alignment = previous.alignment ?? alignment
-      result.replacementPatches = Self.stabilizedPatches(
-        replacementPatches,
-        previous.replacementPatches,
-        imageSize: imageSize
-      )
       result.styleRuns = Self.stabilizedStyleRuns(
         styleRuns,
-        previous.styleRuns,
-        imageSize: imageSize
+        previous.styleRuns
       )
 
       // Ink coverage sits close to the weight thresholds on anti-aliased UI
@@ -160,16 +161,8 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
         appearance.background,
         previous.appearance.background
       ) <= 0.04
-      switch (surface, previous.surface) {
-      case (.some(var current), .some(let previousSurface)):
-        current.box = Self.stabilizedRect(current.box, previousSurface.box, imageSize: imageSize)
-        result.surface = current
-
-      case (.none, .some(let previousSurface)) where backgroundMatchesPrevious:
+      if surface == nil, let previousSurface = previous.surface, backgroundMatchesPrevious {
         result.surface = previousSurface
-
-      default:
-        break
       }
       return result
     }
@@ -344,36 +337,13 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
       }
     }
 
-    private static func stabilizedPatches(
-      _ current: [OverlaySourcePatch],
-      _ previous: [OverlaySourcePatch],
-      imageSize: CGSize
-    ) -> [OverlaySourcePatch] {
-      guard current.count == previous.count else { return current }
-      var remaining = Array(previous.indices)
-      return current.map { patch in
-        guard
-          let match = remaining.min(by: {
-            centerDistance(patch.box, previous[$0].box, imageSize: imageSize)
-              < centerDistance(patch.box, previous[$1].box, imageSize: imageSize)
-          })
-        else { return patch }
-        remaining.removeAll { $0 == match }
-        var patch = patch
-        patch.box = stabilizedRect(patch.box, previous[match].box, imageSize: imageSize)
-        return patch
-      }
-    }
-
     private static func stabilizedStyleRuns(
       _ current: [OverlaySourceStyleRun],
-      _ previous: [OverlaySourceStyleRun],
-      imageSize: CGSize
+      _ previous: [OverlaySourceStyleRun]
     ) -> [OverlaySourceStyleRun] {
       current.map { run in
         guard let previous = previous.first(where: { $0.range == run.range }) else { return run }
         var result = run
-        result.box = stabilizedRect(run.box, previous.box, imageSize: imageSize)
         if
           colorDistance(run.appearance.background, previous.appearance.background) <= 0.04,
           colorDistance(run.appearance.foreground, previous.appearance.foreground) <= 0.08
@@ -384,19 +354,6 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
         }
         return result
       }
-    }
-
-    private static func stabilizedRect(_ current: CGRect, _ previous: CGRect, imageSize: CGSize) -> CGRect {
-      let delta = maximumEdgeDelta(current, previous, imageSize: imageSize)
-      guard delta <= 24 else { return current }
-      guard delta > 4 else { return previous }
-      let currentWeight: CGFloat = 0.35
-      return CGRect(
-        x: previous.minX + (current.minX - previous.minX) * currentWeight,
-        y: previous.minY + (current.minY - previous.minY) * currentWeight,
-        width: previous.width + (current.width - previous.width) * currentWeight,
-        height: previous.height + (current.height - previous.height) * currentWeight
-      )
     }
 
     private static func maximumEdgeDelta(_ lhs: CGRect, _ rhs: CGRect, imageSize: CGSize) -> CGFloat {

--- a/Sources/Overlay/OverlayWindowController.swift
+++ b/Sources/Overlay/OverlayWindowController.swift
@@ -32,7 +32,9 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
         // arrives (the user picked a new region/window). Otherwise the user's
         // own drag/resize is the source of truth and we leave the frame alone.
         if isNewWindow || state.placementID != lastPlacementID {
+          isPlacingWindow = true
           window.setFrame(overlayFrame.rect, display: true)
+          isPlacingWindow = false
           window.makeKeyAndOrderFront(nil)
         }
       }
@@ -62,23 +64,24 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
   }
 
   func windowDidMove(_: Notification) {
+    guard !isPlacingWindow else { return }
     scheduleFrameSave()
     markInteracting()
   }
 
   func windowDidResize(_: Notification) {
+    guard !isPlacingWindow else { return }
     scheduleFrameSave()
   }
 
   func windowWillStartLiveResize(_: Notification) {
     pendingInteractionReset?.cancel()
-    model.isInteracting = true
+    beginInteraction()
   }
 
   func windowDidEndLiveResize(_: Notification) {
     pendingInteractionReset?.cancel()
-    model.isInteracting = false
-    flushFrameSave()
+    endInteraction()
   }
 
   // MARK: Private
@@ -96,6 +99,7 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
   private var resizeEdgeMonitors = [Any]()
   private var pendingFrameSaveTask: Task<Void, Never>?
   private var pendingInteractionReset: Task<Void, Never>?
+  private var isPlacingWindow = false
   private var window: OverlayPanel?
   private var resultWindow: NSPanel?
   private var lastPlacementID = 0
@@ -131,6 +135,9 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
   /// model carries stale state into the next use. Both windows are cheap to
   /// rebuild on the next show, which also re-snaps them to the stored frame.
   private func teardownWindows() {
+    pendingInteractionReset?.cancel()
+    pendingInteractionReset = nil
+    model.isInteracting = false
     if window != nil { flushFrameSave() }
     window?.delegate = nil
     window?.orderOut(nil)
@@ -144,12 +151,29 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
   /// but long enough that the lines don't pop in/out mid-drag.
   private func markInteracting() {
     pendingInteractionReset?.cancel()
-    model.isInteracting = true
+    beginInteraction()
     pendingInteractionReset = Task { @MainActor [weak self] in
       try? await Task.sleep(for: .milliseconds(150))
       guard !Task.isCancelled, let self else { return }
-      model.isInteracting = false
+      endInteraction()
     }
+  }
+
+  private func beginInteraction() {
+    guard model.isLive, !model.isInteracting else { return }
+    // Hide synchronously with the event, before the reducer round trip.
+    model.isInteracting = true
+    eventHandler?(.sourceInteractionBegan)
+  }
+
+  private func endInteraction() {
+    guard model.isInteracting else { return }
+    flushFrameSave()
+    // Never reveal the pre-gesture snapshot while waiting for a fresh capture.
+    model.lines = []
+    model.backdrop = nil
+    model.isInteracting = false
+    eventHandler?(.sourceInteractionEnded)
   }
 
   private func scheduleFrameSave() {
@@ -228,14 +252,31 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
     // Global fires while events pass through to apps below (interior); local
     // fires while the window is interactive near an edge / on the handle.
     // Together they keep the cursor state current as it moves in and out.
-    let global = NSEvent.addGlobalMonitorForEvents(matching: [.mouseMoved, .leftMouseDragged]) { [weak self] _ in
-      MainActor.assumeIsolated { self?.updatePassThroughForCursor() }
+    let global = NSEvent.addGlobalMonitorForEvents(matching: [.mouseMoved, .leftMouseDragged, .scrollWheel]) { [weak self] event in
+      MainActor.assumeIsolated {
+        self?.updatePassThroughForCursor()
+        self?.sourceContentInteracted(event)
+      }
     }
-    let local = NSEvent.addLocalMonitorForEvents(matching: [.mouseMoved, .leftMouseDragged]) { [weak self] event in
-      MainActor.assumeIsolated { self?.updatePassThroughForCursor() }
+    let local = NSEvent.addLocalMonitorForEvents(matching: [.mouseMoved, .leftMouseDragged, .scrollWheel]) { [weak self] event in
+      MainActor.assumeIsolated {
+        self?.updatePassThroughForCursor()
+        if event.type == .scrollWheel { self?.sourceContentInteracted(event) }
+      }
       return event
     }
     resizeEdgeMonitors = [global, local].compactMap { $0 }
+  }
+
+  private func sourceContentInteracted(_ event: NSEvent) {
+    guard
+      model.isLive,
+      event.type == .scrollWheel || event.type == .leftMouseDragged,
+      window?.frame.contains(NSEvent.mouseLocation) == true
+    else { return }
+    // Includes trackpad momentum and scrollbar dragging. Coalesce the gesture
+    // into one cancellation and one immediate capture after it settles.
+    markInteracting()
   }
 
   private func stopResizeEdgeTracking() {
@@ -461,7 +502,7 @@ private struct LiveResultView: View {
 
   @ViewBuilder
   private var content: some View {
-    if let backdrop = model.backdrop {
+    if !model.isInteracting, let backdrop = model.backdrop {
       ZStack {
         LiveBackdropImage(backdrop: backdrop)
           .equatable()

--- a/Sources/Overlay/TranslationOverlayLayer.swift
+++ b/Sources/Overlay/TranslationOverlayLayer.swift
@@ -36,6 +36,7 @@ struct TranslationOverlayLayer: View {
         size: proxy.size,
         prefersHorizontalTextLayout: prefersHorizontalTextLayout
       )
+      .equatable()
     }
     .onReceive(
       NotificationCenter.default.publisher(
@@ -57,7 +58,7 @@ struct TranslationOverlayLayer: View {
 
 // MARK: - OverlayCanvas
 
-private struct OverlayCanvas: View {
+private struct OverlayCanvas: View, Equatable {
 
   // MARK: Internal
 
@@ -106,6 +107,11 @@ private struct OverlayCanvas: View {
     }
     .frame(width: size.width, height: size.height, alignment: .topLeading)
     .clipped()
+  }
+
+  static func ==(lhs: Self, rhs: Self) -> Bool {
+    lhs.lines == rhs.lines && lhs.size == rhs.size
+      && lhs.prefersHorizontalTextLayout == rhs.prefersHorizontalTextLayout
   }
 
   // MARK: Private

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -30,7 +30,6 @@ struct SettingsView: View {
         switch pane ?? .general {
         case .general: GeneralSection(store: store)
         case .languages: LanguagesSection(store: store)
-        case .capture: LiveCaptureSection()
         case .translation: TranslationSection()
         case .overlay: OverlaySection()
         case .shortcuts: ShortcutsSection()
@@ -50,7 +49,6 @@ struct SettingsView: View {
   private enum Pane: String, CaseIterable, Identifiable {
     case general
     case languages
-    case capture
     case translation
     case overlay
     case shortcuts
@@ -67,7 +65,6 @@ struct SettingsView: View {
       switch self {
       case .general: "General"
       case .languages: "Languages"
-      case .capture: "Capture"
       case .translation: "Translation"
       case .overlay: "Overlay"
       case .shortcuts: "Shortcuts"
@@ -80,7 +77,6 @@ struct SettingsView: View {
       switch self {
       case .general: "gearshape"
       case .languages: "globe"
-      case .capture: "viewfinder"
       case .translation: "character.bubble"
       case .overlay: "rectangle.dashed"
       case .shortcuts: "command"
@@ -137,39 +133,6 @@ private struct LanguagesSection: View {
       Text("Languages")
     } footer: {
       Text("List is loaded from Apple Translation \u{00B7} Vision on this device.")
-        .font(.caption)
-        .foregroundStyle(.secondary)
-    }
-  }
-
-  // MARK: Private
-
-  @Shared(.settings) private var settings
-
-}
-
-// MARK: - LiveCaptureSection
-
-private struct LiveCaptureSection: View {
-
-  // MARK: Internal
-
-  var body: some View {
-    Section {
-      LabeledContent("Capture interval") {
-        VStack(alignment: .trailing, spacing: 2) {
-          Slider(value: Binding($settings.capture.interval), in: 0.3...3.0, step: 0.1)
-            .frame(width: 220)
-          Text(String(format: "%.1f s", settings.capture.interval))
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            .monospacedDigit()
-        }
-      }
-    } header: {
-      Text("Live Capture")
-    } footer: {
-      Text("How often Live Mode re-captures the overlay region.")
         .font(.caption)
         .foregroundStyle(.secondary)
     }

--- a/Tests/CaptureFeatureTests.swift
+++ b/Tests/CaptureFeatureTests.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import ComposableArchitecture
+import CustomDump
 import Foundation
 import Testing
 @testable import SwiftyCrow
@@ -43,6 +44,7 @@ struct CaptureFeatureTests {
       )
     ) {
       $0.translationCache[cacheKey] = TranslatedText(text: "Current translation")
+      $0.translationCacheOrder = [cacheKey]
       $0.overlayLines[0].showTranslation(
         "Current translation",
         language: Locale.Language(identifier: "en-US")
@@ -99,8 +101,12 @@ struct CaptureFeatureTests {
     }
     state.translationRequestContext = CaptureFeature.TranslationRequestContext(
       strategy: .lowLatency,
-      target: "en-US"
+      target: "en-US",
+      imageSize: CGSize(width: 900, height: 600),
+      sources: [pendingLine.id: pendingLine.source]
     )
+    state.isLive = true
+    state.recognitionSettings = LiveFrame.Settings(state.settings)
     let appearance = OverlaySourceAppearance(
       background: OverlayColor(red: 0.1, green: 0.2, blue: 0.3, alpha: 1),
       foreground: OverlayColor(red: 0.8, green: 0.7, blue: 0.6, alpha: 1),
@@ -132,15 +138,14 @@ struct CaptureFeatureTests {
       detect: { _, _ in nil }
     )
 
-    await store.send(.captureResponse(.success(capture))) {
+    await store.send(.liveCaptureResponse(generation: 0, frame: state.overlayFrame, result: .success(capture))) {
       $0.imageSize = capture.imageSize
       $0.overlayLines[0].source = expectedSource
     }
 
     #expect(store.state.translationGeneration == 2)
     #expect(store.state.overlayLines[0].isPending)
-    #expect(store.state.overlayLines[0].source.box != refreshed.boundingBoxNormalized)
-    #expect(abs(store.state.overlayLines[0].source.box.minX - 0.4035) < 0.000_001)
+    expectNoDifference(store.state.overlayLines[0].source.box, refreshed.boundingBoxNormalized)
   }
 
   @Test
@@ -182,6 +187,61 @@ struct CaptureFeatureTests {
         elapsed: .seconds(2)
       ) == nil
     )
+  }
+
+  @Test
+  func cacheEvictsOldestEntryAtCapacity() async {
+    var state = makeState()
+    for index in 0..<512 {
+      var key = cacheKey
+      key.text = "Source \(index)"
+      state.translationCache[key] = TranslatedText(text: "Translation \(index)")
+      state.translationCacheOrder.append(key)
+    }
+    let oldest = state.translationCacheOrder[0]
+    let store = TestStore(initialState: state) { CaptureFeature() }
+    store.exhaustivity = .off
+    await store.send(.translationResponse(
+      generation: 2,
+      lineID: pendingLine.id,
+      key: cacheKey,
+      translation: TranslatedText(text: "Current translation")
+    ))
+    expectNoDifference(store.state.translationCache.count, 512)
+    expectNoDifference(store.state.translationCacheOrder.count, 512)
+    #expect(store.state.translationCache[oldest] == nil)
+    expectNoDifference(store.state.translationCache[cacheKey]?.text, "Current translation")
+  }
+
+  @Test
+  func optionalStyleResponseRemainsAcceptedAfterPlainTextAppears() async {
+    var state = makeState()
+    state.overlayLines[0].source.styleRuns = [OverlaySourceStyleRun(
+      range: NSRange(location: 0, length: 2),
+      box: pendingLine.source.box,
+      appearance: OverlaySourceAppearance(background: .white, foreground: .black, confidence: 1, fontWeight: .bold)
+    )]
+    let store = TestStore(initialState: state) { CaptureFeature() }
+    store.exhaustivity = .off
+    await store.send(.translationResponse(
+      generation: 2,
+      lineID: pendingLine.id,
+      key: cacheKey,
+      translation: TranslatedText(text: "Hello")
+    ))
+    #expect(!store.state.isTranslating)
+    var styled = AttributedString("Hello")
+    styled.link = URL(string: "swiftycrow-style://run/0")
+    await store.send(.translationResponse(
+      generation: 2,
+      lineID: pendingLine.id,
+      key: cacheKey,
+      translation: TranslatedText(text: "Hello", attributedText: styled)
+    ))
+    expectNoDifference(store.state.overlayLines[0].translatedText, "Hello")
+    expectNoDifference(store.state.overlayLines[0].displayedStyleRuns.count, 1)
+    expectNoDifference(store.state.overlayLines[0].displayedStyleRuns[0].appearance.fontWeight, .bold)
+    #expect(!store.state.isTranslating)
   }
 
   // MARK: Private

--- a/Tests/LiveCapturePipelineTests.swift
+++ b/Tests/LiveCapturePipelineTests.swift
@@ -1,0 +1,280 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import ComposableArchitecture
+import CoreGraphics
+import CustomDump
+import Foundation
+import Testing
+import TOML
+@testable import SwiftyCrow
+
+@Suite("Live capture freshness")
+@MainActor
+struct LiveCapturePipelineTests {
+
+  // MARK: Internal
+
+  @Test
+  func identicalPixelsSkipOCRAndChangedPixelsCancelPendingRecognition() async throws {
+    let first = try LiveFrame(image: image(gray: 0.2))
+    let identical = try LiveFrame(image: image(gray: 0.2))
+    let changed = try LiveFrame(image: image(gray: 0.7))
+    expectNoDifference(first.signature, identical.signature)
+    #expect(first.signature != changed.signature)
+    let calls = LockIsolated(0)
+    let cancellations = LockIsolated(0)
+    let clock = TestClock()
+    let store = TestStore(initialState: state()) { CaptureFeature() } withDependencies: {
+      $0.continuousClock = clock
+      $0.ocr = OCRClient(recognizeText: { _, _ in
+        calls.withValue { $0 += 1 }
+        let stream = AsyncThrowingStream<OCRResult, any Error> { continuation in
+          continuation.onTermination = { _ in cancellations.withValue { $0 += 1 } }
+        }
+        for try await result in stream { return result }
+        throw CancellationError()
+      }, warmUp: { })
+    }
+    store.exhaustivity = .off
+    let frame = store.state.overlayFrame
+    await store.send(.liveFrameResponse(generation: 0, frame: frame, result: .success(first)))
+    // Let the effect enter its controllable OCR stream.
+    for _ in 0..<100 where calls.value < 1 { await Task.yield() }
+    expectNoDifference(calls.value, 1)
+    let generation = store.state.recognitionGeneration
+    await store.send(.liveFrameResponse(generation: 0, frame: frame, result: .success(identical)))
+    expectNoDifference(store.state.recognitionGeneration, generation)
+    expectNoDifference(calls.value, 1)
+    await store.send(.liveFrameResponse(generation: 0, frame: frame, result: .success(changed)))
+    for _ in 0..<100 where cancellations.value < 1 || calls.value < 2 { await Task.yield() }
+    expectNoDifference(calls.value, 2)
+    expectNoDifference(cancellations.value, 1)
+    #expect(store.state.recognitionGeneration > generation)
+    await store.send(.dismissOverlay)
+    await store.finish()
+  }
+
+  @Test
+  func captureLoopKeepsSamplingWhileOCRIsSuspended() async throws {
+    let clock = TestClock()
+    let pixels = try image(gray: 0.4)
+    let captures = LockIsolated(0)
+    let recognitions = LockIsolated(0)
+    let store = TestStore(initialState: state()) { CaptureFeature() } withDependencies: {
+      $0.continuousClock = clock
+      $0.screenCapture = ScreenCaptureClient(captureImage: { _, _, _ in
+        captures.withValue { $0 += 1 }
+        return pixels
+      }, captureWindow: { _ in pixels })
+      $0.ocr = OCRClient(recognizeText: { _, _ in
+        recognitions.withValue { $0 += 1 }
+        try await clock.sleep(for: .seconds(60))
+        return OCRResult(lines: [])
+      }, warmUp: { })
+    }
+    store.exhaustivity = .off
+    await store.send(.setLive(true))
+    await store.receive(\.liveFrameResponse)
+    await clock.advance(by: .seconds(1))
+    await store.receive(\.liveFrameResponse)
+    #expect(captures.value >= 2)
+    expectNoDifference(recognitions.value, 1)
+    #expect(store.state.isCapturing)
+    await store.send(.dismissOverlay)
+    await store.finish()
+  }
+
+  @Test
+  func scrollInvalidatesBothLateOCRAndLateTranslations() async {
+    var initial = state()
+    initial.overlayLines = [line()]
+    initial.isTranslating = true
+    initial.recognitionGeneration = 4
+    initial.translationGeneration = 8
+    let store = TestStore(initialState: initial) { CaptureFeature() }
+    store.exhaustivity = .off
+    let frame = store.state.overlayFrame
+    await store.send(.sourceInteractionBegan)
+    #expect(store.state.overlayLines.isEmpty)
+    #expect(!store.state.isTranslating)
+    let afterScroll = store.state
+    await store.send(.liveCaptureResponse(generation: 4, frame: frame, result: .success(capture())))
+    await store.send(.translationResponse(
+      generation: 8,
+      lineID: line().id,
+      key: .init(source: "en", strategy: .lowLatency, target: "ko", text: "Hello"),
+      translation: .init(text: "안녕하세요")
+    ))
+    expectNoDifference(store.state, afterScroll)
+    await store.send(.dismissOverlay)
+  }
+
+  @Test
+  func changedFrameHidesOldMasksBeforeNewOCRFinishes() async throws {
+    var initial = state()
+    var translated = line()
+    translated.showTranslation("안녕하세요", language: Locale.Language(identifier: "ko"))
+    initial.overlayLines = [translated]
+    let clock = TestClock()
+    let store = TestStore(initialState: initial) { CaptureFeature() } withDependencies: {
+      $0.continuousClock = clock
+      $0.ocr = OCRClient(recognizeText: { _, _ in
+        try await clock.sleep(for: .seconds(60))
+        return OCRResult(lines: [])
+      }, warmUp: { })
+    }
+    store.exhaustivity = .off
+    await store.send(.liveFrameResponse(
+      generation: 0,
+      frame: store.state.overlayFrame,
+      result: .success(try LiveFrame(image: image(gray: 0.8)))
+    ))
+    #expect(store.state.overlayLines.isEmpty)
+    #expect(store.state.isCapturing)
+    #expect(store.state.backdrop == nil)
+    await store.send(.dismissOverlay)
+    await store.finish()
+  }
+
+  @Test
+  func failureClearsStaleContentAndAllowsIdenticalFrameRetry() async throws {
+    var initial = state()
+    initial.overlayLines = [line()]
+    initial.lastFrameSignature = try LiveFrame(image: image(gray: 0.4)).signature
+    let store = TestStore(initialState: initial) { CaptureFeature() }
+    store.exhaustivity = .off
+    await store.send(.liveFrameResponse(
+      generation: 0,
+      frame: store.state.overlayFrame,
+      result: .failure(ScreenCaptureError.emptyRegion)
+    ))
+    #expect(store.state.overlayLines.isEmpty)
+    #expect(store.state.lastFrameSignature == nil)
+    #expect(store.state.lastError != nil)
+    #expect(store.state.isLive)
+  }
+
+  @Test
+  func requestGeometryUsesOriginalSnapshotSoSmallDriftCannotAccumulate() {
+    let original = line().source
+    let size = CGSize(width: 1000, height: 600)
+    var drifted = original
+    drifted.box.origin.x += 0.01
+    #expect(drifted.canReuseTranslation(relativeTo: original, imageSize: size))
+    drifted.box.origin.x += 0.01
+    #expect(!drifted.canReuseTranslation(relativeTo: original, imageSize: size))
+    var reflowed = original
+    reflowed.box.size.width += 0.08
+    #expect(!reflowed.canReuseTranslation(relativeTo: original, imageSize: size))
+  }
+
+  @Test
+  func materialOCRMovementReplacesInFlightTranslationRequest() async {
+    var initial = state()
+    let original = line()
+    initial.overlayLines = [original]
+    initial.recognitionSettings = LiveFrame.Settings(initial.settings)
+    initial.isTranslating = true
+    initial.translationRequestContext = .init(
+      strategy: .lowLatency,
+      target: "ko",
+      imageSize: CGSize(width: 1000, height: 600),
+      sources: [original.id: original.source]
+    )
+    let requests = LockIsolated(0)
+    let store = TestStore(initialState: initial) { CaptureFeature() } withDependencies: {
+      $0.languageDetection = LanguageDetectionClient(detect: { _, _ in nil })
+      $0.translation = TranslationClient(translateBatch: { items, _, _, _ in
+        requests.withValue { $0 += 1 }
+        return AsyncThrowingStream { continuation in
+          for item in items { continuation.yield(.init(id: item.id, text: "안녕하세요")) }
+          continuation.finish()
+        }
+      })
+    }
+    store.exhaustivity = .off
+    var moved = capture()
+    moved.result.lines[0].boundingBoxNormalized.origin.y += 0.2
+    await store.send(.liveCaptureResponse(generation: 0, frame: initial.overlayFrame, result: .success(moved)))
+    await store.receive(\.translationResponse)
+    await store.receive(\.translationFinished)
+    expectNoDifference(requests.value, 1)
+    expectNoDifference(store.state.translationGeneration, 1)
+    expectNoDifference(store.state.overlayLines[0].source.box, moved.result.lines[0].boundingBoxNormalized)
+    expectNoDifference(store.state.overlayLines[0].translatedText, "안녕하세요")
+  }
+
+  @Test
+  func cadenceAdaptsToChangesAndBacksOffAfterFailures() throws {
+    let first = try LiveFrame(image: image(gray: 0.2)).signature
+    let changed = try LiveFrame(image: image(gray: 0.7)).signature
+    var cadence = LiveCaptureCadence()
+    expectNoDifference(cadence.interval(after: first), .milliseconds(150))
+    expectNoDifference(cadence.interval(after: first), .milliseconds(150))
+    expectNoDifference(cadence.interval(after: first), .milliseconds(150))
+    expectNoDifference(cadence.interval(after: first), .milliseconds(500))
+    expectNoDifference(cadence.interval(after: changed), .milliseconds(150))
+    expectNoDifference(cadence.interval(after: nil), .milliseconds(500))
+    expectNoDifference(cadence.interval(after: nil), .seconds(1))
+    expectNoDifference(cadence.interval(after: nil), .seconds(2))
+    expectNoDifference(cadence.interval(after: nil), .seconds(2))
+    expectNoDifference(cadence.interval(after: changed), .milliseconds(150))
+  }
+
+  @Test
+  func legacyCaptureIntervalIsIgnoredAndNotWrittenBack() throws {
+    let settings = try TOMLDecoder().decode(AppSettings.self, from: """
+      [capture]
+      interval = 99.0
+      [languages.target]
+      code = "ko"
+      """)
+    expectNoDifference(settings.languages.target, Language(code: "ko"))
+    let encoded = String(decoding: try TOMLEncoder().encode(settings), as: UTF8.self)
+    #expect(!encoded.contains("[capture]"))
+    #expect(!encoded.contains("interval"))
+  }
+
+  // MARK: Private
+
+  private func state() -> CaptureFeature.State {
+    var state = CaptureFeature.State()
+    state.overlayActive = true
+    state.isLive = true
+    state.$settings.withLock {
+      $0.languages.source = Language(code: "en")
+      $0.languages.target = Language(code: "ko")
+    }
+    return state
+  }
+
+  private func line() -> OverlayLine {
+    OverlayLine(
+      id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+      source: .init(recognized: capture().result.lines[0], language: Locale.Language(identifier: "en")),
+      initialContent: .pending
+    )
+  }
+
+  private func capture() -> CaptureFeature.LiveCapture {
+    .init(backdrop: nil, imageSize: CGSize(width: 1000, height: 600), result: OCRResult(lines: [
+      .init(boundingBoxNormalized: CGRect(x: 0.2, y: 0.2, width: 0.3, height: 0.06), text: "Hello")
+    ]))
+  }
+
+  private func image(gray: CGFloat) throws -> CGImage {
+    let context = try #require(CGContext(
+      data: nil,
+      width: 32,
+      height: 16,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(gray: gray, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 32, height: 16))
+    return try #require(context.makeImage())
+  }
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -14,7 +14,6 @@ in your editor.
 
 Settings are grouped into tables that mirror the in-app Settings panes:
 
-- **`[capture]`:** Live Mode capture cadence
 - **`[languages]`:** Source and target language pair
 - **`[overlay]`:** Live translation overlay
 - **`[shortcuts]`:** Global hotkeys and capture-window keys
@@ -41,11 +40,10 @@ Modifiers: `cmd`, `ctrl`, `alt` (option), `shift`. Keys are letters, digits,
 `tab`, `return`, `space`, arrow keys (`left`/`right`/`up`/`down`), punctuation,
 etc. Omit a key to leave that action unbound.
 
-## `[capture]`
-
-| Key | Type | Default | Description |
-| --- | --- | --- | --- |
-| `interval` | double | `0.8` | Seconds between re-captures while Live Mode is on. |
+Live capture adapts automatically: it checks frequently while content changes
+and slows down when the screen is still. OCR runs only for changed pixels or
+language settings. Scrolling refreshes as soon as the gesture settles.
+The former `[capture].interval` setting is ignored and omitted on the next save.
 
 ## `[languages]`
 


### PR DESCRIPTION
Live overlays can retain stale translations and source masks while OCR is slow or the source moves. Separate screen capture from OCR, invalidate outdated work on frame changes and source interaction, and refresh after scrolling settles.

- Skip recognition for identical pixels and adapt capture cadence automatically; remove the manual interval setting and Capture pane while accepting existing configuration files.
- Use current source geometry, display translation text before optional style mapping completes, and bound the translation cache.
- Add regression coverage for cancellation, late responses, unchanged frames, adaptive cadence, progressive styling, cache eviction, and configuration compatibility.

Validation: all 157 macOS tests passed through XcodeBuildMCP, and the Debug build and launch succeeded. Visual verification of scrolling and overlap remains incomplete because macOS UI automation could not reliably access the menu bar app.
