### PR TITLE
fix(translation): improve OCR and layout for complex sources

### DIFF
--- a/Sources/Capture/CaptureFeature.swift
+++ b/Sources/Capture/CaptureFeature.swift
@@ -406,7 +406,8 @@ struct CaptureFeature {
         }
         let translation = TranslatedText(
           text: text,
-          attributedText: text == translation.text ? translation.attributedText : nil
+          attributedText: text == translation.text ? translation.attributedText : nil,
+          modelNotice: translation.modelNotice
         )
         state.translationCacheOrder.removeAll { $0 == key }
         state.translationCacheOrder.append(key)
@@ -421,7 +422,8 @@ struct CaptureFeature {
           state.overlayLines[index].showTranslation(
             translation.text,
             attributedText: translation.attributedText,
-            language: Locale.Language(identifier: key.target)
+            language: Locale.Language(identifier: key.target),
+            modelNotice: translation.modelNotice
           )
         }
         state.isTranslating = state.overlayLines.contains(where: \.isPending)
@@ -547,7 +549,8 @@ struct CaptureFeature {
         overlayLine.showTranslation(
           cached.text,
           attributedText: cached.attributedText,
-          language: target
+          language: target,
+          modelNotice: cached.modelNotice
         )
       }
 
@@ -596,7 +599,8 @@ struct CaptureFeature {
                       key: key,
                       translation: TranslatedText(
                         text: result.text,
-                        attributedText: result.attributedText
+                        attributedText: result.attributedText,
+                        modelNotice: result.modelNotice
                       )
                     )
                   )

--- a/Sources/Capture/CaptureView.swift
+++ b/Sources/Capture/CaptureView.swift
@@ -6,8 +6,6 @@ import SwiftUI
 
 struct CaptureView: View {
 
-  // MARK: Internal
-
   let store: StoreOf<CaptureFeature>
 
   var body: some View {
@@ -27,7 +25,7 @@ struct CaptureView: View {
       .keyboardShortcut(.defaultAction)
 
       if store.translationUnavailable {
-        TranslationModelHint()
+        TranslationModelHint(message: store.lastError)
           .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
           .transition(.opacity)
       } else if let error = store.lastError {
@@ -37,6 +35,7 @@ struct CaptureView: View {
           .frame(maxWidth: .infinity, alignment: .leading)
           .transition(.opacity)
       }
+      CaptureStatusNote(lines: store.overlayLines)
     }
     .animation(.easeOut(duration: 0.15), value: store.lastError)
     .animation(.easeOut(duration: 0.15), value: store.translationUnavailable)

--- a/Sources/Capture/RegionCaptureFeature.swift
+++ b/Sources/Capture/RegionCaptureFeature.swift
@@ -140,7 +140,8 @@ struct RegionCaptureFeature {
                       id: result.id,
                       translation: TranslatedText(
                         text: result.text,
-                        attributedText: result.attributedText
+                        attributedText: result.attributedText,
+                        modelNotice: result.modelNotice
                       ),
                       target: target
                     ))
@@ -180,12 +181,13 @@ struct RegionCaptureFeature {
         }
         if
           let index = state.overlayLines.firstIndex(where: { $0.id == id }),
-          (state.overlayLines[index].isPending || state.overlayLines[index].translatedText == text)
+          state.overlayLines[index].isPending || state.overlayLines[index].translatedText == text
         {
           state.overlayLines[index].showTranslation(
             text,
             attributedText: text == translation.text ? translation.attributedText : nil,
-            language: target
+            language: target,
+            modelNotice: translation.modelNotice
           )
         }
         state.isTranslating = state.overlayLines.contains(where: \.isPending)

--- a/Sources/Capture/RegionResultView.swift
+++ b/Sources/Capture/RegionResultView.swift
@@ -22,7 +22,7 @@ struct RegionResultView: View {
       toolbar
       Divider().opacity(0.4)
       if store.translationUnavailable {
-        TranslationModelHint()
+        TranslationModelHint(message: store.lastError)
       } else if let error = store.lastError, store.imageData != nil {
         Label(error, systemImage: "exclamationmark.triangle.fill")
           .font(.caption)
@@ -31,6 +31,7 @@ struct RegionResultView: View {
           .padding(.horizontal, 14)
           .padding(.vertical, 8)
       }
+      CaptureStatusNote(lines: store.overlayLines)
       content
     }
     .frame(minWidth: 360, minHeight: 280)

--- a/Sources/Capture/TranslationModelHint.swift
+++ b/Sources/Capture/TranslationModelHint.swift
@@ -58,6 +58,8 @@ struct TranslationModelHint: View {
 
   // MARK: Internal
 
+  var message: String? = nil
+
   var body: some View {
     if !dismissed {
       content
@@ -74,10 +76,11 @@ struct TranslationModelHint: View {
         Image(systemName: "exclamationmark.triangle.fill")
           .foregroundStyle(.orange)
         VStack(alignment: .leading, spacing: 1) {
-          Text("Translation model not installed")
+          Text("Translation unavailable")
             .font(.caption)
             .fontWeight(.semibold)
-          Text("Add the language under System Settings → General → Language & Region → Translation Languages, then capture again.")
+          Text(message ??
+            "Add the required language model in System Settings → General → Language & Region → Translation Languages, then capture again.")
             .font(.caption2)
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
@@ -99,5 +102,33 @@ struct TranslationModelHint: View {
     .frame(maxWidth: .infinity, alignment: .leading)
     .background(.orange.opacity(0.18))
     .background(.regularMaterial)
+  }
+}
+
+// MARK: - CaptureStatusNote
+
+struct CaptureStatusNote: View {
+  let lines: [OverlayLine]
+
+  var body: some View {
+    if lines.contains(where: { $0.source.needsReview }) {
+      Label("Some text may be misread. Compare the translation with the original.", systemImage: "text.magnifyingglass")
+        .font(.caption2).foregroundStyle(.orange)
+        .padding(8).frame(maxWidth: .infinity, alignment: .leading).background(.regularMaterial)
+    }
+    let notices = Array(Set(lines.compactMap(\.modelNotice))).sorted()
+    if let first = notices.first {
+      Label(
+        notices.count == 1 ? first : "Using installed models for \(notices.count) language pairs.",
+        systemImage: "info.circle"
+      )
+      .font(.caption2)
+      .foregroundStyle(.secondary)
+      .fixedSize(horizontal: false, vertical: true)
+      .help(notices.joined(separator: "\n"))
+      .padding(8)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(.regularMaterial)
+    }
   }
 }

--- a/Sources/Dependencies/JapaneseRubyOCRCorrector.swift
+++ b/Sources/Dependencies/JapaneseRubyOCRCorrector.swift
@@ -145,6 +145,35 @@ enum JapaneseRubyOCRCorrector {
     }
   }
 
+  /// A separate small upper ink band and an intervening blank band are
+  /// evidence of ruby. Merely being a large Japanese row is not evidence.
+  static func baseBandStart(rowInk: [Int]) -> CGFloat? {
+    let height = rowInk.count
+    guard height >= 24, let peak = rowInk.max(), peak > 0 else { return nil }
+    let threshold = max(1, peak / 20)
+    let occupied = rowInk.map { $0 > threshold }
+    let minimumGap = max(2, height / 16)
+    var start = height / 6
+    while start < height / 2 {
+      guard !occupied[start] else { start += 1
+        continue
+      }
+      var end = start
+      while end < height, !occupied[end] { end += 1 }
+      let upper = occupied[..<start].count(where: { $0 })
+      let lower = occupied[end...].count(where: { $0 })
+      if
+        end - start >= minimumGap,
+        upper >= max(5, height / 8), lower >= height / 3,
+        upper * 4 <= lower * 3, end < height / 2
+      {
+        return CGFloat(max(0, end - 1)) / CGFloat(height)
+      }
+      start = end + 1
+    }
+    return nil
+  }
+
   // MARK: Private
 
   private struct Input {
@@ -184,11 +213,12 @@ enum JapaneseRubyOCRCorrector {
       return nil
     }
 
+    guard let fraction = baseBandStart(for: box, in: image) else { return nil }
     let baseBox = CGRect(
       x: max(0, box.minX - box.height * 0.08),
-      y: box.minY + box.height * 0.28,
+      y: box.minY + box.height * fraction,
       width: min(1 - box.minX, box.width + box.height * 0.16),
-      height: box.height * 0.72
+      height: box.height * (1 - fraction)
     )
     let imageBounds = CGRect(
       x: 0,
@@ -206,6 +236,39 @@ enum JapaneseRubyOCRCorrector {
       return nil
     }
     return Input(lineIndex: index, original: line.text, crop: crop)
+  }
+
+  private static func baseBandStart(for box: CGRect, in image: CGImage) -> CGFloat? {
+    let rect = CGRect(
+      x: box.minX * CGFloat(image.width),
+      y: box.minY * CGFloat(image.height),
+      width: box.width * CGFloat(image.width),
+      height: box.height * CGFloat(image.height)
+    ).integral
+    guard
+      let crop = image.cropping(to: rect),
+      let context = CGContext(
+        data: nil,
+        width: crop.width,
+        height: crop.height,
+        bitsPerComponent: 8,
+        bytesPerRow: crop.width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    else { return nil }
+    context.draw(crop, in: CGRect(x: 0, y: 0, width: crop.width, height: crop.height))
+    guard let data = context.data else { return nil }
+    defer { withExtendedLifetime(context) { } }
+    let pixels = data.bindMemory(to: UInt8.self, capacity: crop.width * crop.height * 4)
+    // Median border brightness is robust to a few glyphs touching the crop.
+    let border = (0..<crop.width).flatMap { x in [Int(pixels[x * 4]), Int(pixels[((crop.height - 1) * crop.width + x) * 4])] }
+      .sorted()
+    let background = border[border.count / 2]
+    let rows = (0..<crop.height).map { y in
+      (0..<crop.width).count { x in abs(Int(pixels[(y * crop.width + x) * 4]) - background) >= 40 }
+    }
+    return baseBandStart(rowInk: rows)
   }
 
   private static func corrections(in inputs: [Input]) async throws -> [Int: Candidate] {

--- a/Sources/Dependencies/LanguageDetectionClient.swift
+++ b/Sources/Dependencies/LanguageDetectionClient.swift
@@ -17,6 +17,8 @@ struct LanguageDetectionClient {
   var detect: @Sendable (_ text: String, _ minConfidence: Double) -> Language? = { _, _ in nil }
 }
 
+// MARK: DependencyKey
+
 extension LanguageDetectionClient: DependencyKey {
   static let liveValue = LanguageDetectionClient(
     detect: { text, minConfidence in
@@ -38,8 +40,35 @@ extension LanguageDetectionClient {
   /// for short or ambiguous lines. For an explicit source, returns it for all.
   func resolveSources(for texts: [String], configured: Language) -> [Language] {
     guard configured.isAuto else { return Array(repeating: configured, count: texts.count) }
-    let fallback = detect(texts.joined(separator: "\n"), 0) ?? .defaultSource
-    return texts.map { detect($0, 0.65) ?? fallback }
+    let prose = texts.filter { !OCRTextSemantics.isIdentifier($0) && !OCRTextSemantics.isCode($0) }
+    let fallback = detect(prose.joined(separator: "\n"), 0) ?? .defaultSource
+    let proseLanguages = prose.filter { $0.split(whereSeparator: \.isWhitespace).count >= 3 }.compactMap { detect($0, 0.65) }
+    let latinLanguages = proseLanguages.filter { $0.localeLanguage.script?.identifier == "Latn" }
+    let preferredLatin = Locale.preferredLanguages.map { Language(code: $0) }.first { preferred in
+      latinLanguages.contains { $0.localeLanguage.usesSameWritingSystem(as: preferred.localeLanguage) }
+    }
+    let shortLatinSource = preferredLatin ?? latinLanguages.first
+      ?? (fallback.localeLanguage.script?.identifier == "Latn" ? fallback : .defaultSource)
+    return texts.map { text in
+      if OCRTextSemantics.isIdentifier(text) || OCRTextSemantics.isCode(text) { return fallback }
+      let scalars = text.unicodeScalars
+      let latin = scalars.count { (0x41...0x5A).contains($0.value) || (0x61...0x7A).contains($0.value) }
+      let letters = scalars.count { CharacterSet.letters.contains($0) }
+      if latin == letters, latin >= 2, latin < 12, text.split(whereSeparator: \.isWhitespace).count == 1 {
+        if
+          let detected = detect(text, 0.9),
+          proseLanguages.contains(where: { $0.localeLanguage.usesSameWritingSystem(as: detected.localeLanguage) })
+        {
+          return detected
+        }
+        return shortLatinSource
+      }
+      if let language = detect(text, 0.65) { return language }
+      // A page's dominant script cannot turn an English caption into Arabic
+      // or Japanese. Ask for the best hypothesis within this actual string.
+      if latin >= 3, latin == letters, let language = detect(text, 0) { return language }
+      return fallback
+    }
   }
 }
 

--- a/Sources/Dependencies/OCRBalloonRefiner.swift
+++ b/Sources/Dependencies/OCRBalloonRefiner.swift
@@ -1,0 +1,372 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import Foundation
+import Vision
+
+// MARK: - OCRBalloonRefiner
+
+/// Reconstructs printed dialogue from enclosed paper regions. Document OCR can
+/// split emphatic lettering into words, or read across two connected balloons.
+/// Boundaries come from the image, never from a dictionary of expected dialogue.
+enum OCRBalloonRefiner {
+  static func refine(_ lines: [OCRResult.Line], in image: CGImage, language: Language) async throws -> [OCRResult.Line] {
+    guard qualifies(lines), let raster = BalloonRaster(image: image, longestSide: 1024) else { return lines }
+    let started = ContinuousClock.now
+    let regions = raster.textRegions(around: lines)
+    guard regions.count >= 2 else { return lines }
+    var replacements = [(BalloonRegion, OCRResult.Line)]()
+    // Bound native Vision work. Rechecking a handful of crops should not launch
+    // one model request for every word in the document.
+    for region in regions.prefix(24) {
+      try Task.checkCancellation()
+      guard let crop = raster.maskedCrop(of: image, region: region) else { continue }
+      let pixelRect = region.pixelRect(in: image)
+      let sourceRect = CGRect(
+        x: pixelRect.minX / CGFloat(image.width),
+        y: pixelRect.minY / CGFloat(image.height),
+        width: pixelRect.width / CGFloat(image.width),
+        height: pixelRect.height / CGFloat(image.height)
+      )
+      var request = RecognizeTextRequest()
+      request.recognitionLevel = .accurate
+      request.usesLanguageCorrection = true
+      if language.isAuto {
+        request.automaticallyDetectsLanguage = true
+      } else {
+        request.recognitionLanguages = [language.localeLanguage]
+      }
+      let observations = try await request.perform(on: crop)
+      let rows = observations.compactMap { observation -> (String, CGRect)? in
+        guard let candidate = observation.topCandidates(1).first, candidate.confidence >= 0.3 else { return nil }
+        let box = observation.boundingBox.cgRect
+        let mapped = CGRect(
+          x: sourceRect.minX + box.minX * sourceRect.width,
+          y: sourceRect.minY + (1 - box.maxY) * sourceRect.height,
+          width: box.width * sourceRect.width,
+          height: box.height * sourceRect.height
+        )
+        return (candidate.string, mapped)
+      }.sorted { lhs, rhs in
+        abs(lhs.1.midY - rhs.1.midY) <= min(lhs.1.height, rhs.1.height) * 0.45
+          ? lhs.1.minX < rhs.1.minX
+          : lhs.1.midY < rhs.1.midY
+      }
+      guard rows.count >= 2 else { continue }
+      let text = joinedRows(rows.map(\.0))
+      let originalLength = lines.filter { region.contains($0.boundingBoxNormalized.center) }.reduce(0) { $0 + $1.text.count }
+      // Never replace an established region with a nearly empty crop result.
+      guard text.count >= max(12, originalLength / 2) else { continue }
+      let bounds = rows.dropFirst().reduce(rows[0].1) { $0.union($1.1) }
+      let heights = rows.map { $0.1.height }.sorted()
+      let glyphHeight = heights[heights.count / 2]
+      var line = OCRResult.Line(
+        boundingBoxNormalized: bounds,
+        text: text,
+        rowCount: rows.count,
+        horizontalGlyphScale: glyphHeight,
+        horizontalInkScale: glyphHeight,
+        replacementPatches: rows.map { OverlaySourcePatch(box: $0.1) },
+        alignment: .center,
+        surface: OverlaySourceSurface(box: region.interiorBox, confidence: 1, clippingBox: region.box, clippingRows: region.spans)
+      )
+      line.isReconstructedTextRegion = true
+      replacements.append((region, line))
+    }
+    guard !replacements.isEmpty else { return lines }
+    Log.ocr
+      .debug(
+        "Reconstructed \(replacements.count, privacy: .public) printed text regions in \((ContinuousClock.now - started).loggedSeconds, privacy: .public)s"
+      )
+    let retained = lines.filter { line in
+      !replacements.contains { region, _ in
+        let box = line.boundingBoxNormalized
+        let overlap = box.intersection(region.box)
+        return region.contains(box.center)
+          || (!overlap.isNull && overlap.width * overlap.height > box.width * box.height * 0.45)
+      }
+    }
+    return (retained + replacements.map(\.1)).sorted {
+      abs($0.boundingBoxNormalized.minY - $1.boundingBoxNormalized.minY) < 0.02
+        ? $0.boundingBoxNormalized.minX < $1.boundingBoxNormalized.minX
+        : $0.boundingBoxNormalized.minY < $1.boundingBoxNormalized.minY
+    }
+  }
+
+  static func qualifies(_ lines: [OCRResult.Line]) -> Bool {
+    guard lines.count >= 12, !lines.contains(where: \.isVerticalBlock) else { return false }
+    let letters = lines.map(\.text).joined().unicodeScalars.filter { CharacterSet.letters.contains($0) }
+    guard letters.count >= 80 else { return false }
+    return letters.count(where: { CharacterSet.uppercaseLetters.contains($0) }) * 10 >= letters.count * 9
+  }
+
+  static func joinedRows(_ rows: [String]) -> String {
+    rows.reduce("") { result, row in
+      let row = row.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !result.isEmpty else { return row }
+      return result + (result.hasSuffix("-") ? "" : " ") + row
+    }
+  }
+}
+
+// MARK: - BalloonRegion
+
+struct BalloonRegion {
+  let box: CGRect
+  let spans: [CGRect]
+
+  /// Largest rectangle inside the ink boundary. A balloon's bounding box can
+  /// overlap its neighbor even though their actual interiors are disjoint.
+  var interiorBox: CGRect {
+    var best = CGRect.zero
+    for start in spans.indices {
+      var left = spans[start].minX
+      var right = spans[start].maxX
+      for end in start..<spans.count {
+        left = max(left, spans[end].minX)
+        right = min(right, spans[end].maxX)
+        guard right > left else { break }
+        let candidate = CGRect(x: left, y: spans[start].minY, width: right - left, height: spans[end].maxY - spans[start].minY)
+        if candidate.width * candidate.height > best.width * best.height { best = candidate }
+      }
+    }
+    return best.insetBy(dx: min(best.width * 0.04, 0.004), dy: min(best.height * 0.04, 0.003))
+  }
+
+  func pixelRect(in image: CGImage) -> CGRect {
+    CGRect(
+      x: box.minX * CGFloat(image.width),
+      y: box.minY * CGFloat(image.height),
+      width: box.width * CGFloat(image.width),
+      height: box.height * CGFloat(image.height)
+    ).integral
+  }
+
+  func contains(_ point: CGPoint) -> Bool {
+    spans.contains { $0.contains(point) }
+  }
+}
+
+// MARK: - BalloonRaster
+
+/// Binary connected components retain ink boundaries even on aged, textured
+/// paper. Fill enclosed glyph holes, then erode the interior to separate narrow
+/// connectors between balloons. Grow the interiors back without crossing ink.
+struct BalloonRaster {
+
+  // MARK: Lifecycle
+
+  init?(image: CGImage, longestSide: Int) {
+    let scale = min(1, CGFloat(longestSide) / CGFloat(max(image.width, image.height)))
+    width = max(1, Int(CGFloat(image.width) * scale))
+    height = max(1, Int(CGFloat(image.height) * scale))
+    guard
+      let context = CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    else { return nil }
+    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+    guard let data = context.data else { return nil }
+    let bytes = data.bindMemory(to: UInt8.self, capacity: width * height * 4)
+    paper = (0..<width * height).map { index in
+      let offset = index * 4
+      return (Double(bytes[offset]) * 0.2126 + Double(bytes[offset + 1]) * 0.7152 + Double(bytes[offset + 2]) * 0.0722) > 153
+    }
+  }
+
+  // MARK: Internal
+
+  let width: Int
+  let height: Int
+  let paper: [Bool]
+
+  func textRegions(around lines: [OCRResult.Line]) -> [BalloonRegion] {
+    let components = Self.components(paper, width: width, height: height)
+    let radius = max(2, height / 128)
+    var result = [BalloonRegion]()
+    for component in components where component.count >= 600 {
+      if Task.isCancelled { break }
+      let xs = component.map { $0 % width }
+      let ys = component.map { $0 / width }
+      let x0 = xs.min()!
+      let x1 = xs.max()!
+      let y0 = ys.min()!
+      let y1 = ys.max()!
+      guard x0 > 0, y0 > 0, x1 < width - 1, y1 < height - 1 else { continue }
+      let box = normalized(x: x0, y: y0, width: x1 - x0 + 1, height: y1 - y0 + 1)
+      guard lines.count(where: { box.contains($0.boundingBoxNormalized.center) }) >= 3 else { continue }
+      let w = x1 - x0 + 3
+      let h = y1 - y0 + 3
+      var filled = [Bool](repeating: false, count: w * h)
+      for index in component { filled[(index / width - y0 + 1) * w + index % width - x0 + 1] = true }
+      // Flood the exterior only. Everything unreachable inside is paper or a
+      // glyph hole, so lettering cannot break the subsequent interior erosion.
+      var outside = [Bool](repeating: false, count: filled.count)
+      var queue = [0]
+      outside[0] = true
+      var cursor = 0
+      while cursor < queue.count {
+        let index = queue[cursor]
+        cursor += 1
+        for next in Self.neighbors(index, width: w, height: h) where !outside[next] && !filled[next] {
+          outside[next] = true
+          queue.append(next)
+        }
+      }
+      filled = outside.map { !$0 }
+      var distance = filled.map { $0 ? w + h : 0 }
+      for y in 1..<h {
+        for x in 1..<w {
+          let i = y * w + x
+          distance[i] = min(distance[i], min(distance[i - 1], distance[i - w]) + 1)
+        }
+      }
+      for y in stride(from: h - 2, through: 0, by: -1) {
+        for x in stride(from: w - 2, through: 0, by: -1) {
+          let i = y * w + x
+          distance[i] = min(distance[i], min(distance[i + 1], distance[i + w]) + 1)
+        }
+      }
+      let cores = Self.components(distance.map { $0 > radius }, width: w, height: h).filter { $0.count >= 400 }
+      var owners = [Int](repeating: -1, count: filled.count)
+      var depth = [Int](repeating: 0, count: filled.count)
+      queue = []
+      for (owner, core) in cores.enumerated() {
+        for index in core { owners[index] = owner
+          queue.append(index)
+        }
+      }
+      cursor = 0
+      while cursor < queue.count {
+        let i = queue[cursor]
+        cursor += 1
+        guard depth[i] < radius - 2 else { continue }
+        for next in Self.neighbors(i, width: w, height: h) where filled[next] && owners[next] == -1 {
+          owners[next] = owners[i]
+          depth[next] = depth[i] + 1
+          queue.append(next)
+        }
+      }
+      for owner in cores.indices {
+        var spans = [CGRect]()
+        for y in 0..<h {
+          let columns = (0..<w).filter { owners[y * w + $0] == owner }
+          guard let first = columns.first, let last = columns.last else { continue }
+          spans.append(normalized(x: x0 + first - 1, y: y0 + y - 1, width: last - first + 1, height: 1))
+        }
+        guard let first = spans.first else { continue }
+        let bounds = spans.dropFirst().reduce(first) { $0.union($1) }
+        let region = BalloonRegion(box: bounds, spans: spans)
+        let contained = lines.filter { region.contains($0.boundingBoxNormalized.center) }
+        guard contained.count >= 3 else { continue }
+        let textBounds = contained.dropFirst().reduce(contained[0].boundingBoxNormalized) { $0.union($1.boundingBoxNormalized) }
+        guard bounds.width * bounds.height < textBounds.width * textBounds.height * 4 else { continue }
+        result.append(region)
+      }
+    }
+    return result
+  }
+
+  func maskedCrop(of image: CGImage, region: BalloonRegion) -> CGImage? {
+    let rect = region.pixelRect(in: image)
+    guard
+      let crop = image.cropping(to: rect),
+      let context = CGContext(
+        data: nil,
+        width: crop.width,
+        height: crop.height,
+        bitsPerComponent: 8,
+        bytesPerRow: crop.width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    else { return nil }
+    context.draw(crop, in: CGRect(x: 0, y: 0, width: crop.width, height: crop.height))
+    guard let data = context.data else { return nil }
+    let bytes = data.bindMemory(to: UInt8.self, capacity: crop.width * crop.height * 4)
+    for y in 0..<crop.height {
+      let globalY = (rect.minY + CGFloat(y) + 0.5) / CGFloat(image.height)
+      let span = region.spans.first { globalY >= $0.minY && globalY < $0.maxY }
+      for x in 0..<crop.width {
+        let globalX = (rect.minX + CGFloat(x) + 0.5) / CGFloat(image.width)
+        if span == nil || globalX < span!.minX || globalX >= span!.maxX {
+          let i = (y * crop.width + x) * 4
+          bytes[i] = 255
+          bytes[i + 1] = 255
+          bytes[i + 2] = 255
+          bytes[i + 3] = 255
+        }
+      }
+    }
+    guard let masked = context.makeImage() else { return nil }
+    let scale = max(1, min(3, 960 / CGFloat(masked.width)))
+    guard
+      let enlarged = CGContext(
+        data: nil,
+        width: Int(CGFloat(masked.width) * scale),
+        height: Int(CGFloat(masked.height) * scale),
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    else { return nil }
+    enlarged.interpolationQuality = .high
+    enlarged.draw(masked, in: CGRect(x: 0, y: 0, width: enlarged.width, height: enlarged.height))
+    return enlarged.makeImage()
+  }
+
+  // MARK: Private
+
+  private static func neighbors(_ i: Int, width: Int, height: Int) -> [Int] {
+    var result = [Int]()
+    if i % width > 0 { result.append(i - 1) }
+    if i % width + 1 < width { result.append(i + 1) }
+    if i >= width { result.append(i - width) }
+    if i + width < width * height { result.append(i + width) }
+    return result
+  }
+
+  private static func components(_ mask: [Bool], width: Int, height: Int) -> [[Int]] {
+    var visited = [Bool](repeating: false, count: mask.count)
+    var result = [[Int]]()
+    for start in mask.indices where mask[start] && !visited[start] {
+      var queue = [start]
+      visited[start] = true
+      var cursor = 0
+      while cursor < queue.count {
+        let i = queue[cursor]
+        cursor += 1
+        for next in neighbors(i, width: width, height: height) where mask[next] && !visited[next] {
+          visited[next] = true
+          queue.append(next)
+        }
+      }
+      result.append(queue)
+    }
+    return result
+  }
+
+  private func normalized(x: Int, y: Int, width: Int, height: Int) -> CGRect {
+    CGRect(
+      x: CGFloat(x) / CGFloat(self.width),
+      y: CGFloat(y) / CGFloat(self.height),
+      width: CGFloat(width) / CGFloat(self.width),
+      height: CGFloat(height) / CGFloat(self.height)
+    )
+  }
+
+}
+
+extension CGRect {
+  fileprivate var center: CGPoint {
+    CGPoint(x: midX, y: midY)
+  }
+}

--- a/Sources/Dependencies/OCRBalloonRefiner.swift
+++ b/Sources/Dependencies/OCRBalloonRefiner.swift
@@ -95,7 +95,7 @@ enum OCRBalloonRefiner {
   }
 
   static func qualifies(_ lines: [OCRResult.Line]) -> Bool {
-    guard lines.count >= 12, !lines.contains(where: \.isVerticalBlock) else { return false }
+    guard lines.count >= 6, !lines.contains(where: \.isVerticalBlock) else { return false }
     let letters = lines.map(\.text).joined().unicodeScalars.filter { CharacterSet.letters.contains($0) }
     guard letters.count >= 80 else { return false }
     return letters.count(where: { CharacterSet.uppercaseLetters.contains($0) }) * 10 >= letters.count * 9
@@ -174,6 +174,7 @@ struct BalloonRaster {
     else { return nil }
     context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
     guard let data = context.data else { return nil }
+    defer { withExtendedLifetime(context) { } }
     let bytes = data.bindMemory(to: UInt8.self, capacity: width * height * 4)
     paper = (0..<width * height).map { index in
       let offset = index * 4
@@ -189,7 +190,8 @@ struct BalloonRaster {
 
   func textRegions(around lines: [OCRResult.Line]) -> [BalloonRegion] {
     let components = Self.components(paper, width: width, height: height)
-    let radius = max(2, height / 128)
+    let glyphHeights = lines.map { $0.boundingBoxNormalized.height * CGFloat(height) / CGFloat(max(1, $0.rowCount)) }.sorted()
+    let radius = max(2, min(min(width, height) / 24, Int(glyphHeights[glyphHeights.count / 2] * 0.65)))
     var result = [BalloonRegion]()
     for component in components where component.count >= 600 {
       if Task.isCancelled { break }
@@ -267,7 +269,7 @@ struct BalloonRaster {
         let contained = lines.filter { region.contains($0.boundingBoxNormalized.center) }
         guard contained.count >= 3 else { continue }
         let textBounds = contained.dropFirst().reduce(contained[0].boundingBoxNormalized) { $0.union($1.boundingBoxNormalized) }
-        guard bounds.width * bounds.height < textBounds.width * textBounds.height * 4 else { continue }
+        guard bounds.width * bounds.height < textBounds.width * textBounds.height * 6 else { continue }
         result.append(region)
       }
     }

--- a/Sources/Dependencies/OCRClient.swift
+++ b/Sources/Dependencies/OCRClient.swift
@@ -92,7 +92,33 @@ extension OCRClient: DependencyKey {
           let observation = recognizedLine.observation
           let transcript = recognizedLine.transcript
           let box = Self.topLeftBox(observation.boundingRegion.boundingBox.cgRect)
-          let isVertical = observation.textDirection == .topToBottom
+          let imageSize = CGSize(width: image.width, height: image.height)
+          let topLeft = observation.topLeft.cgPoint
+          let topRight = observation.topRight.cgPoint
+          let bottomLeft = observation.bottomLeft.cgPoint
+          let isVertical = OCRGeometry.isVertical(
+            text: transcript,
+            topLeft: topLeft,
+            topRight: topRight,
+            imageSize: imageSize,
+            declaredVertical: observation.textDirection == .topToBottom
+          )
+          let dx = (topRight.x - topLeft.x) * imageSize.width
+          let dy = -(topRight.y - topLeft.y) * imageSize.height
+          let angle = isVertical ? 0 : atan2(dy, dx)
+          let rotation = abs(angle) > 0.025 ? angle : 0
+          let orientedHeight = hypot(
+            (bottomLeft.x - topLeft.x) * imageSize.width,
+            (bottomLeft.y - topLeft.y) * imageSize.height
+          ) /
+            imageSize.height
+          let orientedWidth = hypot(dx, dy) / imageSize.width
+          let orientedBox = CGRect(
+            x: box.midX - orientedWidth / 2,
+            y: box.midY - orientedHeight / 2,
+            width: orientedWidth,
+            height: orientedHeight
+          )
           let documentWords = paragraphWords.filter { word in
             let intersection = box.intersection(word.box)
             return !intersection.isNull
@@ -115,9 +141,12 @@ extension OCRClient: DependencyKey {
           return OCRResult.Line(
             boundingBoxNormalized: box,
             text: transcript,
+            rotationRadians: rotation,
+            orientedBox: rotation == 0 ? nil : orientedBox,
+            imageAspectRatio: imageSize.width / imageSize.height,
             isVerticalBlock: isVertical,
             verticalCharScale: isVertical ? box.width : 0,
-            horizontalGlyphScale: horizontalGlyphScale,
+            horizontalGlyphScale: rotation == 0 ? horizontalGlyphScale : orientedHeight,
             recognitionGroupID: groupBase + segmentIndices[lineIndex],
             replacementPatches: patches,
             styleRuns: Self.styleRuns(in: transcript, words: words),
@@ -161,6 +190,7 @@ extension OCRClient: DependencyKey {
         }
       }
       try Task.checkCancellation()
+      lines = try await OCRLineRefiner.refine(lines, in: image, language: language)
       lines = try await OCRBalloonRefiner.refine(lines, in: image, language: language)
       let correctedLines: [OCRResult.Line]
       let languageCode = language.localeLanguage.languageCode?.identifier
@@ -188,7 +218,9 @@ extension OCRClient: DependencyKey {
       Log.ocr.debug(
         "Post-processing produced \(result.lines.count, privacy: .public) lines in \(postProcessingElapsed.loggedSeconds, privacy: .public)s"
       )
-      return result
+      let restored = SourceRestorationBuilder.applying(to: result, image: image)
+      try Task.checkCancellation()
+      return await OCRQualityAssessment.markingUncertainText(in: restored)
     },
     warmUp: { await VisionWarmUp.shared.run() }
   )

--- a/Sources/Dependencies/OCRClient.swift
+++ b/Sources/Dependencies/OCRClient.swift
@@ -161,6 +161,7 @@ extension OCRClient: DependencyKey {
         }
       }
       try Task.checkCancellation()
+      lines = try await OCRBalloonRefiner.refine(lines, in: image, language: language)
       let correctedLines: [OCRResult.Line]
       let languageCode = language.localeLanguage.languageCode?.identifier
       if language.isAuto || languageCode == "ja" {

--- a/Sources/Dependencies/OCRLineRefiner.swift
+++ b/Sources/Dependencies/OCRLineRefiner.swift
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import Foundation
+import Vision
+
+/// A compact mixed-script control can inherit the dominant page language and
+/// lose its last script entirely. Re-read just that small row at a useful scale.
+enum OCRLineRefiner {
+  static func refine(_ lines: [OCRResult.Line], in image: CGImage, language _: Language) async throws -> [OCRResult.Line] {
+    var result = lines
+    var replacements = [Int: [OCRResult.Line]]()
+    for index in lines.indices.filter({ needsRefinement(lines[$0]) }).prefix(6) {
+      try Task.checkCancellation()
+      let box = lines[index].boundingBoxNormalized
+      let rect = CGRect(
+        x: box.minX * CGFloat(image.width),
+        y: box.minY * CGFloat(image.height),
+        width: box.width * CGFloat(image.width),
+        height: box.height * CGFloat(image.height)
+      )
+      .insetBy(dx: -3, dy: -3).integral.intersection(CGRect(x: 0, y: 0, width: image.width, height: image.height))
+      guard
+        let crop = image.cropping(to: rect), let context = CGContext(
+          data: nil,
+          width: crop.width * 3,
+          height: crop.height * 3,
+          bitsPerComponent: 8,
+          bytesPerRow: 0,
+          space: CGColorSpaceCreateDeviceRGB(),
+          bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+      else { continue }
+      context.interpolationQuality = .high
+      context.draw(crop, in: CGRect(x: 0, y: 0, width: context.width, height: context.height))
+      guard let enlarged = context.makeImage() else { continue }
+      var request = RecognizeTextRequest()
+      request.recognitionLevel = .accurate
+      let code = OCRTextSemantics.isCode(lines[index].text)
+      request.usesLanguageCorrection = !code
+      request.automaticallyDetectsLanguage = false
+      var hints = [Locale.Language]()
+      if
+        index > 0,
+        let preceding = LanguageDetectionClient.liveValue.detect(lines[index - 1].text, 0.65)?
+          .localeLanguage { hints.append(preceding) }
+      hints += Locale.preferredLanguages.map { Locale.Language(identifier: $0) }
+      if let inferred = LanguageDetectionClient.liveValue.detect(lines[index].text, 0)?.localeLanguage { hints.append(inferred) }
+      let supported = request.supportedRecognitionLanguages
+      var resolved = [Locale.Language]()
+      for hint in hints {
+        if
+          let match = supported.first(where: { $0.usesSameWritingSystem(as: hint) }),
+          !resolved.contains(match) { resolved.append(match) }
+      }
+      request.recognitionLanguages = code ? [Locale.Language(identifier: "en")] : resolved
+      let rows = try await request.perform(on: enlarged).compactMap { observation -> String? in
+        guard let candidate = observation.topCandidates(1).first, candidate.confidence >= 0.5 else { return nil }
+        return candidate.string
+      }
+      let text = rows.joined(separator: " ")
+      guard text.count >= lines[index].text.count / 2, !text.isEmpty else { continue }
+      if !code, let segments = splitMixedLine(lines[index], hypothesis: text) {
+        replacements[index] = segments
+        continue
+      }
+      result[index].text = text
+      result[index].styleRuns = JapaneseRubyOCRCorrector.remappedStyleRuns(
+        lines[index].styleRuns,
+        from: lines[index].text,
+        to: text
+      )
+    }
+    return result.indices.flatMap { replacements[$0] ?? [result[$0]] }
+  }
+
+  /// Keep each reliably recognized script, and use the second hypothesis only
+  /// for a segment whose script was lost. Each segment retains observed range
+  /// geometry, so different languages no longer share one translation session.
+  static func splitMixedLine(_ line: OCRResult.Line, hypothesis: String) -> [OCRResult.Line]? {
+    let pattern = try! NSRegularExpression(pattern: #"[^/／|]+|[/／|]"#)
+    let source = line.text as NSString
+    let matches = pattern.matches(in: line.text, range: NSRange(location: 0, length: source.length))
+    let alternatives = hypothesis.split(whereSeparator: { "/／|".contains($0) })
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    let originals = matches.filter { !"/／|".contains(source.substring(with: $0.range)) }
+    guard originals.count == alternatives.count, originals.count >= 2 else { return nil }
+    var ordinal = 0
+    var segments = [OCRResult.Line]()
+    for match in matches {
+      let original = source.substring(with: match.range).trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !original.isEmpty else { continue }
+      var text = original
+      var review = false
+      if !"/／|".contains(original) {
+        let alternative = alternatives[ordinal]
+        ordinal += 1
+        let originalIsNumber = original.unicodeScalars.allSatisfy { CharacterSet.decimalDigits.contains($0) }
+        let addsScript = alternative.unicodeScalars
+          .contains { (0x3040...0x9FFF).contains($0.value) || (0xAC00...0xD7AF).contains($0.value) }
+        if originalIsNumber, addsScript { text = alternative
+          review = true
+        }
+      }
+      let runs = line.styleRuns.filter { NSIntersectionRange($0.range, match.range).length > 0 }
+      guard let first = runs.first else { return nil }
+      let box = runs.dropFirst().reduce(first.box) { $0.union($1.box) }
+      var segment = OCRResult.Line(
+        boundingBoxNormalized: box,
+        text: text,
+        rotationRadians: line.rotationRadians,
+        imageAspectRatio: line.imageAspectRatio,
+        horizontalGlyphScale: line.horizontalGlyphScale,
+        replacementPatches: [OverlaySourcePatch(box: box)],
+        alignment: .leading
+      )
+      segment.preventsJoining = true
+      segment.needsReview = review
+      segments.append(segment)
+    }
+    return segments
+  }
+
+  static func needsRefinement(_ line: OCRResult.Line) -> Bool {
+    if !line.isVerticalBlock, line.text.count <= 240, OCRTextSemantics.isCode(line.text) { return true }
+    guard
+      !line.isVerticalBlock, line.text.count <= 100, line.boundingBoxNormalized.height < 0.12,
+      line.text.contains(where: { "/／|".contains($0) }), !OCRTextSemantics.isIdentifier(line.text),
+      !OCRTextSemantics.isCode(line.text)
+    else { return false }
+    let latin = line.text.unicodeScalars.contains { (0x41...0x7A).contains($0.value) }
+    let cjk = line.text.unicodeScalars.contains { (0x3040...0x9FFF).contains($0.value) || (0xAC00...0xD7AF).contains($0.value) }
+    return latin && cjk
+  }
+}

--- a/Sources/Dependencies/OCRQualityAssessment.swift
+++ b/Sources/Dependencies/OCRQualityAssessment.swift
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import AppKit
+import Foundation
+import NaturalLanguage
+
+enum OCRQualityAssessment {
+  /// This is a review hint, never a spelling correction. Domain terms and
+  /// identifiers must not be silently rewritten to dictionary words.
+  @MainActor
+  static func markingUncertainText(in result: OCRResult) -> OCRResult {
+    var result = result
+    var dictionary = [String: Bool]()
+    for i in result.lines.indices {
+      let text = result.lines[i].text
+      guard
+        !OCRTextSemantics.isCode(text), !OCRTextSemantics.isIdentifier(text),
+        LanguageDetectionClient.liveValue.detect(text, 0)?.localeLanguage.languageCode?.identifier == "en"
+      else { continue }
+      let tokenizer = NLTokenizer(unit: .word)
+      tokenizer.string = text
+      tokenizer.setLanguage(.english)
+      let words = tokenizer.tokens(for: text.startIndex..<text.endIndex).map { String(text[$0]) }
+        .filter { $0.count >= 3 && $0.unicodeScalars.allSatisfy(CharacterSet.letters.contains) }
+      guard words.count >= 6 else { continue }
+      let unknown = words.count { word in
+        let normalized = word.lowercased()
+        if let cached = dictionary[normalized] { return cached }
+        let unknown = NSSpellChecker.shared.checkSpelling(
+          of: word.lowercased(),
+          startingAt: 0,
+          language: "en_US",
+          wrap: false,
+          inSpellDocumentWithTag: 0,
+          wordCount: nil
+        ).location != NSNotFound
+        dictionary[normalized] = unknown
+        return unknown
+      }
+      result.lines[i].needsReview = unknown >= 3 && unknown * 4 >= words.count
+    }
+    return result
+  }
+}

--- a/Sources/Dependencies/OverlayClient.swift
+++ b/Sources/Dependencies/OverlayClient.swift
@@ -44,6 +44,7 @@ struct OverlayRenderState: Equatable, Sendable {
   /// Vision is still loading its document model, which takes tens of seconds
   /// when cold — shows a "preparing" note so the empty overlay isn't a mystery.
   var isPreparingRecognition: Bool
+  var lastError: String? = nil
 }
 
 // MARK: - OverlayUserAction

--- a/Sources/Dependencies/ScreenCaptureClient.swift
+++ b/Sources/Dependencies/ScreenCaptureClient.swift
@@ -108,20 +108,45 @@ extension ScreenCaptureClient: DependencyKey {
       configuration.pixelFormat = kCVPixelFormatType_32BGRA
       configuration.showsCursor = false
 
-      if
-        let overlayFrame,
-        let nsScreen,
-        let sourceRect = displayLocalRect(overlayFrame: overlayFrame, screen: nsScreen)
-      {
-        configuration.sourceRect = sourceRect
-        configuration.width = max(1, Int(sourceRect.width * scale))
-        configuration.height = max(1, Int(sourceRect.height * scale))
+      var capturedFrame: CGRect?
+      if let overlayFrame {
+        guard let nsScreen else { throw ScreenCaptureError.noDisplay }
+        let geometry = try ScreenCaptureRegionGeometry(requested: overlayFrame, display: nsScreen.frame)
+        capturedFrame = geometry.intersection
+        configuration.sourceRect = geometry.sourceRect
+        configuration.width = max(1, Int((geometry.intersection.width * scale).rounded(.up)))
+        configuration.height = max(1, Int((geometry.intersection.height * scale).rounded(.up)))
       } else {
         configuration.width = Int(Double(display.width) * scale)
         configuration.height = Int(Double(display.height) * scale)
       }
 
-      return try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: configuration)
+      let image = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: configuration)
+      guard let overlayFrame, let capturedFrame, overlayFrame != capturedFrame else { return image }
+      // A partially off-screen panel still renders over its full frame. Keep
+      // that canvas extent instead of stretching a clipped screenshot across it.
+      let width = max(1, Int((overlayFrame.width * scale).rounded(.up)))
+      let height = max(1, Int((overlayFrame.height * scale).rounded(.up)))
+      guard
+        let context = CGContext(
+          data: nil,
+          width: width,
+          height: height,
+          bitsPerComponent: 8,
+          bytesPerRow: 0,
+          space: CGColorSpace(name: CGColorSpace.sRGB)!,
+          bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+      else { throw ScreenCaptureError.unreadableImage }
+      context.clear(CGRect(x: 0, y: 0, width: width, height: height))
+      context.draw(image, in: CGRect(
+        x: (capturedFrame.minX - overlayFrame.minX) * scale,
+        y: (capturedFrame.minY - overlayFrame.minY) * scale,
+        width: capturedFrame.width * scale,
+        height: capturedFrame.height * scale
+      ))
+      guard let composed = context.makeImage() else { throw ScreenCaptureError.unreadableImage }
+      return composed
     },
     captureWindow: { windowID in
       try await ScreenRecordingPermissionTracker.shared.requestIfNeeded()
@@ -161,18 +186,24 @@ extension DependencyValues {
   }
 }
 
-/// Converts an AppKit-global rectangle (points, bottom-left origin) into
-/// a display-local rectangle in ScreenCaptureKit's top-left coordinate space.
-private func displayLocalRect(overlayFrame: CGRect, screen: NSScreen) -> CGRect? {
-  let screenFrame = screen.frame
-  let intersection = overlayFrame.intersection(screenFrame)
-  guard !intersection.isNull, !intersection.isEmpty else { return nil }
-  return CGRect(
-    x: intersection.minX - screenFrame.minX,
-    y: screenFrame.maxY - intersection.maxY,
-    width: intersection.width,
-    height: intersection.height
-  )
+// MARK: - ScreenCaptureRegionGeometry
+
+/// The requested canvas and captured intersection are distinct coordinate
+/// spaces. A crop outside a display must never become a full-display capture.
+struct ScreenCaptureRegionGeometry: Equatable {
+  init(requested: CGRect, display: CGRect) throws {
+    intersection = requested.intersection(display)
+    guard !intersection.isNull, !intersection.isEmpty else { throw ScreenCaptureError.emptyRegion }
+    sourceRect = CGRect(
+      x: intersection.minX - display.minX,
+      y: display.maxY - intersection.maxY,
+      width: intersection.width,
+      height: intersection.height
+    )
+  }
+
+  let intersection: CGRect
+  let sourceRect: CGRect
 }
 
 // MARK: - ScreenRecordingPermissionTracker

--- a/Sources/Dependencies/TranslationClient.swift
+++ b/Sources/Dependencies/TranslationClient.swift
@@ -14,6 +14,7 @@ struct TranslationLine: Equatable, Sendable {
   var id: UUID
   var text: String
   var attributedText: AttributedString? = nil
+  var modelNotice: String? = nil
   /// Neighboring compact value used only to disambiguate this label. It is
   /// never rendered as part of the label's translated output.
   var trailingContext: String? = nil
@@ -29,6 +30,7 @@ struct TranslationLine: Equatable, Sendable {
 struct TranslatedText: Equatable, Sendable {
   var text: String
   var attributedText: AttributedString? = nil
+  var modelNotice: String? = nil
 }
 
 // MARK: - TranslationTextStructure
@@ -120,12 +122,6 @@ extension TranslationClient: DependencyKey {
     translateBatch: { lines, source, target, strategy in
       AsyncThrowingStream { continuation in
         let pair = "\(source.maximalIdentifier)->\(target.maximalIdentifier)"
-        let session =
-          if #available(macOS 26.4, *) {
-            TranslationSession(installedSource: source, target: target, preferredStrategy: strategy.sessionStrategy)
-          } else {
-            TranslationSession(installedSource: source, target: target)
-          }
         let linesByID = Dictionary(uniqueKeysWithValues: lines.map { ($0.id, $0) })
         let requests = lines.map {
           TranslationSession.Request(sourceText: $0.requestText, clientIdentifier: $0.id.uuidString)
@@ -135,55 +131,67 @@ extension TranslationClient: DependencyKey {
           let started = clock.now
           var receivedFirstResponse = false
           do {
-            var styledTargets = [UUID: String]()
-            for try await response in session.translate(batch: requests) {
-              try Task.checkCancellation()
-              if !receivedFirstResponse {
-                receivedFirstResponse = true
-                let elapsed = clock.now - started
-                Log.translation.debug(
-                  "First response for \(pair, privacy: .public) arrived in \(elapsed.loggedSeconds, privacy: .public)s"
+            let selection = try await TranslationModelResolver.resolve(source: source, target: target, preferred: strategy)
+            try Task.checkCancellation()
+            let session =
+              if #available(macOS 26.4, *) {
+                TranslationSession(installedSource: source, target: target, preferredStrategy: selection.strategy.sessionStrategy)
+              } else {
+                TranslationSession(installedSource: source, target: target)
+              }
+            try await withTaskCancellationHandler {
+              var styledTargets = [UUID: String]()
+              for try await response in session.translate(batch: requests) {
+                try Task.checkCancellation()
+                if !receivedFirstResponse {
+                  receivedFirstResponse = true
+                  let elapsed = clock.now - started
+                  Log.translation.debug(
+                    "First response for \(pair, privacy: .public) arrived in \(elapsed.loggedSeconds, privacy: .public)s"
+                  )
+                }
+                guard
+                  let id = response.clientIdentifier.flatMap(UUID.init(uuidString:)),
+                  let sourceLine = linesByID[id]
+                else { continue }
+                let translatedLabel = sourceLine.trailingContext == nil
+                  ? response.targetText
+                  : TranslationTextStructure.label(fromContextualTranslation: response.targetText)
+                    ?? response.targetText
+                let targetText = TranslationTextStructure.matchingSourceBreaks(
+                  translatedLabel,
+                  source: sourceLine.text
+                )
+                var attributedTarget: AttributedString?
+                if #available(macOS 26.4, *), let attributedSource = sourceLine.attributedText {
+                  let alignment = TranslationStyleMapper.align(source: attributedSource, target: targetText)
+                  attributedTarget = alignment.target
+                  if !alignment.unmatched.isEmpty { styledTargets[id] = targetText }
+                }
+                // Text is usable now. Optional style-snippet translation must
+                // never hold an entire paragraph behind the rest of the batch.
+                continuation.yield(TranslationLine(
+                  id: id,
+                  text: targetText,
+                  attributedText: attributedTarget,
+                  modelNotice: selection.notice
+                ))
+              }
+              if #available(macOS 26.4, *), !styledTargets.isEmpty {
+                try await Self.yieldStyledTranslations(
+                  styledTargets,
+                  linesByID: linesByID,
+                  session: session,
+                  continuation: continuation,
+                  modelNotice: selection.notice
                 )
               }
-              guard
-                let id = response.clientIdentifier.flatMap(UUID.init(uuidString:)),
-                let sourceLine = linesByID[id]
-              else { continue }
-              let translatedLabel = sourceLine.trailingContext == nil
-                ? response.targetText
-                : TranslationTextStructure.label(fromContextualTranslation: response.targetText)
-                  ?? response.targetText
-              let targetText = TranslationTextStructure.matchingSourceBreaks(
-                translatedLabel,
-                source: sourceLine.text
+              let elapsed = clock.now - started
+              Log.translation.debug(
+                "Batch of \(lines.count, privacy: .public) lines (\(pair, privacy: .public)) finished in \(elapsed.loggedSeconds, privacy: .public)s"
               )
-              var attributedTarget: AttributedString?
-              if #available(macOS 26.4, *), let attributedSource = sourceLine.attributedText {
-                let alignment = TranslationStyleMapper.align(source: attributedSource, target: targetText)
-                attributedTarget = alignment.target
-                if !alignment.unmatched.isEmpty { styledTargets[id] = targetText }
-              }
-              // Text is usable now. Optional style-snippet translation must
-              // never hold an entire paragraph behind the rest of the batch.
-              continuation.yield(TranslationLine(
-                id: id,
-                text: targetText,
-                attributedText: attributedTarget
-              ))
-            }
-            if #available(macOS 26.4, *), !styledTargets.isEmpty {
-              try await Self.yieldStyledTranslations(
-                styledTargets,
-                linesByID: linesByID,
-                session: session,
-                continuation: continuation
-              )
-            }
-            let elapsed = clock.now - started
-            Log.translation.debug(
-              "Batch of \(lines.count, privacy: .public) lines (\(pair, privacy: .public)) finished in \(elapsed.loggedSeconds, privacy: .public)s"
-            )
-            continuation.finish()
+              continuation.finish()
+            } onCancel: { session.cancel() }
           } catch {
             continuation.finish(throwing: error)
           }
@@ -203,12 +211,6 @@ extension TranslationClient: DependencyKey {
         }
         continuation.onTermination = { _ in
           watchdog.cancel()
-          // `task.cancel()` alone doesn't stop work already handed to the
-          // translation daemon — `cancel()` is the documented way to stop a
-          // session's ongoing work. Without it, every live tick whose batch
-          // outruns the capture interval abandons a session that keeps working
-          // daemon-side, and they accumulate for the life of the process.
-          session.cancel()
           task.cancel()
         }
       }
@@ -222,7 +224,8 @@ extension TranslationClient: DependencyKey {
     _ targets: [UUID: String],
     linesByID: [UUID: TranslationLine],
     session: TranslationSession,
-    continuation: AsyncThrowingStream<TranslationLine, any Error>.Continuation
+    continuation: AsyncThrowingStream<TranslationLine, any Error>.Continuation,
+    modelNotice: String?
   ) async throws {
     var alternatives = [UUID: [URL: String]]()
     var snippetOwners = [UUID: (lineID: UUID, link: URL)]()
@@ -270,7 +273,8 @@ extension TranslationClient: DependencyKey {
       continuation.yield(TranslationLine(
         id: lineID,
         text: targetText,
-        attributedText: alignment.target
+        attributedText: alignment.target,
+        modelNotice: modelNotice
       ))
     }
   }

--- a/Sources/Dependencies/TranslationModelResolver.swift
+++ b/Sources/Dependencies/TranslationModelResolver.swift
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Foundation
+import Translation
+
+enum TranslationModelResolver {
+  struct Selection: Sendable {
+    var strategy: TranslationStrategy
+    var notice: String?
+  }
+
+  struct ModelError: LocalizedError {
+    var message: String
+
+    var errorDescription: String? {
+      message
+    }
+  }
+
+  static func choose(
+    preferred: TranslationStrategy,
+    preferredInstalled: Bool,
+    alternativeInstalled: Bool
+  ) -> TranslationStrategy? {
+    if preferredInstalled { return preferred }
+    if alternativeInstalled { return preferred == .lowLatency ? .highFidelity : .lowLatency }
+    return nil
+  }
+
+  static func resolve(
+    source: Locale.Language,
+    target: Locale.Language,
+    preferred: TranslationStrategy
+  ) async throws -> Selection {
+    guard #available(macOS 26.4, *) else { return Selection(strategy: preferred) }
+    let alternative: TranslationStrategy = preferred == .lowLatency ? .highFidelity : .lowLatency
+    let requested = await LanguageAvailability(preferredStrategy: preferred.sessionStrategy).status(from: source, to: target)
+    if requested == .installed { return Selection(strategy: preferred) }
+    try Task.checkCancellation()
+    let other = await LanguageAvailability(preferredStrategy: alternative.sessionStrategy).status(from: source, to: target)
+    let sourceName = Locale.current
+      .localizedString(forLanguageCode: source.languageCode?.identifier ?? source.maximalIdentifier) ?? source.maximalIdentifier
+    let targetName = Locale.current
+      .localizedString(forLanguageCode: target.languageCode?.identifier ?? target.maximalIdentifier) ?? target.maximalIdentifier
+    guard
+      let selected = choose(
+        preferred: preferred,
+        preferredInstalled: requested == .installed,
+        alternativeInstalled: other == .installed
+      )
+    else {
+      throw ModelError(message: requested == .unsupported && other == .unsupported
+        ? "Translation is not supported from \(sourceName) to \(targetName)."
+        : "No translation model is installed for \(sourceName) → \(targetName). Download these languages in System Settings.")
+    }
+    // This is resolved before submitting any work, not retried after an opaque
+    // engine failure. Every response carries the choice so the UI explains it.
+    return Selection(
+      strategy: selected,
+      notice: "Using \(selected.displayName) for \(sourceName) → \(targetName); the preferred model is not installed."
+    )
+  }
+
+}

--- a/Sources/Models/OCRGeometry.swift
+++ b/Sources/Models/OCRGeometry.swift
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Foundation
+
+// MARK: - OCRGeometry
+
+enum OCRGeometry {
+  static func isVertical(text: String, topLeft: CGPoint, topRight: CGPoint, imageSize: CGSize, declaredVertical: Bool) -> Bool {
+    if declaredVertical { return true }
+    let dx = abs(topRight.x - topLeft.x) * imageSize.width
+    let dy = abs(topRight.y - topLeft.y) * imageSize.height
+    return dy > dx * 2 && OverlayTextFlowResolver.scriptEvidence(in: text).verticalCharacterCount >= 2
+  }
+
+  static func alignedBox(_ box: CGRect, angle: CGFloat, aspect: CGFloat) -> CGRect {
+    let x = box.midX * aspect
+    let y = box.midY
+    return CGRect(
+      x: (x * cos(angle) + y * sin(angle)) / aspect - box.width / 2,
+      y: -x * sin(angle) + y * cos(angle) - box.height / 2,
+      width: box.width,
+      height: box.height
+    )
+  }
+
+  static func combinedFrame(_ lines: [OCRResult.Line], angle: CGFloat) -> CGRect {
+    let aspect = lines.first?.imageAspectRatio ?? 1
+    let projected = lines.map { alignedBox($0.orientedBox ?? $0.boundingBoxNormalized, angle: angle, aspect: aspect) }
+    let union = projected.dropFirst().reduce(projected[0]) { $0.union($1) }
+    let x = union.midX * aspect
+    let y = union.midY
+    return CGRect(
+      x: (x * cos(angle) - y * sin(angle)) / aspect - union.width / 2,
+      y: x * sin(angle) + y * cos(angle) - union.height / 2,
+      width: union.width,
+      height: union.height
+    )
+  }
+}
+
+extension OCRResult.Line {
+  var alignedBox: CGRect {
+    guard abs(rotationRadians) > 0.025 else { return orientedBox ?? boundingBoxNormalized }
+    return OCRGeometry.alignedBox(orientedBox ?? boundingBoxNormalized, angle: rotationRadians, aspect: imageAspectRatio)
+  }
+}

--- a/Sources/Models/OCRResult.swift
+++ b/Sources/Models/OCRResult.swift
@@ -12,9 +12,14 @@ struct OCRResult: Equatable, Sendable {
     /// Top-left origin, 0–1 normalized to the captured frame.
     var boundingBoxNormalized: CGRect
     var text: String
+    var rotationRadians: CGFloat = 0
+    var orientedBox: CGRect?
+    var imageAspectRatio: CGFloat = 1
     /// How many source rows this line spans. >1 after wrapped lines are
     /// stitched into one sentence, so the renderer can size the font to a
     /// single row and wrap the text instead of stretching it.
+    var preventsJoining = false
+    var needsReview = false
     var rowCount = 1
     /// True when this is a block of vertical (top-to-bottom) CJK columns stitched
     /// together. The renderer lays the translation out vertically over the box.
@@ -153,11 +158,17 @@ struct OCRResult: Equatable, Sendable {
       )
       let appearance = Self.representativeAppearance(in: fragments)
       let groupIDs = Set(fragments.compactMap(\.recognitionGroupID))
+      let rotation = fragments.max { $0.boundingBoxNormalized.width < $1.boundingBoxNormalized.width }?.rotationRadians ?? 0
       return (
         indices[0],
         Line(
           boundingBoxNormalized: box,
           text: text,
+          rotationRadians: rotation,
+          orientedBox: fragments.contains(where: { $0.orientedBox != nil })
+            ? OCRGeometry.combinedFrame(fragments, angle: rotation)
+            : nil,
+          imageAspectRatio: fragments[0].imageAspectRatio,
           rowCount: totalRows,
           isVerticalBlock: isVertical,
           verticalCharScale: weightedScale,
@@ -242,6 +253,11 @@ struct OCRResult: Equatable, Sendable {
 
       var base = result[baseIndex]
       let baseBox = base.boundingBoxNormalized.standardized
+      base.orientedBox = base.orientedBox ?? baseBox
+      if base.replacementPatches.isEmpty { base.replacementPatches = [OverlaySourcePatch(
+        box: baseBox,
+        appearance: base.appearance
+      )] }
       base.boundingBoxNormalized = baseBox.union(rubyBox)
       base.replacementPatches.append(contentsOf: ruby.replacementPatches.isEmpty
         ? [OverlaySourcePatch(box: rubyBox, appearance: ruby.appearance)]
@@ -294,7 +310,12 @@ struct OCRResult: Equatable, Sendable {
     _ rhs: Line,
     suppressesInlineMerge: Bool
   ) -> Bool {
-    guard !lhs.isReconstructedTextRegion, !rhs.isReconstructedTextRegion else { return false }
+    guard
+      !lhs.isReconstructedTextRegion, !rhs.isReconstructedTextRegion, !lhs.preventsJoining,
+      !rhs.preventsJoining
+    else { return false }
+    guard !OCRTextSemantics.isCode(lhs.text), !OCRTextSemantics.isCode(rhs.text) else { return false }
+    guard abs(lhs.rotationRadians - rhs.rotationRadians) <= 0.04 else { return false }
     return switch (lhs.isVerticalBlock, rhs.isVerticalBlock) {
     case (true, true):
       areNeighboringVerticalColumns(lhs, rhs)
@@ -649,8 +670,8 @@ struct OCRResult: Equatable, Sendable {
   }
 
   private static func isOnSameVisualRow(_ lhs: Line, _ rhs: Line) -> Bool {
-    let a = lhs.boundingBoxNormalized.standardized
-    let b = rhs.boundingBoxNormalized.standardized
+    let a = lhs.alignedBox.standardized
+    let b = rhs.alignedBox.standardized
     guard a.height > 0, b.height > 0 else { return false }
     let verticalOverlap = max(0, min(a.maxY, b.maxY) - max(a.minY, b.minY))
     return verticalOverlap / min(a.height, b.height) >= 0.55
@@ -708,10 +729,18 @@ struct OCRResult: Equatable, Sendable {
   }
 
   private static func areNeighboringHorizontalRows(_ lhs: Line, _ rhs: Line) -> Bool {
-    let a = lhs.boundingBoxNormalized.standardized
-    let b = rhs.boundingBoxNormalized.standardized
+    let a = lhs.alignedBox.standardized
+    let b = rhs.alignedBox.standardized
     guard a.width > 0, a.height > 0, b.width > 0, b.height > 0 else { return false }
     let lowerLine = a.minY <= b.minY ? rhs : lhs
+    let upperLine = a.minY <= b.minY ? lhs : rhs
+    let upperText = upperLine.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    let continuesSentence = lowerLine.text.first?.isLowercase == true
+      && upperText.split(whereSeparator: \.isWhitespace).count >= 6
+      && (upperText.contains(". ") || upperLine.rowCount > 1
+        || (lhs.recognitionGroupID != nil && lhs.recognitionGroupID == rhs.recognitionGroupID))
+      && upperText.last.map { !".!?。！？".contains($0) } == true
+      && hasCompatibleAppearance(lhs, rhs)
     // A list marker is a semantic paragraph boundary even when the neighboring
     // item is multiline, shares the same appearance, and sits at ordinary CSS
     // line spacing. Without this boundary, connected-component coalescing can
@@ -722,12 +751,12 @@ struct OCRResult: Equatable, Sendable {
     let crossesVisionParagraphBoundary = lhs.recognitionGroupID != nil
       && rhs.recognitionGroupID != nil
       && lhs.recognitionGroupID != rhs.recognitionGroupID
-    if hasMaterialTypographyBreak(lhs, rhs), !isLowContrastBodyWeightNoise(lhs, rhs) {
+    if hasMaterialTypographyBreak(lhs, rhs), !isLowContrastBodyWeightNoise(lhs, rhs), !continuesSentence {
       return false
     }
     let hasContinuousBodyAppearance = hasCompatibleBodyAppearance(lhs, rhs)
     let continuesAcrossParagraphBoundary = crossesVisionParagraphBoundary
-      && sharesSourceSurface(lhs, rhs)
+      && (sharesSourceSurface(lhs, rhs) || continuesSentence)
       && (hasCompatibleAppearance(lhs, rhs) || hasContinuousBodyAppearance)
 
     let horizontalOverlap = max(0, min(a.maxX, b.maxX) - max(a.minX, b.minX))
@@ -945,7 +974,7 @@ struct OCRResult: Equatable, Sendable {
     let overlap = max(0, min(rubyBox.maxX, base.maxX) - max(rubyBox.minX, base.minX))
     guard overlap / max(0.000_001, rubyBox.width) >= 0.7 else { return false }
     let verticalGap = max(0, base.minY - rubyBox.maxY)
-    return verticalGap <= max(rubyBox.height, base.height * 0.25)
+    return verticalGap <= max(min(rubyBox.height * 1.5, base.height * 0.7), base.height * 0.25)
   }
 
   private static func rubyBaseDistance(_ base: CGRect, _ ruby: CGRect) -> CGFloat {

--- a/Sources/Models/OCRResult.swift
+++ b/Sources/Models/OCRResult.swift
@@ -41,6 +41,8 @@ struct OCRResult: Equatable, Sendable {
     /// visual text region. Appearance analysis uses the union only in this
     /// case, so an inline chip cannot become the paragraph's base style.
     var wasCoalesced = false
+    /// A complete image-bounded paragraph; neighboring balloons must stay separate.
+    var isReconstructedTextRegion = false
     /// Dominant local background and readable foreground sampled from the
     /// original pixels, used to redraw the translation as an in-place replacement.
     var appearance = OverlaySourceAppearance.fallback
@@ -292,7 +294,8 @@ struct OCRResult: Equatable, Sendable {
     _ rhs: Line,
     suppressesInlineMerge: Bool
   ) -> Bool {
-    switch (lhs.isVerticalBlock, rhs.isVerticalBlock) {
+    guard !lhs.isReconstructedTextRegion, !rhs.isReconstructedTextRegion else { return false }
+    return switch (lhs.isVerticalBlock, rhs.isVerticalBlock) {
     case (true, true):
       areNeighboringVerticalColumns(lhs, rhs)
     case (true, false):

--- a/Sources/Models/OCRTextSemantics.swift
+++ b/Sources/Models/OCRTextSemantics.swift
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Foundation
+
+/// Syntax is independent of sampled font appearance. OCR can misclassify a
+/// monospace font, but that must never make executable source into prose.
+enum OCRTextSemantics {
+  static func isIdentifier(_ text: String) -> Bool {
+    let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    if
+      !text.isEmpty, text.count <= 10,
+      text.unicodeScalars
+        .allSatisfy({ CharacterSet.punctuationCharacters.contains($0) || CharacterSet.symbols.contains($0) }) { return true }
+    if text.range(of: #"^(?:https?|file|ssh)://\S+$"#, options: .regularExpression) != nil { return true }
+    if
+      text.range(
+        of: #"^(?:MIT|(?:A|L)?GPL(?:-\d[\w.-]*)?|BSD(?:-\d[\w.-]*)?|Apache-\d[\w.-]*|MPL-\d[\w.-]*|CC0(?:-\d[\w.-]*)?)$"#,
+        options: .regularExpression
+      ) != nil { return true }
+    if text.range(of: #"^v?\d+(?:\.\d+){1,3}(?:[-+][\w.-]+)?$"#, options: .regularExpression) != nil { return true }
+    return false
+  }
+
+  static func isCode(_ text: String) -> Bool {
+    let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !text.isEmpty else { return false }
+    if text.hasPrefix("//") || text.hasPrefix("#!") || text.hasPrefix("```") { return true }
+    if ["{", "}", "};", "]", ");"].contains(text) { return true }
+    let patterns = [
+      #"^(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*\s*="#,
+      #"^(?:let|var|const|func|def|class|struct|enum|import|from)\s+[^\s]+.*(?:[=:{(]|\bimport\b)"#,
+      #"^(?:if|while|for|switch|guard)\s+.*[{}=():]"#,
+      #"^return\s+(?:nil|null|true|false|\w+[.(])"#,
+      #"^(?:git|swift|cargo|npm|pnpm|yarn|pip|python\d*|curl|wget|brew|tuist|xcodebuild)\s+\S+"#,
+    ]
+    return patterns.contains { text.range(of: $0, options: .regularExpression) != nil }
+  }
+}

--- a/Sources/Models/OverlayLine.swift
+++ b/Sources/Models/OverlayLine.swift
@@ -39,8 +39,11 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
         styleRuns: line.styleRuns,
         fallback: line.appearance
       )
+      needsReview = line.needsReview
       isReconstructedTextRegion = line.isReconstructedTextRegion
       box = line.boundingBoxNormalized
+      orientedBox = line.orientedBox
+      rotationRadians = line.rotationRadians
       text = line.text
       self.language = language
       appearance = semanticAppearance
@@ -65,9 +68,12 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
 
     // MARK: Internal
 
+    var needsReview = false
     var isReconstructedTextRegion = false
     /// Top-left origin, 0–1 normalized to the captured frame.
     var box: CGRect
+    var orientedBox: CGRect?
+    var rotationRadians: CGFloat = 0
     var text: String
     var language: Locale.Language
     var layout: OverlaySourceLayout
@@ -85,6 +91,7 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
     /// monospace metrics, and native rounded backgrounds while also avoiding a
     /// needless translation request.
     var isProtectedLiteral: Bool {
+      if OCRTextSemantics.isIdentifier(text) || OCRTextSemantics.isCode(text) { return true }
       guard case .horizontal = layout, appearance.fontDesign == .monospaced else { return false }
       let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
       let words = text.split(whereSeparator: \.isWhitespace)
@@ -518,6 +525,7 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
 
   let id: UUID
   var source: Source
+  private(set) var modelNotice: String?
   private(set) var content: Content
 
   var displayedText: String {
@@ -566,8 +574,10 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
   mutating func showTranslation(
     _ text: String,
     attributedText: AttributedString? = nil,
-    language: Locale.Language
+    language: Locale.Language,
+    modelNotice: String? = nil
   ) {
+    self.modelNotice = modelNotice
     let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !text.isEmpty else {
       content = .unavailable

--- a/Sources/Models/OverlayLine.swift
+++ b/Sources/Models/OverlayLine.swift
@@ -39,6 +39,7 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
         styleRuns: line.styleRuns,
         fallback: line.appearance
       )
+      isReconstructedTextRegion = line.isReconstructedTextRegion
       box = line.boundingBoxNormalized
       text = line.text
       self.language = language
@@ -64,6 +65,7 @@ struct OverlayLine: Equatable, Identifiable, Sendable {
 
     // MARK: Internal
 
+    var isReconstructedTextRegion = false
     /// Top-left origin, 0–1 normalized to the captured frame.
     var box: CGRect
     var text: String

--- a/Sources/Models/OverlaySourceAppearance.swift
+++ b/Sources/Models/OverlaySourceAppearance.swift
@@ -90,6 +90,7 @@ struct OverlaySourcePatch: Equatable, Hashable, Sendable {
   /// larger sentence, such as the old position of an inline-code pill. These
   /// patches must survive flat-row consolidation.
   var erasesDistinctSurface = false
+  var restorationPNG: Data? = nil
 }
 
 // MARK: - OverlaySourceSurface

--- a/Sources/Models/OverlaySourceAppearance.swift
+++ b/Sources/Models/OverlaySourceAppearance.swift
@@ -108,4 +108,6 @@ struct OverlaySourceSurface: Equatable, Hashable, Sendable {
   /// Corner radius relative to the surface's shorter side. Pixel flood-fill
   /// distinguishes balloons and pills from rectangular UI surfaces.
   var cornerRadiusFraction: CGFloat = 0
+  /// Image-bounded interiors for irregular printed text regions.
+  var clippingRows = [CGRect]()
 }

--- a/Sources/Models/OverlayTranslationPolicy.swift
+++ b/Sources/Models/OverlayTranslationPolicy.swift
@@ -23,6 +23,7 @@ enum OverlayTranslationPolicy {
     return sources.indices.contains { candidate in
       candidate != index
         && sources[candidate].isProtectedLiteral
+        && !OCRTextSemantics.isIdentifier(sources[candidate].text)
         && sharesVisualRow(source.box, sources[candidate].box)
     }
   }
@@ -45,7 +46,8 @@ enum OverlayTranslationPolicy {
     }
     // One nearby number can be ordinary prose. Repeated compact values on the
     // same row are the structural signal for a badge/segmented-control run.
-    guard rowValues.count >= 2 else { return nil }
+    let explicitLabel = source.text.hasSuffix(":") || source.text.split(whereSeparator: \.isWhitespace).count == 1
+    guard rowValues.count >= 2 || explicitLabel else { return nil }
 
     return rowValues.compactMap { candidate -> (gap: CGFloat, text: String)? in
       let value = sources[candidate]
@@ -54,7 +56,7 @@ enum OverlayTranslationPolicy {
       let gap = valueBox.minX - labelBox.maxX
       guard
         gap >= -max(labelBox.height, valueBox.height) * 0.1,
-        gap <= max(labelBox.height, valueBox.height) * 0.35
+        gap <= max(labelBox.height, valueBox.height) * 2
       else { return nil }
       return (gap, value.text.trimmingCharacters(in: .whitespacesAndNewlines))
     }
@@ -89,17 +91,23 @@ enum OverlayTranslationPolicy {
       text.unicodeScalars.contains(where: CharacterSet.decimalDigits.contains)
     else { return false }
 
-    return text.split(whereSeparator: \.isWhitespace).contains { token in
-      let letters = token.unicodeScalars.filter(CharacterSet.letters.contains)
-      guard letters.count >= 2 else { return false }
-      let uppercase = letters.count(where: CharacterSet.uppercaseLetters.contains)
-      let lowercase = letters.count(where: CharacterSet.lowercaseLetters.contains)
-      return uppercase == letters.count || (uppercase >= 2 && lowercase >= 1)
-    }
+    let words = text.split(whereSeparator: \.isWhitespace)
+    guard
+      let first = words.first,
+      words.dropFirst().allSatisfy({ $0.range(of: #"^v?\d\S*$"#, options: .regularExpression) != nil })
+    else { return false }
+    let letters = first.unicodeScalars.filter(CharacterSet.letters.contains)
+    guard
+      letters.count >= 2,
+      letters.allSatisfy({ (0x41...0x5A).contains($0.value) || (0x61...0x7A).contains($0.value) })
+    else { return false }
+    let upper = letters.count { (0x41...0x5A).contains($0.value) }
+    return upper == letters.count || upper >= 2
   }
 
   private static func isContextValue(_ source: OverlayLine.Source) -> Bool {
-    source.isProtectedLiteral
+    guard source.text.unicodeScalars.contains(where: { CharacterSet.alphanumerics.contains($0) }) else { return false }
+    return source.isProtectedLiteral
       || source.isProtectedVisualMetadata
       || isNonlinguisticMetadata(source.text)
       || isVersionedTechnicalMetadata(source.text)

--- a/Sources/Overlay/OverlayLayoutEngine.swift
+++ b/Sources/Overlay/OverlayLayoutEngine.swift
@@ -206,6 +206,7 @@ enum OverlayLayoutEngine {
       canvas: canvas,
       safeBounds: safeBounds
     )
+    if line.source.isReconstructedTextRegion { return surfaceFrame }
     guard surfaceFrame.contains(CGPoint(x: sourceFrame.midX, y: sourceFrame.midY)) else {
       return sourceFrame
     }
@@ -403,6 +404,7 @@ enum OverlayLayoutEngine {
     safeBounds: CGRect,
     among lines: [OverlayLine]
   ) -> OverlayTextAlignment {
+    if line.source.isReconstructedTextRegion { return .center }
     switch flow {
     case .vertical:
       return .center
@@ -629,7 +631,7 @@ enum OverlayLayoutEngine {
       ? line.source.horizontalGlyphScale
       : sourceFrame.height / CGFloat(max(1, rows)) / canvasSize.height
     // Weight changes stroke thickness, not point size.
-    let boxBasedSize = boxScale * canvasSize.height * 0.94
+    let boxBasedSize = boxScale * canvasSize.height * (line.source.isReconstructedTextRegion ? 1.2 : 0.94)
     // Vision line boxes can include icons, controls, or Japanese ruby. Whenever
     // pixel ink shows that inflation clearly, cap the estimate for every source
     // scale rather than only large controls.

--- a/Sources/Overlay/OverlayLayoutEngine.swift
+++ b/Sources/Overlay/OverlayLayoutEngine.swift
@@ -60,7 +60,7 @@ enum OverlayLayoutEngine {
       // stay as untouched source pixels.
       guard line.translatedText != nil else { return nil }
       let sourceFrame = sourceFrame(
-        for: line.source.box,
+        for: line.source.orientedBox ?? line.source.box,
         canvas: canvas,
         safeBounds: safeBounds
       )
@@ -97,6 +97,22 @@ enum OverlayLayoutEngine {
     }
   }
 
+  /// An eraser belonging to a translated neighbor must not touch source that
+  /// is pending, unavailable, or deliberately preserved (including separators).
+  static func protectedSourceFrames(for lines: [OverlayLine], in size: CGSize, displayScale: CGFloat) -> [CGRect] {
+    let halo = 1 / max(1, displayScale)
+    return lines.filter { $0.translatedText == nil }.flatMap { line in
+      line.source.replacementPatches.map { patch in
+        CGRect(
+          x: patch.box.minX * size.width,
+          y: patch.box.minY * size.height,
+          width: patch.box.width * size.width,
+          height: patch.box.height * size.height
+        ).insetBy(dx: -halo, dy: -halo)
+      }
+    }
+  }
+
   static func replacementFrame(
     for patch: OverlaySourcePatch,
     sourceLayout: OverlaySourceLayout,
@@ -113,6 +129,7 @@ enum OverlayLayoutEngine {
       width: max(1, box.width * canvasSize.width),
       height: max(1, box.height * canvasSize.height)
     )
+    if patch.restorationPNG != nil { return source }
     // Vision boxes hug the strongest part of antialiased glyphs and can omit a
     // few faint edge pixels, especially around large Japanese headings. Scale
     // the restoration bleed with glyph height while keeping it tightly bounded.
@@ -197,6 +214,7 @@ enum OverlayLayoutEngine {
     canvas: CGRect,
     safeBounds: CGRect
   ) -> CGRect {
+    if abs(line.source.rotationRadians) > 0.025 { return sourceFrame }
     guard let surface = line.source.surface, surface.confidence >= 0.35 else {
       return sourceFrame
     }

--- a/Sources/Overlay/OverlaySourceAppearanceAnalyzer.swift
+++ b/Sources/Overlay/OverlaySourceAppearanceAnalyzer.swift
@@ -132,7 +132,7 @@ enum OverlaySourceAppearanceAnalyzer {
           line.replacementPatches.append(rubyPatch)
         }
       }
-      line.surface = surfaceRaster.flatMap {
+      line.surface = (line.isReconstructedTextRegion ? line.surface : nil) ?? surfaceRaster.flatMap {
         inferredSurface(
           containing: line.boundingBoxNormalized,
           appearance: line.appearance,

--- a/Sources/Overlay/OverlayView.swift
+++ b/Sources/Overlay/OverlayView.swift
@@ -21,6 +21,7 @@ struct OverlayView: View {
   /// Translation failed (usually a missing model) — shows the "open Settings"
   /// hint banner along the bottom.
   var translationUnavailable = false
+  var lastError: String? = nil
   /// Vision is still loading its document model (tens of seconds when cold).
   var isPreparingRecognition = false
   /// Window live mode: the overlay is a thin region frame; the translation
@@ -60,6 +61,17 @@ struct OverlayView: View {
       }
       .overlay(alignment: .topTrailing) {
         HStack(spacing: 6) {
+          if lines.contains(where: { $0.source.needsReview }) {
+            Image(systemName: "exclamationmark.triangle")
+              .foregroundStyle(.orange)
+              .help("Some text may be misread. Compare with the original.")
+          }
+          if showMoveHandle {
+            let notices = Array(Set(lines.compactMap(\.modelNotice))).sorted()
+            if !notices.isEmpty {
+              Image(systemName: "info.circle").help(notices.joined(separator: "\n"))
+            }
+          }
           // A small spinner while the overlay is busy (capturing / OCR or
           // translating); nothing otherwise.
           if isTranslating {
@@ -83,7 +95,7 @@ struct OverlayView: View {
       }
       .overlay(alignment: .bottom) {
         if translationUnavailable, !frameOnly {
-          TranslationModelHint()
+          TranslationModelHint(message: lastError)
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             .padding(8)
             .transition(.opacity)

--- a/Sources/Overlay/OverlayWindowController.swift
+++ b/Sources/Overlay/OverlayWindowController.swift
@@ -110,6 +110,7 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
   /// value or not, so blindly re-assigning `lines` or the backdrop on each
   /// render invalidated the whole overlay view tree at the live capture rate.
   private func assign(_ state: OverlayRenderState) {
+    if model.lastError != state.lastError { model.lastError = state.lastError }
     if model.lines != state.lines { model.lines = state.lines }
     if model.hideOnHover != state.hideOnHover { model.hideOnHover = state.hideOnHover }
     if model.isTranslating != state.isTranslating { model.isTranslating = state.isTranslating }
@@ -252,7 +253,11 @@ final class OverlayWindowController: NSObject, NSWindowDelegate {
     // Global fires while events pass through to apps below (interior); local
     // fires while the window is interactive near an edge / on the handle.
     // Together they keep the cursor state current as it moves in and out.
-    let global = NSEvent.addGlobalMonitorForEvents(matching: [.mouseMoved, .leftMouseDragged, .scrollWheel]) { [weak self] event in
+    let global = NSEvent.addGlobalMonitorForEvents(matching: [
+      .mouseMoved,
+      .leftMouseDragged,
+      .scrollWheel,
+    ]) { [weak self] event in
       MainActor.assumeIsolated {
         self?.updatePassThroughForCursor()
         self?.sourceContentInteracted(event)
@@ -418,6 +423,7 @@ final class OverlayWindowModel {
   var imageSize = CGSize.zero
   var translationUnavailable = false
   var isPreparingRecognition = false
+  var lastError: String?
 
   /// In Window mode while live, the overlay is just a thin region frame and the
   /// translation lives in a detached window.
@@ -442,6 +448,7 @@ private struct OverlayRootView: View {
       isTranslating: model.isTranslating,
       isLive: model.isLive,
       translationUnavailable: model.translationUnavailable,
+      lastError: model.lastError,
       isPreparingRecognition: model.isPreparingRecognition,
       frameOnly: model.isWindowFrame,
       showMoveHandle: model.cursorInside,
@@ -484,12 +491,14 @@ private struct LiveResultView: View {
   var body: some View {
     content
       .frame(maxWidth: .infinity, maxHeight: .infinity)
-      .overlay(alignment: .bottom) {
+      .safeAreaInset(edge: .bottom, spacing: 0) {
         if model.translationUnavailable {
-          TranslationModelHint()
+          TranslationModelHint(message: model.lastError)
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             .padding(8)
             .transition(.opacity)
+        } else {
+          CaptureStatusNote(lines: model.lines).padding(8)
         }
       }
       .animation(.easeOut(duration: 0.15), value: model.translationUnavailable)

--- a/Sources/Overlay/SourceRestorationBuilder.swift
+++ b/Sources/Overlay/SourceRestorationBuilder.swift
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import Foundation
+
+/// Extends masks to observed ink, not an arbitrary larger rectangle. On textured
+/// surfaces, replace only glyph pixels using nearby background samples while
+/// retaining the actual surrounding pixels in a local restoration tile.
+enum SourceRestorationBuilder {
+
+  // MARK: Internal
+
+  static func applying(to result: OCRResult, image: CGImage) -> OCRResult {
+    guard
+      let context = CGContext(
+        data: nil,
+        width: image.width,
+        height: image.height,
+        bitsPerComponent: 8,
+        bytesPerRow: image.width * 4,
+        space: CGColorSpace(name: CGColorSpace.sRGB)!,
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    else { return result }
+    context.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
+    guard let data = context.data else { return result }
+    defer { withExtendedLifetime(context) { } }
+    let pixels = data.bindMemory(to: UInt8.self, capacity: image.width * image.height * 4)
+    func color(_ x: Int, _ y: Int) -> Pixel {
+      let i = (y * image.width + x) * 4
+      return Pixel(r: Int(pixels[i]), g: Int(pixels[i + 1]), b: Int(pixels[i + 2]))
+    }
+    var result = result
+    for i in result.lines.indices {
+      if Task.isCancelled { break }
+      let line = result.lines[i]
+      guard !OCRTextSemantics.isCode(line.text), !OCRTextSemantics.isIdentifier(line.text) else { continue }
+      let bounds = line.boundingBoxNormalized
+      var samples = [Int]()
+      for y in [Int(bounds.minY * CGFloat(image.height)) - 2, Int(bounds.maxY * CGFloat(image.height)) + 2]
+        where y >= 0 && y < image.height
+      {
+        for x in stride(
+          from: max(0, Int(bounds.minX * CGFloat(image.width))),
+          to: min(image.width, Int(bounds.maxX * CGFloat(image.width))),
+          by: 3
+        ) {
+          samples.append(color(x, y).luminance)
+        }
+      }
+      samples.sort()
+      var histogram = [Int: Int]()
+      for sample in samples { histogram[sample / 12, default: 0] += 1 }
+      let textured = samples.count >= 30 && samples[samples.count * 9 / 10] - samples[samples.count / 10] > 24
+        && histogram.values.count(where: { $0 * 20 >= samples.count }) >= 3
+      if textured {
+        // Background variation is not an inline badge/code style. Keeping
+        // those false style spans would repaint blocks over the restored tile.
+        result.lines[i].styleRuns = line.styleRuns.map { run in
+          var run = run
+          run.appearance.background = line.appearance.background
+          return run
+        }
+      }
+      let patches = textured
+        ? [OverlaySourcePatch(box: line.boundingBoxNormalized, appearance: line.appearance)]
+        : line.replacementPatches
+      result.lines[i].replacementPatches = patches
+      for j in patches.indices {
+        var patch = patches[j]
+        guard !patch.erasesDistinctSurface || textured else { continue }
+        if textured { patch.erasesDistinctSurface = false }
+        let fg = components(patch.appearance.foreground)
+        let bg = components(patch.appearance.background)
+        let contrast = distance(fg, bg)
+        guard contrast >= 30 else { continue }
+        let box = patch.box
+        let original = CGRect(
+          x: box.minX * CGFloat(image.width),
+          y: box.minY * CGFloat(image.height),
+          width: box.width * CGFloat(image.width),
+          height: box.height * CGFloat(image.height)
+        ).integral
+        let margin = max(2, min(8, Int(original.height * 0.15)))
+        let rect = original.insetBy(dx: -CGFloat(margin), dy: -CGFloat(margin)).intersection(CGRect(
+          x: 0,
+          y: 0,
+          width: image.width,
+          height: image.height
+        )).integral
+        let x0 = Int(rect.minX)
+        let y0 = Int(rect.minY)
+        let w = Int(rect.width)
+        let h = Int(rect.height)
+        guard w > 0, h > 0 else { continue }
+        var ink = [Bool](repeating: false, count: w * h)
+        var queue = [Int]()
+        for y in 0..<h {
+          for x in 0..<w {
+            let c = color(x0 + x, y0 + y)
+            if
+              original.insetBy(dx: 0, dy: -CGFloat(margin)).contains(CGPoint(x: x0 + x, y: y0 + y)),
+              distance(c, fg) < contrast / 2
+            {
+              ink[y * w + x] = true
+              queue.append(y * w + x)
+            }
+          }
+        }
+        guard !queue.isEmpty else { continue }
+        var cursor = 0
+        while cursor < queue.count {
+          let k = queue[cursor]
+          cursor += 1
+          let x = k % w
+          let y = k / w
+          for ny in max(0, y - 1)...min(h - 1, y + 1) {
+            for nx in max(0, x - 1)...min(w - 1, x + 1) {
+              let next = ny * w + nx
+              guard !ink[next] else { continue }
+              let c = color(x0 + nx, y0 + ny)
+              guard distance(c, bg) >= max(8, contrast / 8), distance(c, fg) < distance(c, bg) else { continue }
+              ink[next] = true
+              queue.append(next)
+            }
+          }
+        }
+        var minX = original.minX
+        var minY = original.minY
+        var maxX = original.maxX
+        var maxY = original.maxY
+        for k in queue {
+          minX = min(minX, CGFloat(x0 + k % w))
+          minY = min(minY, CGFloat(y0 + k / w))
+          maxX = max(maxX, CGFloat(x0 + k % w + 1))
+          maxY = max(maxY, CGFloat(y0 + k / w + 1))
+        }
+        patch.box = CGRect(
+          x: minX / CGFloat(image.width),
+          y: minY / CGFloat(image.height),
+          width: (maxX - minX) / CGFloat(image.width),
+          height: (maxY - minY) / CGFloat(image.height)
+        )
+        // The spread of non-glyph pixels distinguishes texture from a flat
+        // surface. Keep the cheap color fill for ordinary UI and paper.
+        var background = [Int]()
+        for k in stride(from: 0, to: ink.count, by: 3) where !ink[k] {
+          background.append(color(x0 + k % w, y0 + k / w).luminance)
+        }
+        background.sort()
+        if
+          textured || (background.count > 20 && background[background.count * 9 / 10] - background[background.count / 10] > 24),
+          let tile = CGContext(
+            data: nil,
+            width: w,
+            height: h,
+            bitsPerComponent: 8,
+            bytesPerRow: w * 4,
+            space: CGColorSpace(name: CGColorSpace.sRGB)!,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+          ), let destination = tile.data
+        {
+          let out = destination.bindMemory(to: UInt8.self, capacity: w * h * 4)
+          let originalInk = ink
+          for k in originalInk.indices where originalInk[k] {
+            let x = k % w
+            let y = k / w
+            for ny in max(0, y - 1)...min(h - 1, y + 1) {
+              for nx in max(0, x - 1)...min(w - 1, x + 1) { ink[ny * w + nx] = true }
+            }
+          }
+          for k in ink.indices {
+            let x = k % w
+            let y = k / w
+            var sample = color(x0 + x, y0 + y)
+            if ink[k] {
+              search: for radius in 1...max(w, h) {
+                for (nx, ny) in [(x - radius, y), (x + radius, y), (x, y - radius), (x, y + radius)] {
+                  if nx >= 0, nx < w, ny >= 0, ny < h, !ink[ny * w + nx] {
+                    sample = color(x0 + nx, y0 + ny)
+                    break search
+                  }
+                }
+              }
+            }
+            out[k * 4] = UInt8(sample.r)
+            out[k * 4 + 1] = UInt8(sample.g)
+            out[k * 4 + 2] = UInt8(sample.b)
+            out[k * 4 + 3] = 255
+          }
+          patch.box = CGRect(
+            x: rect.minX / CGFloat(image.width),
+            y: rect.minY / CGFloat(image.height),
+            width: rect.width / CGFloat(image.width),
+            height: rect.height / CGFloat(image.height)
+          )
+          patch.restorationPNG = tile.makeImage()?.pngData
+        }
+        result.lines[i].replacementPatches[j] = patch
+      }
+    }
+    return result
+  }
+
+  // MARK: Private
+
+  private struct Pixel {
+    var r: Int
+    var g: Int
+    var b: Int
+
+    var luminance: Int {
+      (r + g + b) / 3
+    }
+  }
+
+  private static func components(_ c: OverlayColor) -> Pixel {
+    Pixel(
+      r: Int(c.red * 255),
+      g: Int(c.green * 255),
+      b: Int(c.blue * 255)
+    )
+  }
+
+  private static func distance(_ a: Pixel, _ b: Pixel) -> Int {
+    max(abs(a.r - b.r), abs(a.g - b.g), abs(a.b - b.b))
+  }
+}

--- a/Sources/Overlay/TranslationOverlayLayer.swift
+++ b/Sources/Overlay/TranslationOverlayLayer.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import Accessibility
+import AppKit
 import SwiftUI
 
 // MARK: - TranslationOverlayLayer
@@ -88,6 +89,7 @@ private struct OverlayCanvas: View, Equatable {
           )
           SourceReplacementSurface(
             appearance: patch.appearance,
+            restorationPNG: patch.restorationPNG,
             patchFrame: frame,
             clippingFrame: sourceSurface.map {
               OverlayLayoutEngine.sourceSurfaceFrame(for: $0, in: size)
@@ -108,13 +110,26 @@ private struct OverlayCanvas: View, Equatable {
       ForEach(placements) { placement in
         ReplacementText(placement: placement)
           .equatable()
+          .help(Text(verbatim: placement.line.source.text))
           .frame(width: placement.frame.width, height: placement.frame.height)
           .clipped()
+          .rotationEffect(.radians(placement.line.source.rotationRadians))
           .position(x: placement.frame.midX, y: placement.frame.midY)
       }
     }
     .frame(width: size.width, height: size.height, alignment: .topLeading)
     .clipped()
+    .mask {
+      Canvas { context, _ in
+        context.fill(Path(CGRect(origin: .zero, size: size)), with: .color(.white))
+        var protected = Path()
+        for frame in OverlayLayoutEngine.protectedSourceFrames(for: lines, in: size, displayScale: displayScale) {
+          protected.addRect(frame)
+        }
+        context.blendMode = .destinationOut
+        context.fill(protected, with: .color(.white))
+      }
+    }
   }
 
   static func ==(lhs: Self, rhs: Self) -> Bool {
@@ -132,7 +147,10 @@ private struct OverlayCanvas: View, Equatable {
 
 private struct SourceReplacementSurface: View, Equatable {
 
+  // MARK: Internal
+
   let appearance: OverlaySourceAppearance
+  let restorationPNG: Data?
   let patchFrame: CGRect
   let clippingFrame: CGRect?
   let cornerRadiusFraction: CGFloat
@@ -141,8 +159,7 @@ private struct SourceReplacementSurface: View, Equatable {
   var body: some View {
     if let clippingFrame, !clippingFrame.isEmpty {
       ZStack(alignment: .topLeading) {
-        Rectangle()
-          .fill(Color(appearance.background))
+        restoredSurface
           .frame(width: patchFrame.width, height: patchFrame.height)
           .offset(
             x: patchFrame.minX - clippingFrame.minX,
@@ -160,12 +177,23 @@ private struct SourceReplacementSurface: View, Equatable {
       ))
       .position(x: clippingFrame.midX, y: clippingFrame.midY)
     } else {
-      Rectangle()
-        .fill(Color(appearance.background))
+      restoredSurface
         .frame(width: patchFrame.width, height: patchFrame.height)
         .position(x: patchFrame.midX, y: patchFrame.midY)
     }
   }
+
+  // MARK: Private
+
+  @ViewBuilder
+  private var restoredSurface: some View {
+    if let restorationPNG, let image = NSImage(data: restorationPNG) {
+      Image(nsImage: image).resizable()
+    } else {
+      Rectangle().fill(Color(appearance.background))
+    }
+  }
+
 }
 
 // MARK: - SourceSurfaceClip

--- a/Sources/Overlay/TranslationOverlayLayer.swift
+++ b/Sources/Overlay/TranslationOverlayLayer.swift
@@ -92,7 +92,15 @@ private struct OverlayCanvas: View, Equatable {
             clippingFrame: sourceSurface.map {
               OverlayLayoutEngine.sourceSurfaceFrame(for: $0, in: size)
             },
-            cornerRadiusFraction: sourceSurface?.cornerRadiusFraction ?? 0
+            cornerRadiusFraction: sourceSurface?.cornerRadiusFraction ?? 0,
+            clippingRows: sourceSurface?.clippingRows.map {
+              CGRect(
+                x: $0.minX * size.width,
+                y: $0.minY * size.height,
+                width: $0.width * size.width,
+                height: $0.height * size.height
+              )
+            } ?? []
           )
           .equatable()
         }
@@ -128,6 +136,7 @@ private struct SourceReplacementSurface: View, Equatable {
   let patchFrame: CGRect
   let clippingFrame: CGRect?
   let cornerRadiusFraction: CGFloat
+  let clippingRows: [CGRect]
 
   var body: some View {
     if let clippingFrame, !clippingFrame.isEmpty {
@@ -145,9 +154,9 @@ private struct SourceReplacementSurface: View, Equatable {
         height: clippingFrame.height,
         alignment: .topLeading
       )
-      .clipShape(.rect(
-        cornerRadius: min(clippingFrame.width, clippingFrame.height) * cornerRadiusFraction,
-        style: .continuous
+      .clipShape(SourceSurfaceClip(
+        rows: clippingRows.map { $0.offsetBy(dx: -clippingFrame.minX, dy: -clippingFrame.minY) },
+        cornerRadius: min(clippingFrame.width, clippingFrame.height) * cornerRadiusFraction
       ))
       .position(x: clippingFrame.midX, y: clippingFrame.midY)
     } else {
@@ -156,6 +165,22 @@ private struct SourceReplacementSurface: View, Equatable {
         .frame(width: patchFrame.width, height: patchFrame.height)
         .position(x: patchFrame.midX, y: patchFrame.midY)
     }
+  }
+}
+
+// MARK: - SourceSurfaceClip
+
+private struct SourceSurfaceClip: Shape {
+  let rows: [CGRect]
+  let cornerRadius: CGFloat
+
+  func path(in rect: CGRect) -> Path {
+    guard !rows.isEmpty else {
+      return RoundedRectangle(cornerRadius: cornerRadius, style: .continuous).path(in: rect)
+    }
+    var path = Path()
+    path.addRects(rows)
+    return path
   }
 }
 

--- a/Sources/Settings/SettingsView.swift
+++ b/Sources/Settings/SettingsView.swift
@@ -149,7 +149,7 @@ private struct LanguagesSection: View {
 private struct TranslationSection: View {
   var body: some View {
     Section {
-      Picker("Strategy", selection: Binding($settings.translation.strategy)) {
+      Picker("Preferred strategy", selection: Binding($settings.translation.strategy)) {
         ForEach(TranslationStrategy.allCases) { strategy in
           Text(strategy.displayName).tag(strategy)
         }
@@ -157,9 +157,11 @@ private struct TranslationSection: View {
     } header: {
       Text("Translation")
     } footer: {
-      Text("High fidelity uses Apple Intelligence on devices that support it (macOS 26.4+).")
-        .font(.caption)
-        .foregroundStyle(.secondary)
+      Text(
+        "Your preferred strategy is used when its model is installed. Otherwise, SwiftyCrow uses an installed model and shows which strategy it selected. High fidelity uses Apple Intelligence on supported devices."
+      )
+      .font(.caption)
+      .foregroundStyle(.secondary)
     }
   }
 

--- a/Sources/SwiftyCrowApp.swift
+++ b/Sources/SwiftyCrowApp.swift
@@ -171,7 +171,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       imageSize: store.capture.imageSize,
       placementID: store.capture.overlayPlacementID,
       translationUnavailable: store.capture.translationUnavailable,
-      isPreparingRecognition: store.capture.isPreparingRecognition
+      isPreparingRecognition: store.capture.isPreparingRecognition,
+      lastError: store.capture.lastError
     )
   }
 

--- a/Tests/OCRBalloonRefinerTests.swift
+++ b/Tests/OCRBalloonRefinerTests.swift
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import CustomDump
+import Foundation
+import Testing
+@testable import SwiftyCrow
+
+@Suite("Printed dialogue regions")
+struct OCRBalloonRefinerTests {
+
+  // MARK: Internal
+
+  @Test
+  func joinsPrintedWrapsWithoutSplittingHyphenatedWords() {
+    expectNoDifference(OCRBalloonRefiner.joinedRows(["A SUPER-", "ELASTIC SUIT", "FITS."]), "A SUPER-ELASTIC SUIT FITS.")
+  }
+
+  @Test
+  func leavesOrdinaryProseAndVerticalTextOnDocumentPath() {
+    let caps = (0..<12).map { _ in row("A COMPLETE PRINTED SENTENCE", x: 0.1, y: 0.1) }
+    #expect(OCRBalloonRefiner.qualifies(caps))
+    var prose = caps
+    for i in prose.indices { prose[i].text = "A normal sentence in a web article." }
+    #expect(!OCRBalloonRefiner.qualifies(prose))
+    prose = caps
+    prose[0].isVerticalBlock = true
+    #expect(!OCRBalloonRefiner.qualifies(prose))
+    #expect(!OCRBalloonRefiner.qualifies(Array(caps.prefix(4))))
+  }
+
+  @Test
+  func reconstructedRegionsDoNotMergeAcrossNeighboringBalloons() {
+    var first = row("THE FIRST COMPLETE SENTENCE.", x: 0.1, y: 0.2)
+    first.isReconstructedTextRegion = true
+    var second = row("THE SECOND COMPLETE SENTENCE.", x: 0.1, y: 0.26)
+    second.isReconstructedTextRegion = true
+    let source = OCRResult(lines: [first, second])
+    expectNoDifference(source.coalescingParagraphFragments(), source)
+  }
+
+  @Test
+  func findsSeparateInteriorsAcrossNarrowConnectors() throws {
+    let image = try bubbles()
+    let raster = try #require(BalloonRaster(image: image, longestSide: 1024))
+    let lines = [0.28, 0.38, 0.48, 0.58].flatMap { y in
+      [row("FIRST SENTENCE", x: 0.12, y: y), row("SECOND SENTENCE", x: 0.62, y: y)]
+    }
+    let regions = raster.textRegions(around: lines).sorted { $0.box.minX < $1.box.minX }
+    expectNoDifference(regions.count, 2)
+    guard regions.count == 2 else { return }
+    #expect(!regions[0].interiorBox.intersects(regions[1].interiorBox))
+    #expect(regions[0].contains(CGPoint(x: 0.2, y: 0.4)))
+    #expect(!regions[0].contains(CGPoint(x: 0.7, y: 0.4)))
+    #expect(raster.maskedCrop(of: image, region: regions[0]) != nil)
+  }
+
+  @Test
+  func pageBackgroundIsNotATextContainer() throws {
+    let context = try #require(CGContext(
+      data: nil,
+      width: 480,
+      height: 200,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(gray: 0.95, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 480, height: 200))
+    let image = try #require(context.makeImage())
+    let raster = try #require(BalloonRaster(image: image, longestSide: 1024))
+    let lines = [0.3, 0.4, 0.5].map { row("TEXT ON A PAGE", x: 0.2, y: $0) }
+    #expect(raster.textRegions(around: lines).isEmpty)
+  }
+
+  @Test
+  func textFitsInsideInteriorInsteadOfOverlappingAdjacentSourceBounds() throws {
+    var recognized = row("A COMPLETE SENTENCE IN A BALLOON", x: 0.1, y: 0.2)
+    recognized.rowCount = 4
+    recognized.boundingBoxNormalized.size.height = 0.3
+    recognized.isReconstructedTextRegion = true
+    recognized.surface = OverlaySourceSurface(box: CGRect(x: 0.14, y: 0.23, width: 0.15, height: 0.22), confidence: 1)
+    var line = OverlayLine(id: UUID(), source: .init(recognized: recognized, language: Locale.Language(identifier: "en")))
+    line.showTranslation("말풍선 안에 들어가는 완전한 문장입니다.", language: Locale.Language(identifier: "ko"))
+    let placement = try #require(OverlayLayoutEngine.placements(for: [line], in: CGSize(width: 1000, height: 1000)).first)
+    expectNoDifference(placement.frame, CGRect(x: 140, y: 230, width: 150, height: 220))
+    expectNoDifference(placement.alignment, .center)
+    #expect(placement.frame.maxX < placement.sourceFrame.maxX)
+  }
+
+  // MARK: Private
+
+  private func row(_ text: String, x: CGFloat, y: CGFloat) -> OCRResult.Line {
+    .init(boundingBoxNormalized: CGRect(x: x, y: y, width: 0.25, height: 0.05), text: text)
+  }
+
+  private func bubbles() throws -> CGImage {
+    let context = try #require(CGContext(
+      data: nil,
+      width: 480,
+      height: 240,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(gray: 0.25, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 480, height: 240))
+    context.setFillColor(CGColor(gray: 0.85, alpha: 1))
+    context.fillEllipse(in: CGRect(x: 20, y: 35, width: 200, height: 160))
+    context.fillEllipse(in: CGRect(x: 260, y: 35, width: 200, height: 160))
+    context.fill(CGRect(x: 200, y: 110, width: 80, height: 4))
+    // Dark enclosed glyph-like islands must not fragment the paper interior.
+    context.setFillColor(CGColor(gray: 0.2, alpha: 1))
+    for x in [80, 120, 320, 360] { context.fill(CGRect(x: x, y: 95, width: 8, height: 12)) }
+    return try #require(context.makeImage())
+  }
+}

--- a/Tests/QualityRegressionTests.swift
+++ b/Tests/QualityRegressionTests.swift
@@ -1,0 +1,338 @@
+// SPDX-FileCopyrightText: 2021-2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import CustomDump
+import Foundation
+import ImageIO
+import Testing
+@testable import SwiftyCrow
+
+@Suite("Quality audit regressions")
+struct QualityRegressionTests {
+  @Test
+  func ordinaryJapaneseInkDoesNotTriggerRubyCropping() {
+    #expect(JapaneseRubyOCRCorrector.baseBandStart(rowInk: Array(repeating: 20, count: 36)) == nil)
+    #expect(JapaneseRubyOCRCorrector.baseBandStart(rowInk: [0, 0, 10, 10, 0, 0] + Array(repeating: 20, count: 30)) == nil)
+  }
+
+  @Test
+  func separateSmallRubyBandHasAnObservedCropBoundary() {
+    let rows = Array(repeating: 5, count: 8) + Array(repeating: 0, count: 5) + Array(repeating: 20, count: 27)
+    expectNoDifference(JapaneseRubyOCRCorrector.baseBandStart(rowInk: rows), 0.3)
+  }
+
+  @Test(arguments: [
+    "export API_URL=https://example.org",
+    "swift test --filter CaptureFeatureTests",
+    "let timeout: Double = 0.8",
+    "if result.isEmpty { return nil ›",
+    "return nil"
+  ])
+  func codeIsProtectedWithoutRelyingOnFontSampling(_ text: String) {
+    let source = OverlayLine.Source(
+      recognized: .init(boundingBoxNormalized: .zero, text: text),
+      language: Locale.Language(identifier: "en")
+    )
+    #expect(source.isProtectedLiteral)
+  }
+
+  @Test(arguments: ["https://example.org/docs", "MIT", "AGPL-3.0-only", "v3.2.1"])
+  func technicalIdentifiersRemainLiteral(_ text: String) {
+    #expect(OCRTextSemantics.isIdentifier(text))
+  }
+
+  @Test
+  func ordinaryEnglishInstructionsAreNotCode() {
+    #expect(!OCRTextSemantics.isCode("If the address is incorrect, the package will not be delivered."))
+    #expect(!OCRTextSemantics.isCode("Export the review to your coding agent."))
+  }
+
+  @Test
+  func codeRowsAreNeverStitchedIntoAProseParagraph() {
+    let result = OCRResult(lines: [
+      .init(boundingBoxNormalized: CGRect(x: 0.1, y: 0.2, width: 0.5, height: 0.03), text: "let x = 1", recognitionGroupID: 1),
+      .init(boundingBoxNormalized: CGRect(x: 0.1, y: 0.24, width: 0.5, height: 0.03), text: "let y = 2", recognitionGroupID: 1),
+    ])
+    expectNoDifference(result.coalescingParagraphFragments(), result)
+  }
+
+  @Test
+  func labelUsesOneExplicitTechnicalValueAsContext() {
+    let sources = [
+      OverlayLine.Source(
+        recognized: .init(boundingBoxNormalized: CGRect(x: 0.1, y: 0.2, width: 0.1, height: 0.03), text: "release"),
+        language: Locale.Language(identifier: "en")
+      ),
+      OverlayLine.Source(
+        recognized: .init(boundingBoxNormalized: CGRect(x: 0.22, y: 0.2, width: 0.1, height: 0.03), text: "v3.2.1"),
+        language: Locale.Language(identifier: "en")
+      ),
+    ]
+    #expect(!OverlayTranslationPolicy.preservesSource(at: 0, in: sources))
+    expectNoDifference(OverlayTranslationPolicy.trailingContext(at: 0, in: sources), "v3.2.1")
+  }
+
+  @Test
+  func verticalGeometryOverridesMisleadingDirectionMetadata() {
+    #expect(OCRGeometry.isVertical(
+      text: "電車は午後三時に出発します",
+      topLeft: CGPoint(x: 0.8, y: 0.9),
+      topRight: CGPoint(x: 0.8, y: 0.2),
+      imageSize: CGSize(width: 1200, height: 720),
+      declaredVertical: false
+    ))
+    #expect(!OCRGeometry.isVertical(
+      text: "A rotated English caption",
+      topLeft: CGPoint(x: 0.8, y: 0.9),
+      topRight: CGPoint(x: 0.8, y: 0.2),
+      imageSize: CGSize(width: 1200, height: 720),
+      declaredVertical: false
+    ))
+  }
+
+  @Test
+  func rotatedRowsJoinInTheirAlignedPlane() {
+    let angle: CGFloat = 0.07
+    let a = CGRect(x: 0.1, y: 0.2, width: 0.65, height: 0.04)
+    let b = CGRect(x: 0.102, y: 0.25, width: 0.12, height: 0.04)
+    func world(_ rect: CGRect) -> CGRect {
+      let x = rect.midX
+      let y = rect.midY
+      return CGRect(
+        x: x * cos(angle) - y * sin(angle) - rect.width / 2,
+        y: x * sin(angle) + y * cos(angle) - rect.height / 2,
+        width: rect.width,
+        height: rect.height
+      )
+    }
+    let result = OCRResult(lines: [
+      .init(
+        boundingBoxNormalized: world(a),
+        text: "The deadline is Friday",
+        rotationRadians: angle,
+        orientedBox: world(a),
+        recognitionGroupID: 1
+      ),
+      .init(
+        boundingBoxNormalized: world(b),
+        text: "at noon.",
+        rotationRadians: angle,
+        orientedBox: world(b),
+        recognitionGroupID: 1
+      ),
+    ]).coalescingParagraphFragments()
+    expectNoDifference(result.lines.count, 1)
+    expectNoDifference(result.lines.first?.text, "The deadline is Friday at noon.")
+    expectNoDifference(result.lines.first?.rotationRadians, angle)
+  }
+
+  @Test
+  func modelChoiceUsesInstalledModelsAndPreservesAnAvailablePreference() {
+    expectNoDifference(
+      TranslationModelResolver.choose(preferred: .lowLatency, preferredInstalled: true, alternativeInstalled: true),
+      .lowLatency
+    )
+    expectNoDifference(
+      TranslationModelResolver.choose(preferred: .lowLatency, preferredInstalled: false, alternativeInstalled: true),
+      .highFidelity
+    )
+    #expect(TranslationModelResolver
+      .choose(preferred: .highFidelity, preferredInstalled: false, alternativeInstalled: false) == nil)
+  }
+
+  @Test
+  func latinCaptionDoesNotInheritArabicPageLanguage() {
+    let client = LanguageDetectionClient(detect: { text, confidence in
+      if text == "Platform 4 Departure 15:30" { return confidence > 0 ? nil : Language(code: "en") }
+      return Language(code: "ar")
+    })
+    expectNoDifference(
+      client.resolveSources(for: ["يرجى إغلاق الباب", "Platform 4 Departure 15:30"], configured: .auto),
+      [Language(code: "ar"), Language(code: "en")]
+    )
+  }
+
+  @Test
+  func maskBoundsReachInkOutsideTheOCRBox() throws {
+    let context = try #require(CGContext(
+      data: nil,
+      width: 100,
+      height: 60,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(gray: 1, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 100, height: 60))
+    context.setFillColor(CGColor(gray: 0, alpha: 1))
+    context.fill(CGRect(x: 30, y: 20, width: 6, height: 20))
+    let image = try #require(context.makeImage())
+    let appearance = OverlaySourceAppearance(background: .white, foreground: .black, confidence: 1)
+    let patch = OverlaySourcePatch(box: CGRect(x: 0.3, y: 22.0 / 60, width: 0.06, height: 16.0 / 60), appearance: appearance)
+    let result = SourceRestorationBuilder.applying(
+      to: OCRResult(lines: [.init(
+        boundingBoxNormalized: patch.box,
+        text: "Sample",
+        appearance: appearance,
+        replacementPatches: [patch]
+      )]),
+      image: image
+    )
+    let restored = try #require(result.lines.first?.replacementPatches.first)
+    #expect(restored.box.minY <= 20.0 / 60)
+    #expect(restored.box.maxY >= 40.0 / 60)
+  }
+
+  @Test
+  func mixedScriptHypothesesKeepEachReliableScriptAndIndependentGeometry() throws {
+    let raw = "Open／閉じる／71"
+    let spans = [(0, 4), (4, 1), (5, 3), (8, 1), (9, 2)]
+    let runs = spans.enumerated().map { i, range in
+      OverlaySourceStyleRun(
+        range: NSRange(location: range.0, length: range.1),
+        box: CGRect(x: CGFloat(i) * 0.15, y: 0.2, width: 0.1, height: 0.04)
+      )
+    }
+    let original = OCRResult.Line(
+      boundingBoxNormalized: CGRect(x: 0, y: 0.2, width: 0.8, height: 0.04),
+      text: raw,
+      styleRuns: runs
+    )
+    let result = try #require(OCRLineRefiner.splitMixedLine(original, hypothesis: "Open / EL 3 / 닫기"))
+    expectNoDifference(result.map(\.text), ["Open", "／", "閉じる", "／", "닫기"])
+    #expect(result.last!.needsReview)
+    expectNoDifference(OCRResult(lines: result).coalescingParagraphFragments().lines, result)
+  }
+
+  @Test
+  func eraserExclusionsProtectSeparatorsAndPendingNeighbors() {
+    let slash = OverlayLine(
+      id: UUID(),
+      source: .init(
+        recognized: .init(boundingBoxNormalized: CGRect(x: 0.2, y: 0.3, width: 0.02, height: 0.05), text: "/"),
+        language: Locale.Language(identifier: "en")
+      )
+    )
+    let frames = OverlayLayoutEngine.protectedSourceFrames(for: [slash], in: CGSize(width: 1000, height: 500), displayScale: 2)
+    expectNoDifference(frames, [CGRect(x: 199.5, y: 149.5, width: 21, height: 26)])
+  }
+
+  @Test
+  func absorbingRubyKeepsTheOriginalBaseTextFrame() throws {
+    let baseBox = CGRect(x: 0.1, y: 0.247, width: 0.6, height: 0.05)
+    let result = OCRResult(lines: [
+      .init(boundingBoxNormalized: CGRect(x: 0.2, y: 0.2, width: 0.06, height: 0.02), text: "しゅうごう"),
+      .init(boundingBoxNormalized: baseBox, text: "集合時間は九時です。"),
+    ]).absorbingRubyAnnotations()
+    expectNoDifference(result.lines.count, 1)
+    let line = try #require(result.lines.first)
+    expectNoDifference(line.orientedBox, baseBox)
+    #expect(line.replacementPatches.contains { $0.box == baseBox })
+  }
+
+  @Test
+  func aShortWrappedContinuationKeepsItsSentenceContext() {
+    let upper = OverlaySourceAppearance(
+      background: .white,
+      foreground: .black,
+      confidence: 1,
+      foregroundConfidence: 0.8,
+      fontWeight: .semibold
+    )
+    var lower = upper
+    lower.foregroundConfidence = 0.3
+    lower.fontWeight = .regular
+    let result = OCRResult(lines: [
+      .init(
+        boundingBoxNormalized: CGRect(x: 0.1, y: 0.2, width: 0.6, height: 0.04),
+        text: "Last entry is at four thirty. The building closes",
+        recognitionGroupID: 1,
+        appearance: upper
+      ),
+      .init(
+        boundingBoxNormalized: CGRect(x: 0.1, y: 0.245, width: 0.12, height: 0.04),
+        text: "at five.",
+        recognitionGroupID: 2,
+        appearance: lower
+      ),
+    ]).coalescingParagraphFragments()
+    expectNoDifference(result.lines.map(\.text), ["Last entry is at four thirty. The building closes at five."])
+  }
+
+  @Test
+  func nonLatinLabelsAreNotVersionLiterals() {
+    let source = OverlayLine.Source(
+      recognized: .init(boundingBoxNormalized: .zero, text: "予約番号：AB-2048"),
+      language: Locale.Language(identifier: "ja")
+    )
+    #expect(!OverlayTranslationPolicy.preservesSource(at: 0, in: [source]))
+  }
+
+  @Test
+  func textureRestorationRetainsMultipleBackgroundColors() throws {
+    let context = try #require(CGContext(
+      data: nil,
+      width: 180,
+      height: 80,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpace(name: CGColorSpace.sRGB)!,
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    for x in stride(from: 0, to: 180, by: 30) {
+      let shade = CGFloat((x / 30) % 3) * 0.12 + 0.15
+      context.setFillColor(CGColor(red: shade, green: shade, blue: shade, alpha: 1))
+      context.fill(CGRect(x: x, y: 0, width: 30, height: 80))
+    }
+    context.setFillColor(CGColor(gray: 1, alpha: 1))
+    context.fill(CGRect(x: 75, y: 30, width: 8, height: 20))
+    let image = try #require(context.makeImage())
+    let appearance = OverlaySourceAppearance(
+      background: OverlayColor(red: 0.27, green: 0.27, blue: 0.27, alpha: 1),
+      foreground: .white,
+      confidence: 1
+    )
+    let box = CGRect(x: 0.1, y: 0.3, width: 0.8, height: 0.4)
+    let line = OCRResult.Line(
+      boundingBoxNormalized: box,
+      text: "Read this message",
+      appearance: appearance,
+      replacementPatches: [OverlaySourcePatch(box: box, appearance: appearance)]
+    )
+    let result = SourceRestorationBuilder.applying(to: OCRResult(lines: [line]), image: image)
+    let data = try #require(result.lines.first?.replacementPatches.first?.restorationPNG)
+    let source = try #require(CGImageSourceCreateWithData(data as CFData, nil))
+    let tile = try #require(CGImageSourceCreateImageAtIndex(source, 0, nil))
+    #expect(tile.width > 100)
+    expectNoDifference(result.lines[0].text, line.text)
+  }
+
+  @Test
+  func clippedCaptureRetainsItsSourceOriginInsteadOfStretching() throws {
+    let geometry = try ScreenCaptureRegionGeometry(
+      requested: CGRect(x: -50, y: 750, width: 400, height: 200),
+      display: CGRect(x: 0, y: 0, width: 1440, height: 900)
+    )
+    expectNoDifference(geometry.intersection, CGRect(x: 0, y: 750, width: 350, height: 150))
+    expectNoDifference(geometry.sourceRect, CGRect(x: 0, y: 0, width: 350, height: 150))
+    #expect(throws: ScreenCaptureError.emptyRegion) {
+      try ScreenCaptureRegionGeometry(
+        requested: CGRect(x: -500, y: 0, width: 100, height: 100),
+        display: CGRect(x: 0, y: 0, width: 1440, height: 900)
+      )
+    }
+  }
+
+  @Test @MainActor
+  func questionableOCRIsFlaggedWithoutChangingItsWords() {
+    let text = "The fomerw twory arbe qzxq request cannot be sent."
+    let result = OCRQualityAssessment.markingUncertainText(in: OCRResult(lines: [.init(
+      boundingBoxNormalized: .zero,
+      text: text
+    )]))
+    expectNoDifference(result.lines[0].text, text)
+    #expect(result.lines[0].needsReview)
+  }
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -123,7 +123,7 @@ toggleLiveMode = "cmd + shift - m"
 
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
-| `strategy` | string | `"lowLatency"` | `lowLatency`, or `highFidelity` to use Apple Intelligence where supported (macOS 26.4+). |
+| `strategy` | string | `"lowLatency"` | Preferred local strategy: `lowLatency` or `highFidelity` (macOS 26.4+). SwiftyCrow uses this strategy when its model is installed, otherwise an installed alternative and displays a notice. |
 
 ## `[updates]`
 

--- a/docs/LANGUAGE_MODELS.md
+++ b/docs/LANGUAGE_MODELS.md
@@ -105,11 +105,15 @@ To confirm a language model is installed:
 
 ### Slow translation, or Low Latency vs. High Fidelity
 
-SwiftyCrow has a **Strategy** setting in Settings → Translation:
+SwiftyCrow has a **Preferred strategy** setting in Settings → Translation:
 - **Low Latency (default):** Faster and lighter, making it a good fit for casual reading.
-- **High Fidelity:** More accurate and uses Apple Intelligence on supported devices running macOS 26.4 or later.
+- **High Fidelity:** Uses Apple Intelligence on supported devices running macOS 26.4 or later. It can improve fluency, but does not guarantee better wording for every passage.
 
 > **The Strategy setting only takes effect on macOS 26.4+.** On macOS 26.0–26.3 SwiftyCrow uses the Translation framework's own default and the choice has no effect, so switching modes there won't change speed or accuracy.
+
+Model availability is checked for the selected strategy and language pair. If the preferred model is missing but another local strategy is installed, SwiftyCrow uses the installed model before submitting the request. The capture status (or the live overlay's information icon) explains the choice. This does not change your preference or download models automatically.
+
+If neither strategy has an installed model, the error names the language pair. An installed Apple Intelligence model does not imply that the corresponding Low Latency model is installed.
 
 If translation feels slow:
 1. On macOS 26.4+, try **Low Latency** mode (Settings → Translation)
@@ -122,3 +126,11 @@ If you encounter issues installing language models or translation still fails:
 1. Check the [SwiftyCrow Issues](https://github.com/PangMo5/SwiftyCrow/issues) on GitHub
 2. Include your macOS version, language pair, and the exact error message from SwiftyCrow
 3. Note whether the language model was fully downloaded before attempting translation
+
+## Reading difficult sources
+
+Recognized code and technical literals retain their original pixels rather than being retyped as translated prose. Copied original text still comes from OCR and should be checked when exact identifiers or code syntax matter.
+
+A review indicator appears when recognized prose contains many questionable words or a mixed-script segment required an uncertain repair. It is a cue to compare with the source, not an automatic spelling correction. Small, blurred, or compressed text and ambiguous terminology can still produce incorrect translations.
+
+Printed dialogue uses image boundaries to keep neighboring balloons separate. Vertical and rotated text retain their reading direction. On textured backgrounds, glyph removal uses local background samples; it cannot recover artwork that was hidden behind the original lettering exactly.


### PR DESCRIPTION
Difficult captures can split sentences, merge neighboring speech balloons or vertical columns, corrupt Japanese text during ruby correction, and repaint code or preserved labels. Reconstruct text using its source boundaries and reading direction, preserve technical content, and prevent restoration masks from erasing untranslated neighbors.

- Detect and re-recognize printed dialogue within speech balloons, including the previously unpushed local commit.
- Gate ruby correction on image evidence, retain code line boundaries, split mixed-script controls, and preserve rotated text geometry.
- Extend masks to actual ink and use local background samples on textured surfaces.
- Choose an installed local translation model before submitting a request, report the selected strategy, and flag uncertain OCR.
- Keep partially off-screen captures aligned with the full overlay canvas.

Validation: all 183 macOS tests passed through XcodeBuildMCP, and the Debug build and launch succeeded. An 18-image corpus was rechecked across 24 configurations using production OCR, reducers, Apple translation, and the offscreen renderer. Pixel comparisons confirmed preservation of code and separators and removal of the previously observed small ink remnants.

Limitations: native LIVE scrolling and WindowServer composition remain unverified because UI automation could not reliably access the app. Apple translation semantic errors, severely degraded input, and some background-restoration artifacts remain.
